### PR TITLE
upgrade dependencies to latest versions available

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,5 +1,5 @@
 # Bleeding edge Django
-django==1.6.4
+django==1.6.5
 
 # Configuration
 django-configurations==0.8
@@ -24,7 +24,7 @@ Pillow==2.4.0
 django-allauth==0.16.1
 
 # For the persistance stores
-psycopg2==2.5.2
+psycopg2==2.5.3
 
 # Unicode slugification
 unicode-slugify==0.1.1

--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -5,4 +5,4 @@ django-discover-runner==1.0
 Sphinx
 
 # django-debug-toolbar that works with Django 1.5+
-django-debug-toolbar==1.1
+django-debug-toolbar==1.2

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -5,5 +5,5 @@
 gunicorn==18.0
 django-storages==1.1.8
 Collectfast==0.2.0
-gevent==1.0
-boto==2.27.0
+gevent==1.0.1
+boto==2.28.0


### PR DESCRIPTION
django==1.6.5 - Security-release - https://www.djangoproject.com/weblog/2014/may/14/security-releases-issued/

psycopg2==2.5.3 - 
django-debug-toolbar==1.2
gevent==1.0.1
boto==2.28.0
