### PR TITLE
Need access to env variables during build

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -17,6 +17,7 @@ Deployment
 * heroku config:add AWS_ACCESS_KEY_ID=YOUR_ID
 * heroku config:add AWS_SECRET_ACCESS_KEY=YOUR_KEY
 * heroku config:add AWS_STORAGE_BUCKET_NAME=BUCKET
+* heroku labs:enable user-env-compile
 * git push heroku master
 * heroku run python {{cookiecutter.repo_name}}/manage.py syncdb --noinput --settings=config.settings
 * heroku run python {{cookiecutter.repo_name}}/manage.py migrate --settings=config.settings


### PR DESCRIPTION
WIthout this setting, env variables are not available during build/run. For example, collectstatic will fail as no AWS credentials are available.
