### PR TITLE
Use reload-excludes in compose start

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -7,7 +7,8 @@ set -o nounset
 
 python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
-uvicorn config.asgi:application --host 0.0.0.0 --reload
+uvicorn config.asgi:application --host 0.0.0.0 --reload-exclude \
+  '.*, .py[cod], .sw.*, ~*, templates/*, static/*, staticfiles/*, compose/*, bin/*, media/*, htmlcov/*, docs/*, locale/*, requirements/*'
 {%- else %}
 python manage.py runserver_plus 0.0.0.0:8000
 {%- endif %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Exclude certain dirs for uvicorn reload which Django already does

<!-- What's it you're proposing? -->


Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

It's annoying having to reload every time I changed an HTML or JS file
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
