### PR TITLE
added config for basic memcache setup

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -13,12 +13,14 @@ Deployment
 * heroku addons:add heroku-postgresql:dev
 * heroku addons:add pgbackups
 * heroku addons:add sendgrid:starter
+* heroku addons:add memcachier:dev
 * heroku pg:promote HEROKU_POSTGRESQL_COLOR
 * heroku config:add DJANGO_CONFIGURATION=Production
 * heroku config:add DJANGO_SECRET_KEY=RANDOM_SECRET_KEY
 * heroku config:add DJANGO_AWS_ACCESS_KEY_ID=YOUR_ID
 * heroku config:add DJANGO_AWS_SECRET_ACCESS_KEY=YOUR_KEY
 * heroku config:add DJANGO_AWS_STORAGE_BUCKET_NAME=BUCKET
+* heroku config:add CACHE_URL=memcached://127.0.0.1:11211
 * git push heroku master
 * heroku run python {{cookiecutter.repo_name}}/manage.py syncdb --noinput --settings=config.settings
 * heroku run python {{cookiecutter.repo_name}}/manage.py migrate --settings=config.settings


### PR DESCRIPTION
I wasn't able to get the basic setup to run on Heroku without settings some sort of caches url. Since it installs pylibmc in prod I just added some instructions to use memcache and add the url scheme to the environment.  
