### PR TITLE
minor pep8 fixes

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import os
 import sys

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/__init__.py
@@ -3,4 +3,3 @@ from __future__ import absolute_import
 
 from .local import Local  # noqa
 from .production import Production  # noqa
-

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -73,7 +73,6 @@ class Common(Configuration):
     }
     # END MIGRATIONS CONFIGURATION
 
-
     # DEBUG
     # See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
     DEBUG = values.BooleanValue(False)


### PR DESCRIPTION
fixes those small linting issues that should not be in this template.

`users/models.py` F401 warnings are intentionally left for
convenience in future coding.
