### PR TITLE
fix(security/dj-secure): add missing middleware of django-secure

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -56,6 +56,8 @@ class Common(Configuration):
 
     # MIDDLEWARE CONFIGURATION
     MIDDLEWARE_CLASSES = (
+        # Make sure djangosecure.middleware.SecurityMiddleware is listed first
+        'djangosecure.middleware.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -22,6 +22,10 @@ from .common import Common
 
 class Production(Common):
 
+    # This ensures that Django will be able to detect a secure connection
+    # properly on Heroku.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
     # INSTALLED_APPS
     INSTALLED_APPS = Common.INSTALLED_APPS
     # END INSTALLED_APPS


### PR DESCRIPTION
- For the working of django-secure the middleware class needs to be added.
  (http://django-secure.readthedocs.org/en/latest/index.html#usage)
- add correct values for SECURE_PROXY_SSL_HEADER for heroku
