### PR TITLE
Match license name with license text

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -4,7 +4,7 @@
 {{cookiecutter.description}}
 
 
-LICENSE: MIT
+LICENSE: BSD
 
 Deployment
 ------------


### PR DESCRIPTION
The license text (LICENSE.rst) is the BSD license, however README.rst denotes it incorrectly as MIT license.
