### PR TITLE
Remove django-discover-runner app

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/local.txt
+++ b/{{cookiecutter.repo_name}}/requirements/local.txt
@@ -1,7 +1,6 @@
 # Local development dependencies go here
 -r base.txt
 coverage==3.7.1
-django-discover-runner==1.0
 Sphinx
 
 # django-debug-toolbar that works with Django 1.5+

--- a/{{cookiecutter.repo_name}}/requirements/test.txt
+++ b/{{cookiecutter.repo_name}}/requirements/test.txt
@@ -1,4 +1,3 @@
 # Test dependencies go here.
 -r base.txt
 coverage==3.7.1
-django-discover-runner==1.0


### PR DESCRIPTION
Because it has been added to Django 1.6 as the default test runner.
