### PR TITLE
fix(cookie cutter): fixes the misuse of `repo_name`/`project_name`

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "{{cookiecutter.project_name}}",
+  "name": "{{cookiecutter.repo_name}}",
   "version": "{{ cookiecutter.version }}",
   "dependencies": {},
   "devDependencies": {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -365,7 +365,7 @@ class Production(Common):
 
     ########## EMAIL
     DEFAULT_FROM_EMAIL = values.Value(
-            '{{cookiecutter.project_name}} <{{cookiecutter.project_name}}-noreply@{{cookiecutter.domain_name}}>')
+            '{{cookiecutter.project_name}} <noreply@{{cookiecutter.domain_name}}>')
     EMAIL_HOST = values.Value('smtp.sendgrid.com')
     EMAIL_HOST_PASSWORD = values.SecretValue(environ_prefix="", environ_name="SENDGRID_PASSWORD")
     EMAIL_HOST_USER = values.SecretValue(environ_prefix="", environ_name="SENDGRID_USERNAME")


### PR DESCRIPTION
- `project_name` may contain spaces, do not use for generating emails
- `name` attribute in package.json is used by `Gruntfile` to figure-out
  the directory structure of project, so `repo_name` is what must
  be used here.
