### PR TITLE
Update cookiecutter vars in sphinx files.

### DIFF
--- a/{{cookiecutter.repo_name}}/LICENSE.rst
+++ b/{{cookiecutter.repo_name}}/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) {{ cookiecutter.year }}, {{ cookiecutter.full_name }}
+Copyright (c) {{ cookiecutter.year }}, {{ cookiecutter.author_name }}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/{{cookiecutter.repo_name}}/docs/Makefile
+++ b/{{cookiecutter.repo_name}}/docs/Makefile
@@ -77,17 +77,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/{{ project_name }}.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/{{ project_name }}.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/{{ project_name }}"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/{{ project_name }}"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
 	@echo "# devhelp"
 
 epub:

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# {{ project_name }} documentation build configuration file, created by
+# {{ cookiecutter.project_name }} documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 17 11:46:20 2013.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'{{ project_name }}'
-copyright = u'2013, ChangeMyName'
+project = u'{{ cookiecutter.project_name }}'
+copyright = u'{{ cookiecutter.year }}, {{ cookiecutter.author_name }}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -164,7 +164,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '{{ project_name }}doc'
+htmlhelp_basename = '{{ cookiecutter.project_name }}doc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -183,8 +183,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', '{{ project_name }}.tex', u'{{ project_name }} Documentation',
-   u'ChangeToMyName', 'manual'),
+  ('index', '{{ cookiecutter.project_name }}.tex', u'{{ cookiecutter.project_name }} Documentation',
+   u'{{ cookiecutter.author_name }}', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,8 +213,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', '{{ project_name }}', u'{{ project_name }} Documentation',
-     [u'ChangeToMyName'], 1)
+    ('index', '{{ cookiecutter.project_name }}', u'{{ cookiecutter.project_name }} Documentation',
+     [u'{{ cookiecutter.author_name }}'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -227,9 +227,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', '{{ project_name }}', u'{{ project_name }} Documentation',
-   u'ChangeToMyName', '{{ project_name }}', 'One line description of project.',
-   'Miscellaneous'),
+  ('index', '{{ cookiecutter.project_name }}', u'{{ cookiecutter.project_name }} Documentation',
+   u'{{ cookiecutter.author_name }}', '{{ cookiecutter.project_name }}',
+   '{{ cookiecutter.description }}','Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/{{cookiecutter.repo_name}}/docs/make.bat
+++ b/{{cookiecutter.repo_name}}/docs/make.bat
@@ -99,9 +99,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\{{ project_name }}.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\{{ project_name }}.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.ghc
 	goto end
 )
 


### PR DESCRIPTION
Many variables were missing the `cookiecutter` prefix.

In conf.py:
Added prefix to `project_name` and `description`.
Changed `ChangeMyName` to `cookiecutter.author_name`.
Changed `ChangeToMyName` to `cookiecutter.author_name`.

In Makefile and make.bat:
Added prefix to `project_name`.

In LICENSE.rst:
Changed `full_name` to `author_name` and added prefix.
