### PR TITLE
removed requirement for security from session cookie

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -30,7 +30,7 @@ DJANGO_SECURE_CONTENT_TYPE_NOSNIFF      SECURE_CONTENT_TYPE_NOSNIFF n/a         
 DJANGO_SECURE_FRAME_DENY                SECURE_FRAME_DENY           n/a                                         True
 DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS   HSTS_INCLUDE_SUBDOMAINS     n/a                                         True
 DJANGO_SESSION_COOKIE_HTTPONLY          SESSION_COOKIE_HTTPONLY     n/a                                         True
-DJANGO_SESSION_COOKIE_SECURE            SESSION_COOKIE_SECURE       n/a                                         True
+DJANGO_SESSION_COOKIE_SECURE            SESSION_COOKIE_SECURE       n/a                                         False
 ======================================= =========================== =========================================== ===========================================
 
 * TODO: Add vendor-added settings in another table

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -318,7 +318,7 @@ class Production(Common):
     SECURE_FRAME_DENY = values.BooleanValue(True)
     SECURE_CONTENT_TYPE_NOSNIFF = values.BooleanValue(True)
     SECURE_BROWSER_XSS_FILTER = values.BooleanValue(True)
-    SESSION_COOKIE_SECURE = values.BooleanValue(True)
+    SESSION_COOKIE_SECURE = values.BooleanValue(False)
     SESSION_COOKIE_HTTPONLY = values.BooleanValue(True)
     SECURE_SSL_REDIRECT = values.BooleanValue(True)
     ########## end django-secure


### PR DESCRIPTION
Default heroku deployments don't come with SSL enabled, and there are not (to my knowledge) any free SSL add-ons. It is therefore easiest to deploy without the security requirement.
