### PR TITLE
fix(settings): fixes wrong cache config used for heroku

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,4 +1,5 @@
 # This file is here because many Platforms as a Service look for
 #	requirements.txt in the root directory of a project.
-pylibmc==1.2.3  # 
+pylibmc==1.2.3
+django-heroku-memcacheify==0.5
 -r requirements/production.txt

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -388,7 +388,12 @@ class Production(Common):
 
     ########## CACHING
     # Only do this here because thanks to django-pylibmc-sasl and pylibmc memcacheify is painful to install on windows.
-    CACHES = values.CacheURLValue(default="memcached://127.0.0.1:11211")
+    try:
+        # See: https://github.com/rdegges/django-heroku-memcacheify
+        from memcacheify import memcacheify
+        CACHES = memcacheify()
+    except ImportError:
+        CACHES = values.CacheURLValue(default="memcached://127.0.0.1:11211")
     ########## END CACHING
 
     ########## Your production stuff: Below this line define 3rd party libary settings


### PR DESCRIPTION
- Installs `django-heroku-memcacheify` only on heroku to 
  avoid installing `libmemcached-dev`[1] locally. 

[1] https://github.com/rdegges/django-heroku-memcacheify#install

Fixes: https://github.com/pydanny/cookiecutter-django/issues/80
