### PR TITLE
force travis-ci not send email with "build status" to github repo owner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ before_install:
 
 script:
   - pep8 --ignore E201,E202 --max-line-length=120 --exclude='migrations' .
+
+notifications:
+  email:
+    on_success: never
+    on_failure: never


### PR DESCRIPTION
@theskumar @pydanny 
it does exactly what the title says, however, currently the build in travis-ci is not activated properly/not working.

I tried to fix it directly in travis-ci, however, I think I do not have permission to do so.
