### PR TITLE
Unescape cookiecutter vars in base.html template.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -35,7 +35,7 @@
 
     <div class="header navbar">
       <div class="container">
-        <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.repo_name }}{% raw %}</a>
+        <a class="navbar-brand" href="/">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a>
         <ul class="nav navbar-nav">
           <li class="active"><a href="{% url 'home' %}">Home</a></li>
           <li><a href="{% url 'about' %}">About</a></li>


### PR DESCRIPTION
Cookiecutter variables don't get replaced inside a raw block,
so I wrapped them in `{% endraw %}...{% raw %}` tags to turn off
raw temporarily.

Also, I used project_name in the base.html nav bar instead of repo_name.
