### PR TITLE
Added default Vagrant gateway to INTERNAL_IPS

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/local.py
@@ -31,7 +31,7 @@ class Local(Common):
     MIDDLEWARE_CLASSES = Common.MIDDLEWARE_CLASSES + ('debug_toolbar.middleware.DebugToolbarMiddleware',)
     INSTALLED_APPS += ('debug_toolbar',)
 
-    INTERNAL_IPS = ('127.0.0.1',)
+    INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
 
     DEBUG_TOOLBAR_CONFIG = {
         'DISABLE_PANELS': [


### PR DESCRIPTION
Makes Django Debug Toolbar show up too when running inside the Vagrant VM.
