### PR TITLE
fix: Switched to node:10 base image.

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-stretch-slim
+FROM node:10
 
 WORKDIR /app
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

- Fixes #3202
- Does make builds larger, there might be a better solution.

Checklist:

- [ X ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ X ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Currently a fresh local build of the cookiecutter using the node builder and the docker-compose will fail. This should put it in working order. Though there may be a better solution long term in order to make build sizes and times smaller.
