### PR TITLE
update django-debug-toolbar config to fix DeprecationWarning

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -297,7 +297,9 @@ class Local(Common):
     INTERNAL_IPS = ('127.0.0.1',)
 
     DEBUG_TOOLBAR_CONFIG = {
-        'INTERCEPT_REDIRECTS': False,
+        'DISABLE_PANELS': [
+            'debug_toolbar.panels.redirects.RedirectsPanel',
+        ],
         'SHOW_TEMPLATE_CONTEXT': True,
     }
     ########## end django-debug-toolbar


### PR DESCRIPTION
update django-debug-toolbar config to fix DeprecationWarning
See more: http://django-debug-toolbar.readthedocs.org/en/1.2/configuration.html#toolbar-options
