### PR TITLE
first load django-debug-toolbar before using it

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/config/settings.py
@@ -286,8 +286,8 @@ class Local(Common):
     ########## End mail settings
 
     ########## django-debug-toolbar
-    MIDDLEWARE_CLASSES = Common.MIDDLEWARE_CLASSES + ('debug_toolbar.middleware.DebugToolbarMiddleware',)
     INSTALLED_APPS += ('debug_toolbar',)
+    MIDDLEWARE_CLASSES = Common.MIDDLEWARE_CLASSES + ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
     INTERNAL_IPS = ('127.0.0.1',)
 


### PR DESCRIPTION
django-debug-toolbar is used before being loaded into INSTALLED_APPS. I fixed it
