### PR TITLE
Added a default LOGIN_URL

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings.py
@@ -231,6 +231,7 @@ class Common(Configuration):
     # Select the correct user model
     AUTH_USER_MODEL = "users.User"
     LOGIN_REDIRECT_URL = "users:redirect"
+    LOGIN_URL = "account_login"
     ########## END Custom user app defaults
 
     ########## SLUGLIFIER


### PR DESCRIPTION
Added "account_login" as the default LOGIN_URL in settings.py.

This fixes a problem where the application will throw a 404 on the login page if you changed allauth from "/accounts" to anything else.
