### PR TITLE
Makes template var/tag delimiter spacing consistent

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email.html
@@ -20,9 +20,9 @@
 
         {% for emailaddress in user.emailaddress_set.all %}
       <div class="ctrlHolder">
-            <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
+            <label for="email_radio_{{ forloop.counter }}" class="{% if emailaddress.primary %}primary_email{% endif %}">
 
-            <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+            <input id="email_radio_{{ forloop.counter }}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{% endif %} value="{{ emailaddress.email }}"/>
 
       {{ emailaddress.email }}
           {% if emailaddress.verified %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email_confirm.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email_confirm.html
@@ -17,7 +17,7 @@
 
         {% user_display confirmation.email_address.user as user_display %}
                 
-        <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
         <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
         {% csrf_token %}
@@ -28,7 +28,7 @@
 
         {% url 'account_email' as email_url %}
 
-        <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url}}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+        <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 
         {% endif %}
     </div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email_confirmed.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/email_confirmed.html
@@ -14,7 +14,7 @@
 
         {% user_display email_address.user as user_display %}
                 
-        <p>{% blocktrans with email_address.email as email %}You have confirmed that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with email_address.email as email %}You have confirmed that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
     </div>
   </div>
 </div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/login.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/login.html
@@ -18,7 +18,7 @@
       {% if socialaccount.providers  %}
       <p>{% blocktrans with site.name as site_name %}Please sign in with one
       of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a> 
-      for a {{site_name}} account and sign in below:{% endblocktrans %}</p>
+      for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
 
       <div class="socialaccount_ballot">
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/logout.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/logout.html
@@ -17,7 +17,7 @@
         <form method="post" action="{% url 'account_logout' %}">
           {% csrf_token %}
           {% if redirect_field_value %}
-          <input type="hidden" name="{{redirect_field_name}}" value="{{redirect_field_value}}"/>
+          <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
           {% endif %}
           <button class="btn btn-danger" type="submit">{% trans 'Sign Out' %}</button>
         </form>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/verification_sent.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/verification_sent.html
@@ -10,7 +10,7 @@
     <div class="col-md-5">
         <h2>{% trans "Verify Your E-mail Address" %}</h2>
         
-        <p>{% blocktrans %}We have sent an e-mail to <a href="mailto:{{email}}">{{ email }}</a> for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+        <p>{% blocktrans %}We have sent an e-mail to <a href="mailto:{{ email }}">{{ email }}</a> for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
     </div>    
   </div>
 </div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/verified_email_required.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/templates/account/verified_email_required.html
@@ -21,7 +21,7 @@
         verification. Please click on the link inside this e-mail. Please
         contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
-        <p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{email_url}}">change your e-mail address</a>.{% endblocktrans %}</p>
+        <p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Single space between delimiter matches prescribed [Django template style](https://docs.djangoproject.com/en/1.6/internals/contributing/writing-code/coding-style/#template-style) and is consistent with the style those really smart people used in Two Scoops of Django.
