### PR TITLE
chore(requirements): update pip requirements to latest stable.

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -2,33 +2,33 @@
 django==1.6.1
 
 # Configuration
-django-configurations==0.5.1
+django-configurations==0.8
 django-secure==1.0
-django-cache-url==0.6.0
+django-cache-url==0.7.0
 dj-database-url==0.2.2
 
 # Forms
-django-braces==1.2.2
+django-braces==1.3.1
 django-crispy-forms==1.4.0
-django-floppyforms==1.1
+django-floppyforms==1.1.1
 
 # Models
-South==0.8.2
-django-model-utils==1.5.0
+South==0.8.4
+django-model-utils==2.0
 
 # images
-Pillow==2.1.0
+Pillow==2.3.0
 
 # For user registration, either via email or social
 # Well-built with regular release cycles!
-django-allauth==0.13.0
+django-allauth==0.15.0
 
 # For the persistance stores
-psycopg2==2.5
+psycopg2==2.5.2
 
 # Unicode slugification
 unicode-slugify==0.1.1
-django-autoslug==1.7.1
+django-autoslug==1.7.2
 
 # Useful things
 django-avatar==2.0

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -1,9 +1,8 @@
 # Local development dependencies go here
 -r base.txt
-coverage==3.6
-django-discover-runner==0.4
+coverage==3.7.1
+django-discover-runner==1.0
 Sphinx
 
-
 # django-debug-toolbar that works with Django 1.5+
-django-debug-toolbar==1.0
+django-debug-toolbar==1.0.1

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -2,8 +2,8 @@
 #	production that isn't in development.
 -r base.txt
 
-gunicorn==0.17.4
-django-storages==1.1.4
+gunicorn==18.0
+django-storages==1.1.8
 Collectfast==0.1.13
-gevent==0.13.8
-boto==2.9.5
+gevent==1.0
+boto==2.23.0

--- a/{{cookiecutter.repo_name}}/requirements/test.txt
+++ b/{{cookiecutter.repo_name}}/requirements/test.txt
@@ -1,4 +1,4 @@
 # Test dependencies go here.
 -r base.txt
-coverage==3.6
-django-discover-runner==0.4
+coverage==3.7.1
+django-discover-runner==1.0


### PR DESCRIPTION
Makes all the packages in requirements to it's latest. The following packages are updated:

django-configurations==0.5.1 # Latest 0.8
django-cache-url==0.6.0 # Latest 0.7.0
django-braces==1.2.2 # Latest 1.3.1
django-floppyforms==1.1 # Latest 1.1.1
South==0.8.2 # Latest 0.8.4
django-model-utils==1.5.0 # Latest 2.0
Pillow==2.1.0 # Latest 2.3.0
django-allauth==0.13.0 # Latest 0.15.0
psycopg2==2.5 # Latest 2.5.2
django-autoslug==1.7.1 # Latest 1.7.2
gunicorn==0.17.4 # Latest 18.0
django-storages==1.1.4 # Latest 1.1.8
gevent==0.13.8 # Latest 1.0
boto==2.9.5 # Latest 2.23.0
coverage==3.6 # Latest 3.7.1
django-discover-runner==0.4 # Latest 1.0
