### PR TITLE
Fixes deployment to Heroku

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -15,7 +15,6 @@ django-allauth==0.12.0
 
 # For the persistance stores
 psycopg2==2.5
-django-heroku-memcacheify==0.4
 
 # Unicode slugification
 unicode-slugify==0.1.1


### PR DESCRIPTION
`django-heroku-memcacheify` is also in `requirements.txt`, giving the following error

```
-----> Installing dependencies using Pip (1.3.1)
   Double requirement given: django-heroku-memcacheify==0.4 (from -r requirements/base.txt (line 18)) (already in django-heroku-memcacheify>=0.4 (from -r requirements.txt (line 4)), name='django-heroku-memcacheify')
   Storing complete log in /app/.pip/pip.log
```
