### PR TITLE
Enable Dependabot for Javascript dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "update"
+  # Update NPM dependencies in packages.json
+  - package-ecosystem: "npm"
+    directory: "/{{cookiecutter.project_slug}}/packages-json/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -88,10 +88,15 @@ def remove_gulp_files():
         os.remove(file_name)
 
 
-def remove_packagejson_file():
-    file_names = ["package.json"]
-    for file_name in file_names:
-        os.remove(file_name)
+def remove_packages_json_dir():
+    shutil.rmtree("packages-json")
+
+
+def copy_package_json(directory):
+    shutil.copy(
+        os.path.join("packages-json", directory, "package.json"),
+        "package.json",
+    )
 
 
 def remove_celery_files():
@@ -377,9 +382,14 @@ def main():
 
     if "{{ cookiecutter.js_task_runner}}".lower() == "none":
         remove_gulp_files()
-        remove_packagejson_file()
         if "{{ cookiecutter.use_docker }}".lower() == "y":
             remove_node_dockerfile()
+    else:
+        if "{{ cookiecutter.custom_bootstrap_compilation }}".lower() == "y":
+            copy_package_json("custom-bs")
+        else:
+            copy_package_json("gulp")
+    remove_packages_json_dir()
 
     if "{{ cookiecutter.cloud_provider}}".lower() == "none":
         print(

--- a/{{cookiecutter.project_slug}}/packages-json/custom-bs/package.json
+++ b/{{cookiecutter.project_slug}}/packages-json/custom-bs/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "{{cookiecutter.project_slug}}",
+  "version": "{{ cookiecutter.version }}",
+  "dependencies": {},
+  "devDependencies": {
+    "bootstrap": "4.3.1",
+    "gulp-concat": "^2.6.1",
+    "jquery": "3.3.1",
+    "popper.js": "1.14.3",
+    "autoprefixer": "^9.4.7",
+    "browser-sync": "^2.14.0",
+    "cssnano": "^4.1.10",
+    "gulp": "^4.0.0",
+    "gulp-imagemin": "^5.0.3",
+    "gulp-plumber": "^1.2.1",
+    "gulp-postcss": "^8.0.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-sass": "^4.0.2",
+    "gulp-uglify-es": "^1.0.4",
+    "pixrem": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=8"
+  },
+  "browserslist": [
+    "last 2 versions"
+  ],
+  "scripts": {
+    "dev": "gulp",
+    "build": "gulp generate-assets"
+  }
+}

--- a/{{cookiecutter.project_slug}}/packages-json/gulp/package.json
+++ b/{{cookiecutter.project_slug}}/packages-json/gulp/package.json
@@ -3,13 +3,6 @@
   "version": "{{ cookiecutter.version }}",
   "dependencies": {},
   "devDependencies": {
-    {% if cookiecutter.js_task_runner == 'Gulp' -%}
-    {% if cookiecutter.custom_bootstrap_compilation == 'y' -%}
-    "bootstrap": "4.3.1",
-    "gulp-concat": "^2.6.1",
-    "jquery": "3.3.1",
-    "popper.js": "1.14.3",
-    {% endif -%}
     "autoprefixer": "^9.4.7",
     "browser-sync": "^2.14.0",
     "cssnano": "^4.1.10",
@@ -21,7 +14,6 @@
     "gulp-sass": "^4.0.2",
     "gulp-uglify-es": "^1.0.4",
     "pixrem": "^5.0.0"
-    {%- endif %}
   },
   "engines": {
     "node": ">=8"
@@ -30,9 +22,7 @@
     "last 2 versions"
   ],
   "scripts": {
-    {% if cookiecutter.js_task_runner == 'Gulp' -%}
     "dev": "gulp",
     "build": "gulp generate-assets"
-    {%- endif %}
   }
 }


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Remove templating from package.json by splitting into 2 separate files to enable dependabot

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
- [ ] Need to update the CI workflow to at least run `gulp generate-assets`

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->

Our JS dependencies are not kept up to date automatically like our Python ones are by PyUp. Currently we can't just enable Dependanbot as it would fail to parse our `package.json` file due to Jinja template.

Since it's not very complicated, we can maintain 2 separate versions of the file, for the 2 if branches and let Dependabot update them.