### PR TITLE
Updated the tests_views module by replacing RequestFactory with Djang…

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -1,101 +1,132 @@
 import pytest
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.models import AnonymousUser
-from django.contrib.messages.middleware import MessageMiddleware
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.http import HttpRequest
-from django.test import RequestFactory
+from django.test import Client
 from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
-from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
-from {{ cookiecutter.project_slug }}.users.views import (
-    UserRedirectView,
-    UserUpdateView,
-    user_detail_view,
-)
 
 pytestmark = pytest.mark.django_db
 
 
 class TestUserUpdateView:
     """
-    TODO:
-        extracting view initialization code as class-scoped fixture
-        would be great if only pytest-django supported non-function-scoped
-        fixture db access -- this is a work-in-progress for now:
-        https://github.com/pytest-dev/pytest-django/pull/258
+    Test class for all tests related to the User Update View
     """
 
     def dummy_get_response(self, request: HttpRequest):
         return None
 
-    def test_get_success_url(self, user: User, rf: RequestFactory):
-        view = UserUpdateView()
-        request = rf.get("/fake-url/")
-        request.user = user
+    def test_get_success_url(
+        self,
+        user: User,
+        client: Client,
+    ):
+        """
+        Test to make sure the correct success url (User's detail view url)
+        is returned for logged-in users
+        """
 
-        view.request = request
+        url = reverse("users:update")
 
-        assert view.get_success_url() == f"/users/{user.username}/"
+        # Make User login
+        client.force_login(user)
 
-    def test_get_object(self, user: User, rf: RequestFactory):
-        view = UserUpdateView()
-        request = rf.get("/fake-url/")
-        request.user = user
+        response = client.post(path=url, data=self.form_data)
 
-        view.request = request
+        # Make sure the correct url is returned with status_code 302
+        # and the final constructed url page can be loaded with status_code 200
+        assertRedirects(response, expected_url=f"/users/{user.username}/")
 
-        assert view.get_object() == user
+    def test_get_object(self, user: User, client: Client):
+        """
+        Test to make sure the correct User Model Instance
+        is returned
+        """
+        url = reverse("users:update")
 
-    def test_form_valid(self, user: User, rf: RequestFactory):
-        view = UserUpdateView()
-        request = rf.get("/fake-url/")
+        # make client login
+        client.force_login(user)
 
-        # Add the session/message middleware to the request
-        SessionMiddleware(self.dummy_get_response).process_request(request)
-        MessageMiddleware(self.dummy_get_response).process_request(request)
-        request.user = user
+        response = client.get(path=url)
 
-        view.request = request
+        assert response.context["view"].get_object() == user
+
+    def test_form_valid(self, user: User, client: Client):
+        """
+        Test to make sure the correct success message is emitted for a valid form
+        """
+
+        url = reverse("users:update")
+
+        # Make User login
+        client.force_login(user)
+
+        response = client.post(path=url, data=self.form_data)
 
         # Initialize the form
         form = UserChangeForm()
         form.cleaned_data = []
         view.form_valid(form)
 
-        messages_sent = [m.message for m in messages.get_messages(request)]
-        assert messages_sent == ["Information successfully updated"]
-
+        # assert correct success message is emmitted
+        messages_sent = [
+            (m.message, m.level_tag)
+            for m in messages.get_messages(response.wsgi_request)
+        ]
+        assert messages_sent == [(_("Information successfully updated"), "success")]
 
 class TestUserRedirectView:
-    def test_get_redirect_url(self, user: User, rf: RequestFactory):
-        view = UserRedirectView()
-        request = rf.get("/fake-url")
-        request.user = user
+    def test_get_redirect_url(self, user: User, client: Client):
+        """
+        Test to make sure authenticated (logged-in) users get redirected to their
+        detail view page
+        """
+        url = reverse("users:redirect")
+        
+        # Make User login
+        client.force_login(user)
 
-        view.request = request
+        # Process request and get response
+        response = client.get(path=url)
 
-        assert view.get_redirect_url() == f"/users/{user.username}/"
+        # Make sure the correct url is returned with status_code 302
+        # and the final constructed url page can be loaded with status_code 200
+        assertRedirects(response, expected_url=f"/users/{user.username}/")
 
 
 class TestUserDetailView:
-    def test_authenticated(self, user: User, rf: RequestFactory):
-        request = rf.get("/fake-url/")
-        request.user = UserFactory()
+    """
+    Test class for all tests related to the User Detail View
+    """
+
+    def test_authenticated(self, user: User, client: Client):
+        """
+        Test to make sure authenticated (logged-in) users can checkout
+        other users' detail view page
+        """
+        url = reverse("users:detail", kwargs={"username": user.username})
+
+        # Make User login
+        client.force_login(user)
+
+        response = client.get(path=url)
 
         response = user_detail_view(request, username=user.username)
 
-        assert response.status_code == 200
-
-    def test_not_authenticated(self, user: User, rf: RequestFactory):
-        request = rf.get("/fake-url/")
-        request.user = AnonymousUser()
-
-        response = user_detail_view(request, username=user.username)
+    def test_not_authenticated(self, user: User, client: Client):
+        """
+        Test to make sure unauthenticated users cannot checkout
+        other users' detail view page and get successfully redirected to the login page url
+        with the correct url to redirect user to thir detail page after they login
+        """
+        # Get Login Url
         login_url = reverse(settings.LOGIN_URL)
+
+        url = reverse("users:detail", kwargs={"username": user.username})
+
+        response = client.get(path=url)
 
         assert response.status_code == 302
         assert response.url == f"{login_url}?next=/fake-url/"


### PR DESCRIPTION
## Description

Refactored `test_views.py` to use `Client` instead of `RequestFactory`. 



Checklist:

- [X] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Doing this has the following benefits:

1) Code is more readable and easier to understand.
1) No need to route the request through various middlewares. `Client` does that for us.
1) No need to define a dummy middleware class.
1) No need to add `# type: ignore` to get rid of mypy warnings
1) Provides a better end-to-end test especially for `POST` requests.
