### PR TITLE
Added ATOMIC_REQUESTS=True to default DB setup

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -264,4 +264,8 @@ class Common(Configuration):
     }
     # END LOGGING CONFIGURATION
 
+    @classmethod
+    def post_setup(cls):
+        cls.DATABASES['default']['ATOMIC_REQUESTS'] = True
+
     # Your common stuff: Below this line define 3rd party library settings


### PR DESCRIPTION
Quoting Two Scoops of Django:

> Use `ATOMIC_REQUESTS` as long as the performance overhead is bearable. That means "forever" on most sites.
