### PR TITLE
Docs: Adds details to on how to set up a secure development environment

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -31,6 +31,7 @@
   "cloud_provider": [
     "AWS",
     "GCP",
+    "nginx",
     "None"
   ],
   "mail_service": [

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -155,6 +155,14 @@ Sass Compilation & Live Reloading
 If you’d like to take advantage of live reloading and Sass compilation you can do so with a little
 bit of preparation, see :ref:`sass-compilation-live-reload`.
 
+Use HTTPS on the local development environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are interested in securing your development evnvironment using TLS certificates, click `here`_ for the instructions.
+
+.. _`here`: ../developing-locally-docker.rst#HTTPS on the local Docker installation
+
+
 Summary
 -------
 

--- a/{{cookiecutter.project_slug}}/compose/production/nginx/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.17.8-alpine
+COPY ./compose/production/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
+++ b/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
@@ -1,7 +1,7 @@
 server {
 	listen       80;
 	server_name  localhost;
-	location /media {
+	location /media/ {
 		autoindex on;
 		alias /usr/share/nginx/media/;
 	}

--- a/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
+++ b/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
@@ -1,0 +1,8 @@
+server {
+	listen       80;
+	server_name  localhost;
+	location /media {
+		autoindex on;
+		alias /usr/share/nginx/media/;
+	}
+}

--- a/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
+++ b/{{cookiecutter.project_slug}}/compose/production/nginx/default.conf
@@ -2,7 +2,6 @@ server {
 	listen       80;
 	server_name  localhost;
 	location /media/ {
-		autoindex on;
 		alias /usr/share/nginx/media/;
 	}
 }

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -240,6 +240,8 @@ EMAIL_TIMEOUT = 5
 # Django Admin URL.
 ADMIN_URL = "admin/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#admins
+# When more than one admin address is inserted, we need to create two tuples with 
+# the addresses looking like they should.
 ADMINS = [("""{{cookiecutter.author_name}}""", "{{cookiecutter.email}}")]
 # https://docs.djangoproject.com/en/dev/ref/settings/#managers
 MANAGERS = ADMINS

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -66,7 +66,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
     "DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", default=True
 )
 
-{% if cookiecutter.cloud_provider != 'None' -%}
+{% if cookiecutter.cloud_provider != 'None' and cookiecutter.cloud_provider != 'nginx' -%}
 # STORAGES
 # ------------------------------------------------------------------------------
 # https://django-storages.readthedocs.io/en/latest/#installation

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -16,7 +16,7 @@ services:
     image: {{ cookiecutter.project_slug }}_production_django
     {%- if cookiecutter.cloud_provider == 'nginx' %}
     volumes:
-      - production_django_media:{{ cookiecutter.project_slug }}/media
+      - production_django_media:/app/{{ cookiecutter.project_slug }}/media
     {%- endif %}
     depends_on:
       - postgres

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -4,6 +4,9 @@ volumes:
   production_postgres_data: {}
   production_postgres_data_backups: {}
   production_traefik: {}
+  {%- if cookiecutter.cloud_provider == 'nginx' %}
+  production_django_media: {}
+  {%- endif %}
 
 services:
   django:{% if cookiecutter.use_celery == 'y' %} &django{% endif %}
@@ -11,6 +14,10 @@ services:
       context: .
       dockerfile: ./compose/production/django/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_django
+    {%- if cookiecutter.cloud_provider == 'nginx' %}
+    volumes:
+      - production_django_media:{{ cookiecutter.project_slug }}/media
+    {%- endif %}
     depends_on:
       - postgres
       - redis
@@ -76,4 +83,15 @@ services:
       - ./.envs/.production/.django
     volumes:
       - production_postgres_data_backups:/backups:z
+  {%- endif %}
+  {%- if cookiecutter.cloud_provider == 'nginx' %}
+  nginx:
+    build:
+      context: .
+      dockerfile: ./compose/production/nginx/Dockerfile
+    image: {{ cookiecutter.project_slug }}_local_nginx
+    depends_on:
+      - django
+    volumes:
+      - production_django_media:/usr/share/nginx/media:ro
   {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/__init__.py
@@ -1,5 +1,5 @@
 """
 To understand why this file is here, please read:
 
-http://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
+https://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
 """

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/__init__.py
@@ -1,5 +1,5 @@
 """
 To understand why this file is here, please read:
 
-http://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
+https://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
 """


### PR DESCRIPTION
## Description

This PR adds details and corrects some erros that were occuring as one set out to install TLS certificates in the developer environment.

This adds the need to edit `/etc/hosts`.
This adds instructions on using `django-sslserver` for non-docker dev environments.

Checklist:

- [x] I've updated the documentation

Fix #2664
Fix #2840