### PR TITLE
use Wayback Machine to fix dead link for postgres user setup

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -87,7 +87,7 @@ or if you're running asynchronously: ::
 .. _Redis: https://redis.io/download
 .. _CookieCutter: https://github.com/cookiecutter/cookiecutter
 .. _createdb: https://www.postgresql.org/docs/current/static/app-createdb.html
-.. _initial PostgreSQL set up: http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
+.. _initial PostgreSQL set up: http://web.archive.org/web/20190303010033/http://suite.opengeo.org/docs/latest/dataadmin/pgGettingStarted/firstconnect.html
 .. _postgres documentation: https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
 .. _pre-commit: https://pre-commit.com/
 .. _direnv: https://direnv.net/


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

This is a documentation fix for issue #3223  -- I've replaced the dead link with the last Wayback Machine capture of that page.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I didn't want to editorialize in a project I don't contribute to regularly by changing the link to another postgres tutorial; but it won't hurt my feelings if this is edited or rejected in favor of a better link. I just like helping with documentation!