### PR TITLE
reverted pylibmc to 1.2.3 version

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,5 +1,5 @@
 # This file is here because many Platforms as a Service look for
 #	requirements.txt in the root directory of a project.
-pylibmc==1.3.0
+pylibmc==1.2.3
 django-heroku-memcacheify==0.5
 -r requirements/production.txt


### PR DESCRIPTION
Reverted pylibmc to 1.2.3 version because django-heroku-memcacheify==0.5 apparently require pylibmc==1.2.3 

https://github.com/rdegges/django-heroku-memcacheify/blob/master/setup.py#L18
