### PR TITLE
Removed unnecessary custom context processor exposing the DEBUG Template Context Variable

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -198,7 +198,6 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
-                "{{ cookiecutter.project_slug }}.utils.context_processors.settings_context",
             ],
         },
     }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/utils/context_processors.py
@@ -1,8 +1,0 @@
-from django.conf import settings
-
-
-def settings_context(_request):
-    """Settings available by default to the templates context."""
-    # Note: we intentionally do NOT expose the entire settings
-    # to prevent accidental leaking of sensitive information
-    return {"DEBUG": settings.DEBUG}


### PR DESCRIPTION
## Description

Remove the custom context processor, ``` {{ cookiecutter.project_slug }}.utils.context_processors.settings_context ```,  that was exposing a Template Context Variable, DEBUG. This is because the first context processor in the list, ```settings.TEMPLATES.context_processor``` enabled [django.template.context_processors.debug](https://docs.djangoproject.com/en/3.1/ref/templates/api/#django-template-context-processors-debug), which exposes the same variable, debug.


Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This is just redundant and doesn't provide any advantage and hence should be removed. The code will also become easier to understand.