### PR TITLE
Add drf stubs

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -17,6 +17,9 @@ mypy==0.910  # https://github.com/python/mypy
 django-stubs==1.8.0  # https://github.com/typeddjango/django-stubs
 pytest==6.2.5  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.4  # https://github.com/Frozenball/pytest-sugar
+{%- if cookiecutter.use_drf == "y" %}
+djangorestframework-stubs==1.4.0  # https://github.com/typeddjango/djangorestframework-stubs
+{%- endif %}
 
 # Documentation
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -24,7 +24,7 @@ ignore_missing_imports = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_unused_configs = True
-plugins = mypy_django_plugin.main
+plugins = mypy_django_plugin.main{% if cookiecutter.use_drf == "y" %}, mypy_drf_plugin.main{% endif %}
 
 [mypy.plugins.django-stubs]
 django_settings_module = config.settings.test

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -16,6 +16,7 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
     lookup_field = "username"
 
     def get_queryset(self, *args, **kwargs):
+        assert isinstance(self.request.user.id, int)
         return self.queryset.filter(id=self.request.user.id)
 
     @action(detail=False, methods=["GET"])


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Add djangorestframework-stubs to local requirements.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This will allow for better type checking when drf is used. 
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
