### PR TITLE
Fill in form action attribute in user_detail.html.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/users/user_form.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/users/user_form.html
@@ -9,7 +9,7 @@
     <div class="row">
         <div class="col-lg-12">
             <h1>{% block header %}User: {{ user.username }}{% endblock %}</h1>
-            <form class="form-horizontal" method="post" action="">
+            <form class="form-horizontal" method="post" action="{% url 'users:update' %}">
                 {% csrf_token %}
                 {{ form|crispy }}
                 <div class="control-group">


### PR DESCRIPTION
Using Chrome, the update form didn't submit with a blank action, but worked fine once I specified it.

Also, in researching whether a blank action attribute was OK, I found out that according to the HTML5 spec, the action attribute "must have a value that is a valid non-empty URL potentially surrounded by spaces."

http://www.w3.org/TR/html5/forms.html#attr-fs-action
