### PR TITLE
STATIC_ROOT should be absolute path

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -110,7 +110,7 @@ MIDDLEWARE_CLASSES = (
 
 ########## STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root
-STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = join(os.path.dirname(BASE_DIR), 'static')
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = '/static/'


### PR DESCRIPTION
According to the [Django docs](https://docs.djangoproject.com/en/dev/ref/settings/#static-root), `STATIC_ROOT` should be an absolute path. So I propose to store the static files (collectstatic) in a level up from the BASE_DIR.
