### PR TITLE
Fix pull request links to correct repo URL on CHANGELOG.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,818 +9,818 @@ All enhancements and patches to Cookiecutter Django will be documented in this f
 
 ## [2021-10-18]
 ### Updated
-- Update django-environ to 0.8.0 ([#3367](https://github.com/pydanny/cookiecutter-django/pull/3367))
+- Update django-environ to 0.8.0 ([#3367](https://github.com/cookiecutter/cookiecutter-django/pull/3367))
 
 ## [2021-10-14]
 ### Updated
-- Update flake8 to 4.0.1 ([#3361](https://github.com/cookicutter/cookiecutter-django/pull/3361))
-- Update flake8-isort to 4.1.1 ([#3360](https://github.com/cookicutter/cookiecutter-django/pull/3360))
-- Update django-model-utils to 4.2.0 ([#3359](https://github.com/cookicutter/cookiecutter-django/pull/3359))
+- Update flake8 to 4.0.1 ([#3361](https://github.com/cookiecutter/cookiecutter-django/pull/3361))
+- Update flake8-isort to 4.1.1 ([#3360](https://github.com/cookiecutter/cookiecutter-django/pull/3360))
+- Update django-model-utils to 4.2.0 ([#3359](https://github.com/cookiecutter/cookiecutter-django/pull/3359))
 
 ## [2021-10-13]
 ### Changed
-- Add drf stubs ([#3353](https://github.com/cookicutter/cookiecutter-django/pull/3353))
+- Add drf stubs ([#3353](https://github.com/cookiecutter/cookiecutter-django/pull/3353))
 
 ## [2021-10-12]
 ### Updated
-- Update coverage to 6.0.2 ([#3356](https://github.com/cookicutter/cookiecutter-django/pull/3356))
+- Update coverage to 6.0.2 ([#3356](https://github.com/cookiecutter/cookiecutter-django/pull/3356))
 
 ## [2021-10-11]
 ### Updated
-- Update werkzeug to 2.0.2 ([#3344](https://github.com/cookicutter/cookiecutter-django/pull/3344))
-- Update coverage to 6.0.1 ([#3348](https://github.com/cookicutter/cookiecutter-django/pull/3348))
-- Update django-coverage-plugin to 2.0.1 ([#3349](https://github.com/cookicutter/cookiecutter-django/pull/3349))
-- Update django-cors-headers to 3.10.0 ([#3345](https://github.com/cookicutter/cookiecutter-django/pull/3345))
-- Update jinja2 to 3.0.2 ([#3343](https://github.com/cookicutter/cookiecutter-django/pull/3343))
-- Update django-storages to 1.12.1 ([#3355](https://github.com/cookicutter/cookiecutter-django/pull/3355))
+- Update werkzeug to 2.0.2 ([#3344](https://github.com/cookiecutter/cookiecutter-django/pull/3344))
+- Update coverage to 6.0.1 ([#3348](https://github.com/cookiecutter/cookiecutter-django/pull/3348))
+- Update django-coverage-plugin to 2.0.1 ([#3349](https://github.com/cookiecutter/cookiecutter-django/pull/3349))
+- Update django-cors-headers to 3.10.0 ([#3345](https://github.com/cookiecutter/cookiecutter-django/pull/3345))
+- Update jinja2 to 3.0.2 ([#3343](https://github.com/cookiecutter/cookiecutter-django/pull/3343))
+- Update django-storages to 1.12.1 ([#3355](https://github.com/cookiecutter/cookiecutter-django/pull/3355))
 
 ## [2021-10-03]
 ### Updated
-- Update pytz to 2021.3 ([#3340](https://github.com/cookicutter/cookiecutter-django/pull/3340))
+- Update pytz to 2021.3 ([#3340](https://github.com/cookiecutter/cookiecutter-django/pull/3340))
 
 ## [2021-10-01]
 ### Changed
-- Fix the wrong pre-commit hyperlink in Prerequisites section ([#3338](https://github.com/cookicutter/cookiecutter-django/pull/3338))
+- Fix the wrong pre-commit hyperlink in Prerequisites section ([#3338](https://github.com/cookiecutter/cookiecutter-django/pull/3338))
 
 ## [2021-09-30]
 ### Updated
-- Update sentry-sdk to 1.4.3 ([#3334](https://github.com/cookicutter/cookiecutter-django/pull/3334))
+- Update sentry-sdk to 1.4.3 ([#3334](https://github.com/cookiecutter/cookiecutter-django/pull/3334))
 
 ## [2021-09-29]
 ### Updated
-- Update django-cors-headers to 3.9.0 ([#3332](https://github.com/cookicutter/cookiecutter-django/pull/3332))
+- Update django-cors-headers to 3.9.0 ([#3332](https://github.com/cookiecutter/cookiecutter-django/pull/3332))
 
 ## [2021-09-27]
 ### Updated
-- Update sentry-sdk to 1.4.2 ([#3329](https://github.com/cookicutter/cookiecutter-django/pull/3329))
+- Update sentry-sdk to 1.4.2 ([#3329](https://github.com/cookiecutter/cookiecutter-django/pull/3329))
 
 ## [2021-09-26]
 ### Updated
-- Update django-crispy-forms to 1.13.0 ([#3327](https://github.com/cookicutter/cookiecutter-django/pull/3327))
+- Update django-crispy-forms to 1.13.0 ([#3327](https://github.com/cookiecutter/cookiecutter-django/pull/3327))
 
 ## [2021-09-24]
 ### Changed
-- Add django-settings-module to .pylintrc ([#3326](https://github.com/cookicutter/cookiecutter-django/pull/3326))
+- Add django-settings-module to .pylintrc ([#3326](https://github.com/cookiecutter/cookiecutter-django/pull/3326))
 
 ## [2021-09-23]
 ### Updated
-- Update sentry-sdk to 1.4.1 ([#3325](https://github.com/cookicutter/cookiecutter-django/pull/3325))
+- Update sentry-sdk to 1.4.1 ([#3325](https://github.com/cookiecutter/cookiecutter-django/pull/3325))
 
 ## [2021-09-22]
 ### Updated
-- Update sentry-sdk to 1.4.0 ([#3324](https://github.com/cookicutter/cookiecutter-django/pull/3324))
+- Update sentry-sdk to 1.4.0 ([#3324](https://github.com/cookiecutter/cookiecutter-django/pull/3324))
 
 ## [2021-09-16]
 ### Updated
-- Update tox to 3.24.4 ([#3323](https://github.com/cookicutter/cookiecutter-django/pull/3323))
+- Update tox to 3.24.4 ([#3323](https://github.com/cookiecutter/cookiecutter-django/pull/3323))
 
 ## [2021-09-15]
 ### Updated
-- Auto-update pre-commit hooks ([#3322](https://github.com/cookicutter/cookiecutter-django/pull/3322))
+- Auto-update pre-commit hooks ([#3322](https://github.com/cookiecutter/cookiecutter-django/pull/3322))
 
 ## [2021-09-14]
 ### Updated
-- Update black to 21.9b0 ([#3321](https://github.com/cookicutter/cookiecutter-django/pull/3321))
+- Update black to 21.9b0 ([#3321](https://github.com/cookiecutter/cookiecutter-django/pull/3321))
 
 ## [2021-09-13]
 ### Updated
-- Bump stefanzweifel/git-auto-commit-action from 4.11.0 to 4.12.0 ([#3320](https://github.com/cookicutter/cookiecutter-django/pull/3320))
-- Update sphinx to 4.2.0 ([#3319](https://github.com/cookicutter/cookiecutter-django/pull/3319))
+- Bump stefanzweifel/git-auto-commit-action from 4.11.0 to 4.12.0 ([#3320](https://github.com/cookiecutter/cookiecutter-django/pull/3320))
+- Update sphinx to 4.2.0 ([#3319](https://github.com/cookiecutter/cookiecutter-django/pull/3319))
 
 ## [2021-09-11]
 ### Changed
-- Removing pycharm docs if app does not use pycharm ([#3139](https://github.com/cookicutter/cookiecutter-django/pull/3139))
+- Removing pycharm docs if app does not use pycharm ([#3139](https://github.com/cookiecutter/cookiecutter-django/pull/3139))
 ### Updated
-- Update django-environ to 0.7.0 ([#3317](https://github.com/cookicutter/cookiecutter-django/pull/3317))
+- Update django-environ to 0.7.0 ([#3317](https://github.com/cookiecutter/cookiecutter-django/pull/3317))
 
 ## [2021-09-06]
 ### Changed
-- Update Celery to v5 ([#3280](https://github.com/cookicutter/cookiecutter-django/pull/3280))
+- Update Celery to v5 ([#3280](https://github.com/cookiecutter/cookiecutter-django/pull/3280))
 
 ## [2021-09-05]
 ### Updated
-- Update django-environ to 0.6.0 ([#3314](https://github.com/cookicutter/cookiecutter-django/pull/3314))
+- Update django-environ to 0.6.0 ([#3314](https://github.com/cookiecutter/cookiecutter-django/pull/3314))
 
 ## [2021-09-03]
 ### Changed
-- Update available postgres versions ([#3297](https://github.com/cookicutter/cookiecutter-django/pull/3297))
+- Update available postgres versions ([#3297](https://github.com/cookiecutter/cookiecutter-django/pull/3297))
 ### Updated
-- Update pre-commit to 2.15.0 ([#3313](https://github.com/cookicutter/cookiecutter-django/pull/3313))
-- Auto-update pre-commit hooks ([#3307](https://github.com/cookicutter/cookiecutter-django/pull/3307))
-- Update pillow to 8.3.2 ([#3312](https://github.com/cookicutter/cookiecutter-django/pull/3312))
-- Update django-environ to 0.5.0 ([#3311](https://github.com/cookicutter/cookiecutter-django/pull/3311))
-- Update pytest to 6.2.5 ([#3310](https://github.com/cookicutter/cookiecutter-django/pull/3310))
-- Update black to 21.8b0 ([#3308](https://github.com/cookicutter/cookiecutter-django/pull/3308))
-- Update argon2-cffi to 21.1.0 ([#3306](https://github.com/cookicutter/cookiecutter-django/pull/3306))
-- Bump peter-evans/create-pull-request from 3.10.0 to 3.10.1 ([#3303](https://github.com/cookicutter/cookiecutter-django/pull/3303))
-- Update django-debug-toolbar to 3.2.2 ([#3296](https://github.com/cookicutter/cookiecutter-django/pull/3296))
-- Update django-cors-headers to 3.8.0 ([#3295](https://github.com/cookicutter/cookiecutter-django/pull/3295))
-- Update uvicorn to 0.15.0 ([#3294](https://github.com/cookicutter/cookiecutter-django/pull/3294))
+- Update pre-commit to 2.15.0 ([#3313](https://github.com/cookiecutter/cookiecutter-django/pull/3313))
+- Auto-update pre-commit hooks ([#3307](https://github.com/cookiecutter/cookiecutter-django/pull/3307))
+- Update pillow to 8.3.2 ([#3312](https://github.com/cookiecutter/cookiecutter-django/pull/3312))
+- Update django-environ to 0.5.0 ([#3311](https://github.com/cookiecutter/cookiecutter-django/pull/3311))
+- Update pytest to 6.2.5 ([#3310](https://github.com/cookiecutter/cookiecutter-django/pull/3310))
+- Update black to 21.8b0 ([#3308](https://github.com/cookiecutter/cookiecutter-django/pull/3308))
+- Update argon2-cffi to 21.1.0 ([#3306](https://github.com/cookiecutter/cookiecutter-django/pull/3306))
+- Bump peter-evans/create-pull-request from 3.10.0 to 3.10.1 ([#3303](https://github.com/cookiecutter/cookiecutter-django/pull/3303))
+- Update django-debug-toolbar to 3.2.2 ([#3296](https://github.com/cookiecutter/cookiecutter-django/pull/3296))
+- Update django-cors-headers to 3.8.0 ([#3295](https://github.com/cookiecutter/cookiecutter-django/pull/3295))
+- Update uvicorn to 0.15.0 ([#3294](https://github.com/cookiecutter/cookiecutter-django/pull/3294))
 
 ## [2021-08-27]
 ### Updated
-- Update tox to 3.24.3 ([#3302](https://github.com/cookicutter/cookiecutter-django/pull/3302))
+- Update tox to 3.24.3 ([#3302](https://github.com/cookiecutter/cookiecutter-django/pull/3302))
 
 ## [2021-08-20]
 ### Changed
-- Fix Jinja2 break line control on Procfile ([#3300](https://github.com/cookicutter/cookiecutter-django/pull/3300))
+- Fix Jinja2 break line control on Procfile ([#3300](https://github.com/cookiecutter/cookiecutter-django/pull/3300))
 
 ## [2021-08-19]
 ### Changed
-- Fix several minor typos ([#3301](https://github.com/cookicutter/cookiecutter-django/pull/3301))
+- Fix several minor typos ([#3301](https://github.com/cookiecutter/cookiecutter-django/pull/3301))
 
 ## [2021-08-13]
 ### Changed
-- Upgrade to Redis 6 ([#3255](https://github.com/cookicutter/cookiecutter-django/pull/3255))
+- Upgrade to Redis 6 ([#3255](https://github.com/cookiecutter/cookiecutter-django/pull/3255))
 ### Fixed
-- Fix RTD build image to support Python 3.9 ([#3293](https://github.com/cookicutter/cookiecutter-django/pull/3293))
+- Fix RTD build image to support Python 3.9 ([#3293](https://github.com/cookiecutter/cookiecutter-django/pull/3293))
 
 ## [2021-08-12]
 ### Changed
-- Add documentation for automating backups ([#3268](https://github.com/cookicutter/cookiecutter-django/pull/3268))
-- Add missing step to getting started locally in docs ([#3291](https://github.com/cookicutter/cookiecutter-django/pull/3291))
-- Moved isort config from `.editorconfig` to `setup.cfg` ([#3290](https://github.com/cookicutter/cookiecutter-django/pull/3290))
-- How to pre-commit in Docker Development ([#3287](https://github.com/cookicutter/cookiecutter-django/pull/3287))
+- Add documentation for automating backups ([#3268](https://github.com/cookiecutter/cookiecutter-django/pull/3268))
+- Add missing step to getting started locally in docs ([#3291](https://github.com/cookiecutter/cookiecutter-django/pull/3291))
+- Moved isort config from `.editorconfig` to `setup.cfg` ([#3290](https://github.com/cookiecutter/cookiecutter-django/pull/3290))
+- How to pre-commit in Docker Development ([#3287](https://github.com/cookiecutter/cookiecutter-django/pull/3287))
 ### Updated
-- Update sentry-sdk to 1.3.1 ([#3281](https://github.com/cookicutter/cookiecutter-django/pull/3281))
-- Update tox to 3.24.1 ([#3285](https://github.com/cookicutter/cookiecutter-django/pull/3285))
-- Update pre-commit to 2.14.0 ([#3289](https://github.com/cookicutter/cookiecutter-django/pull/3289))
+- Update sentry-sdk to 1.3.1 ([#3281](https://github.com/cookiecutter/cookiecutter-django/pull/3281))
+- Update tox to 3.24.1 ([#3285](https://github.com/cookiecutter/cookiecutter-django/pull/3285))
+- Update pre-commit to 2.14.0 ([#3289](https://github.com/cookiecutter/cookiecutter-django/pull/3289))
 
 ## [2021-07-30]
 ### Updated
-- Auto-update pre-commit hooks ([#3283](https://github.com/cookicutter/cookiecutter-django/pull/3283))
-- Update isort to 5.9.3 ([#3282](https://github.com/cookicutter/cookiecutter-django/pull/3282))
+- Auto-update pre-commit hooks ([#3283](https://github.com/cookiecutter/cookiecutter-django/pull/3283))
+- Update isort to 5.9.3 ([#3282](https://github.com/cookiecutter/cookiecutter-django/pull/3282))
 
 ## [2021-07-27]
 ### Changed
-- Convert trans to translate in templates ([#3277](https://github.com/cookicutter/cookiecutter-django/pull/3277))
+- Convert trans to translate in templates ([#3277](https://github.com/cookiecutter/cookiecutter-django/pull/3277))
 ### Updated
-- Update hiredis to 2.0.0 ([#3110](https://github.com/cookicutter/cookiecutter-django/pull/3110))
-- Update mypy to 0.910 ([#3237](https://github.com/cookicutter/cookiecutter-django/pull/3237))
-- Update whitenoise to 5.3.0 ([#3273](https://github.com/cookicutter/cookiecutter-django/pull/3273))
-- Update tox to 3.24.0 ([#3269](https://github.com/cookicutter/cookiecutter-django/pull/3269))
-- Update django-allauth to 0.45.0 ([#3267](https://github.com/cookicutter/cookiecutter-django/pull/3267))
-- Update sentry-sdk to 1.3.0 ([#3262](https://github.com/cookicutter/cookiecutter-django/pull/3262))
-- Update sphinx to 4.1.2 ([#3278](https://github.com/cookicutter/cookiecutter-django/pull/3278))
-- Auto-update pre-commit hooks ([#3264](https://github.com/cookicutter/cookiecutter-django/pull/3264))
-- Update isort to 5.9.2 ([#3279](https://github.com/cookicutter/cookiecutter-django/pull/3279))
-- Update pillow to 8.3.1 ([#3259](https://github.com/cookicutter/cookiecutter-django/pull/3259))
-- Update black to 21.7b0 ([#3272](https://github.com/cookicutter/cookiecutter-django/pull/3272))
+- Update hiredis to 2.0.0 ([#3110](https://github.com/cookiecutter/cookiecutter-django/pull/3110))
+- Update mypy to 0.910 ([#3237](https://github.com/cookiecutter/cookiecutter-django/pull/3237))
+- Update whitenoise to 5.3.0 ([#3273](https://github.com/cookiecutter/cookiecutter-django/pull/3273))
+- Update tox to 3.24.0 ([#3269](https://github.com/cookiecutter/cookiecutter-django/pull/3269))
+- Update django-allauth to 0.45.0 ([#3267](https://github.com/cookiecutter/cookiecutter-django/pull/3267))
+- Update sentry-sdk to 1.3.0 ([#3262](https://github.com/cookiecutter/cookiecutter-django/pull/3262))
+- Update sphinx to 4.1.2 ([#3278](https://github.com/cookiecutter/cookiecutter-django/pull/3278))
+- Auto-update pre-commit hooks ([#3264](https://github.com/cookiecutter/cookiecutter-django/pull/3264))
+- Update isort to 5.9.2 ([#3279](https://github.com/cookiecutter/cookiecutter-django/pull/3279))
+- Update pillow to 8.3.1 ([#3259](https://github.com/cookiecutter/cookiecutter-django/pull/3259))
+- Update black to 21.7b0 ([#3272](https://github.com/cookiecutter/cookiecutter-django/pull/3272))
 
 ## [2021-07-12]
 ### Changed
-- Define REMAP_SIGTERM=SIGQUIT on Profile of Celery on Heroku ([#3263](https://github.com/cookicutter/cookiecutter-django/pull/3263))
+- Define REMAP_SIGTERM=SIGQUIT on Profile of Celery on Heroku ([#3263](https://github.com/cookiecutter/cookiecutter-django/pull/3263))
 
 ## [2021-07-08]
 ### Updated
-- Update django to 3.1.13 ([#3247](https://github.com/cookicutter/cookiecutter-django/pull/3247))
+- Update django to 3.1.13 ([#3247](https://github.com/cookiecutter/cookiecutter-django/pull/3247))
 
 ## [2021-06-29]
 ### Changed
-- Improve github bug report template ([#3243](https://github.com/cookicutter/cookiecutter-django/pull/3243))
+- Improve github bug report template ([#3243](https://github.com/cookiecutter/cookiecutter-django/pull/3243))
 
 ## [2021-06-28]
 ### Changed
-- Revert &#34;Fix Celery ports error on local Docker&#34; ([#3242](https://github.com/cookicutter/cookiecutter-django/pull/3242))
+- Revert &#34;Fix Celery ports error on local Docker&#34; ([#3242](https://github.com/cookiecutter/cookiecutter-django/pull/3242))
 ### Fixed
-- Fix Celery ports error on local Docker ([#3241](https://github.com/cookicutter/cookiecutter-django/pull/3241))
+- Fix Celery ports error on local Docker ([#3241](https://github.com/cookiecutter/cookiecutter-django/pull/3241))
 
 ## [2021-06-25]
 ### Changed
-- Update `.gitignore` file for VSCode ([#3238](https://github.com/cookicutter/cookiecutter-django/pull/3238))
+- Update `.gitignore` file for VSCode ([#3238](https://github.com/cookiecutter/cookiecutter-django/pull/3238))
 ### Fixed
-- Wrap jQuery call in `DOMContentLoaded` event listener on account email page ([#3239](https://github.com/cookicutter/cookiecutter-django/pull/3239))
+- Wrap jQuery call in `DOMContentLoaded` event listener on account email page ([#3239](https://github.com/cookiecutter/cookiecutter-django/pull/3239))
 
 ## [2021-06-22]
 ### Changed
-- Update docs/howto.rst ([#3230](https://github.com/cookicutter/cookiecutter-django/pull/3230))
-- Add support for PG 13. Drop PG 9. Update all minor versions ([#3154](https://github.com/cookicutter/cookiecutter-django/pull/3154))
+- Update docs/howto.rst ([#3230](https://github.com/cookiecutter/cookiecutter-django/pull/3230))
+- Add support for PG 13. Drop PG 9. Update all minor versions ([#3154](https://github.com/cookiecutter/cookiecutter-django/pull/3154))
 ### Updated
-- Update isort to 5.9.1 ([#3236](https://github.com/cookicutter/cookiecutter-django/pull/3236))
-- Auto-update pre-commit hooks ([#3235](https://github.com/cookicutter/cookiecutter-django/pull/3235))
+- Update isort to 5.9.1 ([#3236](https://github.com/cookiecutter/cookiecutter-django/pull/3236))
+- Auto-update pre-commit hooks ([#3235](https://github.com/cookiecutter/cookiecutter-django/pull/3235))
 
 ## [2021-06-21]
 ### Updated
-- Update isort to 5.9.0 ([#3234](https://github.com/cookicutter/cookiecutter-django/pull/3234))
-- Update django-anymail to 8.4 ([#3225](https://github.com/cookicutter/cookiecutter-django/pull/3225))
-- Update django-redis to 5.0.0 ([#3205](https://github.com/cookicutter/cookiecutter-django/pull/3205))
-- Update pylint-django to 2.4.4 ([#3233](https://github.com/cookicutter/cookiecutter-django/pull/3233))
-- Auto-update pre-commit hooks ([#3220](https://github.com/cookicutter/cookiecutter-django/pull/3220))
-- Bump peter-evans/create-pull-request from 3.9.2 to 3.10.0 ([#3197](https://github.com/cookicutter/cookiecutter-django/pull/3197))
-- Update black to 21.6b0 ([#3232](https://github.com/cookicutter/cookiecutter-django/pull/3232))
-- Update pytest to 6.2.4 ([#3231](https://github.com/cookicutter/cookiecutter-django/pull/3231))
-- Update django-crispy-forms to 1.12.0 ([#3221](https://github.com/cookicutter/cookiecutter-django/pull/3221))
-- Update mypy to 0.902 ([#3219](https://github.com/cookicutter/cookiecutter-django/pull/3219))
-- Update django-coverage-plugin to 2.0.0 ([#3217](https://github.com/cookicutter/cookiecutter-django/pull/3217))
-- Update ipdb to 0.13.9 ([#3210](https://github.com/cookicutter/cookiecutter-django/pull/3210))
-- Update uvicorn to 0.14.0 ([#3207](https://github.com/cookicutter/cookiecutter-django/pull/3207))
-- Update pytest-cookies to 0.6.1 ([#3196](https://github.com/cookicutter/cookiecutter-django/pull/3196))
-- Update sphinx to 4.0.2 ([#3193](https://github.com/cookicutter/cookiecutter-django/pull/3193))
-- Update jinja2 to 3.0.1 ([#3189](https://github.com/cookicutter/cookiecutter-django/pull/3189))
+- Update isort to 5.9.0 ([#3234](https://github.com/cookiecutter/cookiecutter-django/pull/3234))
+- Update django-anymail to 8.4 ([#3225](https://github.com/cookiecutter/cookiecutter-django/pull/3225))
+- Update django-redis to 5.0.0 ([#3205](https://github.com/cookiecutter/cookiecutter-django/pull/3205))
+- Update pylint-django to 2.4.4 ([#3233](https://github.com/cookiecutter/cookiecutter-django/pull/3233))
+- Auto-update pre-commit hooks ([#3220](https://github.com/cookiecutter/cookiecutter-django/pull/3220))
+- Bump peter-evans/create-pull-request from 3.9.2 to 3.10.0 ([#3197](https://github.com/cookiecutter/cookiecutter-django/pull/3197))
+- Update black to 21.6b0 ([#3232](https://github.com/cookiecutter/cookiecutter-django/pull/3232))
+- Update pytest to 6.2.4 ([#3231](https://github.com/cookiecutter/cookiecutter-django/pull/3231))
+- Update django-crispy-forms to 1.12.0 ([#3221](https://github.com/cookiecutter/cookiecutter-django/pull/3221))
+- Update mypy to 0.902 ([#3219](https://github.com/cookiecutter/cookiecutter-django/pull/3219))
+- Update django-coverage-plugin to 2.0.0 ([#3217](https://github.com/cookiecutter/cookiecutter-django/pull/3217))
+- Update ipdb to 0.13.9 ([#3210](https://github.com/cookiecutter/cookiecutter-django/pull/3210))
+- Update uvicorn to 0.14.0 ([#3207](https://github.com/cookiecutter/cookiecutter-django/pull/3207))
+- Update pytest-cookies to 0.6.1 ([#3196](https://github.com/cookiecutter/cookiecutter-django/pull/3196))
+- Update sphinx to 4.0.2 ([#3193](https://github.com/cookiecutter/cookiecutter-django/pull/3193))
+- Update jinja2 to 3.0.1 ([#3189](https://github.com/cookiecutter/cookiecutter-django/pull/3189))
 
 ## [2021-06-19]
 ### Updated
-- Update psycopg2 to 2.9.1 ([#3227](https://github.com/cookicutter/cookiecutter-django/pull/3227))
-- Update psycopg2-binary to 2.9.1 ([#3228](https://github.com/cookicutter/cookiecutter-django/pull/3228))
+- Update psycopg2 to 2.9.1 ([#3227](https://github.com/cookiecutter/cookiecutter-django/pull/3227))
+- Update psycopg2-binary to 2.9.1 ([#3228](https://github.com/cookiecutter/cookiecutter-django/pull/3228))
 
 ## [2021-06-14]
 ### Changed
-- Update black GitHub link in requirements ([#3222](https://github.com/cookicutter/cookiecutter-django/pull/3222))
+- Update black GitHub link in requirements ([#3222](https://github.com/cookiecutter/cookiecutter-django/pull/3222))
 
 ## [2021-06-09]
 ### Changed
-- Fix link format in developing-locally.rst ([#3214](https://github.com/cookicutter/cookiecutter-django/pull/3214))
+- Fix link format in developing-locally.rst ([#3214](https://github.com/cookiecutter/cookiecutter-django/pull/3214))
 ### Updated
-- Update pre-commit to 2.13.0 ([#3195](https://github.com/cookicutter/cookiecutter-django/pull/3195))
-- Update pytest-django to 4.4.0 ([#3212](https://github.com/cookicutter/cookiecutter-django/pull/3212))
-- Update mypy to 0.901 ([#3215](https://github.com/cookicutter/cookiecutter-django/pull/3215))
-- Auto-update pre-commit hooks ([#3206](https://github.com/cookicutter/cookiecutter-django/pull/3206))
-- Update black to 21.5b2 ([#3204](https://github.com/cookicutter/cookiecutter-django/pull/3204))
+- Update pre-commit to 2.13.0 ([#3195](https://github.com/cookiecutter/cookiecutter-django/pull/3195))
+- Update pytest-django to 4.4.0 ([#3212](https://github.com/cookiecutter/cookiecutter-django/pull/3212))
+- Update mypy to 0.901 ([#3215](https://github.com/cookiecutter/cookiecutter-django/pull/3215))
+- Auto-update pre-commit hooks ([#3206](https://github.com/cookiecutter/cookiecutter-django/pull/3206))
+- Update black to 21.5b2 ([#3204](https://github.com/cookiecutter/cookiecutter-django/pull/3204))
 
 ## [2021-06-06]
 ### Changed
-- Updated .pre-commit-config.yaml to self-update its dependencies ([#3208](https://github.com/cookicutter/cookiecutter-django/pull/3208))
+- Updated .pre-commit-config.yaml to self-update its dependencies ([#3208](https://github.com/cookiecutter/cookiecutter-django/pull/3208))
 
 ## [2021-06-05]
 ### Changed
-- Shorthand for the officially supported buildpack ([#3211](https://github.com/cookicutter/cookiecutter-django/pull/3211))
+- Shorthand for the officially supported buildpack ([#3211](https://github.com/cookiecutter/cookiecutter-django/pull/3211))
 
 ## [2021-06-02]
 ### Updated
-- Update django to 3.1.12 ([#3209](https://github.com/cookicutter/cookiecutter-django/pull/3209))
+- Update django to 3.1.12 ([#3209](https://github.com/cookiecutter/cookiecutter-django/pull/3209))
 
 ## [2021-05-18]
 ### Changed
-- Move ARG PYTHON_VERSION=3.9-slim-buster to the global scope ([#3188](https://github.com/cookicutter/cookiecutter-django/pull/3188))
+- Move ARG PYTHON_VERSION=3.9-slim-buster to the global scope ([#3188](https://github.com/cookiecutter/cookiecutter-django/pull/3188))
 
 ## [2021-05-17]
 ### Updated
-- Bump tiangolo/issue-manager from 0.3.0 to 0.4.0 ([#3186](https://github.com/cookicutter/cookiecutter-django/pull/3186))
-- Auto-update pre-commit hooks ([#3185](https://github.com/cookicutter/cookiecutter-django/pull/3185))
+- Bump tiangolo/issue-manager from 0.3.0 to 0.4.0 ([#3186](https://github.com/cookiecutter/cookiecutter-django/pull/3186))
+- Auto-update pre-commit hooks ([#3185](https://github.com/cookiecutter/cookiecutter-django/pull/3185))
 
 ## [2021-05-15]
 ### Changed
-- Update watchgod to 0.7 ([#3177](https://github.com/cookicutter/cookiecutter-django/pull/3177))
+- Update watchgod to 0.7 ([#3177](https://github.com/cookiecutter/cookiecutter-django/pull/3177))
 ### Updated
-- Auto-update pre-commit hooks ([#3184](https://github.com/cookicutter/cookiecutter-django/pull/3184))
-- Update black to 21.5b1 ([#3167](https://github.com/cookicutter/cookiecutter-django/pull/3167))
-- Update flake8 to 3.9.2 ([#3164](https://github.com/cookicutter/cookiecutter-django/pull/3164))
-- Update pytest-django to 4.3.0 ([#3182](https://github.com/cookicutter/cookiecutter-django/pull/3182))
-- Auto-update pre-commit hooks ([#3157](https://github.com/cookicutter/cookiecutter-django/pull/3157))
-- Update python-slugify to 5.0.2 ([#3161](https://github.com/cookicutter/cookiecutter-django/pull/3161))
-- Bump stefanzweifel/git-auto-commit-action from 4.10.0 to 4.11.0 ([#3171](https://github.com/cookicutter/cookiecutter-django/pull/3171))
-- Update sentry-sdk to 1.1.0 ([#3163](https://github.com/cookicutter/cookiecutter-django/pull/3163))
-- Bump actions/setup-python from 2 to 2.2.2 ([#3173](https://github.com/cookicutter/cookiecutter-django/pull/3173))
-- Update tox to 3.23.1 ([#3160](https://github.com/cookicutter/cookiecutter-django/pull/3160))
-- Update pytest to 6.2.4 ([#3156](https://github.com/cookicutter/cookiecutter-django/pull/3156))
-- Bump peter-evans/create-pull-request from 3.8.2 to 3.9.2 ([#3179](https://github.com/cookicutter/cookiecutter-django/pull/3179))
-- Update sphinx to 4.0.1 ([#3169](https://github.com/cookicutter/cookiecutter-django/pull/3169))
-- Update cookiecutter to 1.7.3 ([#3180](https://github.com/cookicutter/cookiecutter-django/pull/3180))
-- Update django to 3.1.11 ([#3178](https://github.com/cookicutter/cookiecutter-django/pull/3178))
+- Auto-update pre-commit hooks ([#3184](https://github.com/cookiecutter/cookiecutter-django/pull/3184))
+- Update black to 21.5b1 ([#3167](https://github.com/cookiecutter/cookiecutter-django/pull/3167))
+- Update flake8 to 3.9.2 ([#3164](https://github.com/cookiecutter/cookiecutter-django/pull/3164))
+- Update pytest-django to 4.3.0 ([#3182](https://github.com/cookiecutter/cookiecutter-django/pull/3182))
+- Auto-update pre-commit hooks ([#3157](https://github.com/cookiecutter/cookiecutter-django/pull/3157))
+- Update python-slugify to 5.0.2 ([#3161](https://github.com/cookiecutter/cookiecutter-django/pull/3161))
+- Bump stefanzweifel/git-auto-commit-action from 4.10.0 to 4.11.0 ([#3171](https://github.com/cookiecutter/cookiecutter-django/pull/3171))
+- Update sentry-sdk to 1.1.0 ([#3163](https://github.com/cookiecutter/cookiecutter-django/pull/3163))
+- Bump actions/setup-python from 2 to 2.2.2 ([#3173](https://github.com/cookiecutter/cookiecutter-django/pull/3173))
+- Update tox to 3.23.1 ([#3160](https://github.com/cookiecutter/cookiecutter-django/pull/3160))
+- Update pytest to 6.2.4 ([#3156](https://github.com/cookiecutter/cookiecutter-django/pull/3156))
+- Bump peter-evans/create-pull-request from 3.8.2 to 3.9.2 ([#3179](https://github.com/cookiecutter/cookiecutter-django/pull/3179))
+- Update sphinx to 4.0.1 ([#3169](https://github.com/cookiecutter/cookiecutter-django/pull/3169))
+- Update cookiecutter to 1.7.3 ([#3180](https://github.com/cookiecutter/cookiecutter-django/pull/3180))
+- Update django to 3.1.11 ([#3178](https://github.com/cookiecutter/cookiecutter-django/pull/3178))
 
 ## [2021-05-06]
 ### Updated
-- Update django to 3.1.10 ([#3162](https://github.com/cookicutter/cookiecutter-django/pull/3162))
+- Update django to 3.1.10 ([#3162](https://github.com/cookiecutter/cookiecutter-django/pull/3162))
 
 ## [2021-05-04]
 ### Updated
-- Update django to 3.1.9 ([#3155](https://github.com/cookicutter/cookiecutter-django/pull/3155))
+- Update django to 3.1.9 ([#3155](https://github.com/cookiecutter/cookiecutter-django/pull/3155))
 
 ## [2021-04-30]
 ### Fixed
-- Fix linting error in production.py ([#3148](https://github.com/cookicutter/cookiecutter-django/pull/3148))
+- Fix linting error in production.py ([#3148](https://github.com/cookiecutter/cookiecutter-django/pull/3148))
 
 ## [2021-04-29]
 ### Updated
-- Update black to 21.4b2 ([#3147](https://github.com/cookicutter/cookiecutter-django/pull/3147))
-- Auto-update pre-commit hooks ([#3146](https://github.com/cookicutter/cookiecutter-django/pull/3146))
+- Update black to 21.4b2 ([#3147](https://github.com/cookiecutter/cookiecutter-django/pull/3147))
+- Auto-update pre-commit hooks ([#3146](https://github.com/cookiecutter/cookiecutter-django/pull/3146))
 
 ## [2021-04-28]
 ### Changed
-- Fix README link ([#3144](https://github.com/cookicutter/cookiecutter-django/pull/3144))
+- Fix README link ([#3144](https://github.com/cookiecutter/cookiecutter-django/pull/3144))
 ### Updated
-- Auto-update pre-commit hooks ([#3145](https://github.com/cookicutter/cookiecutter-django/pull/3145))
+- Auto-update pre-commit hooks ([#3145](https://github.com/cookiecutter/cookiecutter-django/pull/3145))
 
 ## [2021-04-27]
 ### Updated
-- Update pygithub to 1.55 ([#3141](https://github.com/cookicutter/cookiecutter-django/pull/3141))
-- Update black to 21.4b1 ([#3143](https://github.com/cookicutter/cookiecutter-django/pull/3143))
+- Update pygithub to 1.55 ([#3141](https://github.com/cookiecutter/cookiecutter-django/pull/3141))
+- Update black to 21.4b1 ([#3143](https://github.com/cookiecutter/cookiecutter-django/pull/3143))
 
 ## [2021-04-26]
 ### Updated
-- Update black to 21.4b0 ([#3138](https://github.com/cookicutter/cookiecutter-django/pull/3138))
-- Auto-update pre-commit hooks ([#3137](https://github.com/cookicutter/cookiecutter-django/pull/3137))
+- Update black to 21.4b0 ([#3138](https://github.com/cookiecutter/cookiecutter-django/pull/3138))
+- Auto-update pre-commit hooks ([#3137](https://github.com/cookiecutter/cookiecutter-django/pull/3137))
 
 ## [2021-04-21]
 ### Updated
-- Auto-update pre-commit hooks ([#3133](https://github.com/cookicutter/cookiecutter-django/pull/3133))
-- Update django-extensions to 3.1.3 ([#3136](https://github.com/cookicutter/cookiecutter-django/pull/3136))
-- Update django-compressor to 2.4.1 ([#3135](https://github.com/cookicutter/cookiecutter-django/pull/3135))
-- Update pre-commit to 2.12.1 ([#3134](https://github.com/cookicutter/cookiecutter-django/pull/3134))
-- Update flake8 to 3.9.1 ([#3131](https://github.com/cookicutter/cookiecutter-django/pull/3131))
-- Update django-stubs to 1.8.0 ([#3127](https://github.com/cookicutter/cookiecutter-django/pull/3127))
-- Update sphinx to 3.5.4 ([#3126](https://github.com/cookicutter/cookiecutter-django/pull/3126))
+- Auto-update pre-commit hooks ([#3133](https://github.com/cookiecutter/cookiecutter-django/pull/3133))
+- Update django-extensions to 3.1.3 ([#3136](https://github.com/cookiecutter/cookiecutter-django/pull/3136))
+- Update django-compressor to 2.4.1 ([#3135](https://github.com/cookiecutter/cookiecutter-django/pull/3135))
+- Update pre-commit to 2.12.1 ([#3134](https://github.com/cookiecutter/cookiecutter-django/pull/3134))
+- Update flake8 to 3.9.1 ([#3131](https://github.com/cookiecutter/cookiecutter-django/pull/3131))
+- Update django-stubs to 1.8.0 ([#3127](https://github.com/cookiecutter/cookiecutter-django/pull/3127))
+- Update sphinx to 3.5.4 ([#3126](https://github.com/cookiecutter/cookiecutter-django/pull/3126))
 
 ## [2021-04-15]
 ### Updated
-- Update django-debug-toolbar to 3.2.1 ([#3129](https://github.com/cookicutter/cookiecutter-django/pull/3129))
+- Update django-debug-toolbar to 3.2.1 ([#3129](https://github.com/cookiecutter/cookiecutter-django/pull/3129))
 
 ## [2021-04-14]
 ### Updated
-- Bump stefanzweifel/git-auto-commit-action from v4.9.2 to v4.10.0 ([#3128](https://github.com/cookicutter/cookiecutter-django/pull/3128))
+- Bump stefanzweifel/git-auto-commit-action from v4.9.2 to v4.10.0 ([#3128](https://github.com/cookiecutter/cookiecutter-django/pull/3128))
 
 ## [2021-04-11]
 ### Updated
-- Update pytest-django to 4.2.0 ([#3125](https://github.com/cookicutter/cookiecutter-django/pull/3125))
-- Update pylint-django to 2.4.3 ([#3122](https://github.com/cookicutter/cookiecutter-django/pull/3122))
+- Update pytest-django to 4.2.0 ([#3125](https://github.com/cookiecutter/cookiecutter-django/pull/3125))
+- Update pylint-django to 2.4.3 ([#3122](https://github.com/cookiecutter/cookiecutter-django/pull/3122))
 
 ## [2021-04-09]
 ### Changed
-- Update from Python 3.8 to Python 3.9 ([#3023](https://github.com/cookicutter/cookiecutter-django/pull/3023))
+- Update from Python 3.8 to Python 3.9 ([#3023](https://github.com/cookiecutter/cookiecutter-django/pull/3023))
 
 ## [2021-04-08]
 ### Changed
-- Switch .dockerignore to explicit list ([#3121](https://github.com/cookicutter/cookiecutter-django/pull/3121))
-- Change Docker image to multi-stage build for Django ([#2815](https://github.com/cookicutter/cookiecutter-django/pull/2815))
-- Fix deprecated warning in middleware tests ([#3038](https://github.com/cookicutter/cookiecutter-django/pull/3038))
+- Switch .dockerignore to explicit list ([#3121](https://github.com/cookiecutter/cookiecutter-django/pull/3121))
+- Change Docker image to multi-stage build for Django ([#2815](https://github.com/cookiecutter/cookiecutter-django/pull/2815))
+- Fix deprecated warning in middleware tests ([#3038](https://github.com/cookiecutter/cookiecutter-django/pull/3038))
 ### Updated
-- Update pre-commit to 2.12.0 ([#3120](https://github.com/cookicutter/cookiecutter-django/pull/3120))
+- Update pre-commit to 2.12.0 ([#3120](https://github.com/cookiecutter/cookiecutter-django/pull/3120))
 
 ## [2021-04-07]
 ### Changed
-- Update django to 3.1.8 ([#3117](https://github.com/cookicutter/cookiecutter-django/pull/3117))
+- Update django to 3.1.8 ([#3117](https://github.com/cookiecutter/cookiecutter-django/pull/3117))
 ### Fixed
-- Fix linting via pre-commit on Github CI ([#3077](https://github.com/cookicutter/cookiecutter-django/pull/3077))
-- Fix gitlab-ci using duplicate key name for image ([#3112](https://github.com/cookicutter/cookiecutter-django/pull/3112))
+- Fix linting via pre-commit on Github CI ([#3077](https://github.com/cookiecutter/cookiecutter-django/pull/3077))
+- Fix gitlab-ci using duplicate key name for image ([#3112](https://github.com/cookiecutter/cookiecutter-django/pull/3112))
 ### Updated
-- Update sentry-sdk to 1.0.0 ([#3080](https://github.com/cookicutter/cookiecutter-django/pull/3080))
-- Update gunicorn to 20.1.0 ([#3108](https://github.com/cookicutter/cookiecutter-django/pull/3108))
-- Update pre-commit to 2.12.0 ([#3118](https://github.com/cookicutter/cookiecutter-django/pull/3118))
-- Update django-extensions to 3.1.2 ([#3116](https://github.com/cookicutter/cookiecutter-django/pull/3116))
-- Update pillow to 8.2.0 ([#3113](https://github.com/cookicutter/cookiecutter-django/pull/3113))
-- Update pytest to 6.2.3 ([#3115](https://github.com/cookicutter/cookiecutter-django/pull/3115))
+- Update sentry-sdk to 1.0.0 ([#3080](https://github.com/cookiecutter/cookiecutter-django/pull/3080))
+- Update gunicorn to 20.1.0 ([#3108](https://github.com/cookiecutter/cookiecutter-django/pull/3108))
+- Update pre-commit to 2.12.0 ([#3118](https://github.com/cookiecutter/cookiecutter-django/pull/3118))
+- Update django-extensions to 3.1.2 ([#3116](https://github.com/cookiecutter/cookiecutter-django/pull/3116))
+- Update pillow to 8.2.0 ([#3113](https://github.com/cookiecutter/cookiecutter-django/pull/3113))
+- Update pytest to 6.2.3 ([#3115](https://github.com/cookiecutter/cookiecutter-django/pull/3115))
 
 ## [2021-03-26]
 ### Updated
-- Update djangorestframework to 3.12.4 ([#3107](https://github.com/cookicutter/cookiecutter-django/pull/3107))
+- Update djangorestframework to 3.12.4 ([#3107](https://github.com/cookiecutter/cookiecutter-django/pull/3107))
 
 ## [2021-03-25]
 ### Updated
-- Update djangorestframework to 3.12.3 ([#3105](https://github.com/cookicutter/cookiecutter-django/pull/3105))
+- Update djangorestframework to 3.12.3 ([#3105](https://github.com/cookiecutter/cookiecutter-django/pull/3105))
 
 ## [2021-03-22]
 ### Updated
-- Update django-crispy-forms to 1.11.2 ([#3104](https://github.com/cookicutter/cookiecutter-django/pull/3104))
-- Update sphinx to 3.5.3 ([#3103](https://github.com/cookicutter/cookiecutter-django/pull/3103))
-- Update ipdb to 0.13.7 ([#3102](https://github.com/cookicutter/cookiecutter-django/pull/3102))
-- Update sphinx-autobuild to 2021.3.14 ([#3101](https://github.com/cookicutter/cookiecutter-django/pull/3101))
-- Update isort to 5.8.0 ([#3100](https://github.com/cookicutter/cookiecutter-django/pull/3100))
-- Update pre-commit to 2.11.1 ([#3089](https://github.com/cookicutter/cookiecutter-django/pull/3089))
-- Update flake8 to 3.9.0 ([#3096](https://github.com/cookicutter/cookiecutter-django/pull/3096))
-- Update pillow to 8.1.2 ([#3084](https://github.com/cookicutter/cookiecutter-django/pull/3084))
-- Auto-update pre-commit hooks ([#3095](https://github.com/cookicutter/cookiecutter-django/pull/3095))
+- Update django-crispy-forms to 1.11.2 ([#3104](https://github.com/cookiecutter/cookiecutter-django/pull/3104))
+- Update sphinx to 3.5.3 ([#3103](https://github.com/cookiecutter/cookiecutter-django/pull/3103))
+- Update ipdb to 0.13.7 ([#3102](https://github.com/cookiecutter/cookiecutter-django/pull/3102))
+- Update sphinx-autobuild to 2021.3.14 ([#3101](https://github.com/cookiecutter/cookiecutter-django/pull/3101))
+- Update isort to 5.8.0 ([#3100](https://github.com/cookiecutter/cookiecutter-django/pull/3100))
+- Update pre-commit to 2.11.1 ([#3089](https://github.com/cookiecutter/cookiecutter-django/pull/3089))
+- Update flake8 to 3.9.0 ([#3096](https://github.com/cookiecutter/cookiecutter-django/pull/3096))
+- Update pillow to 8.1.2 ([#3084](https://github.com/cookiecutter/cookiecutter-django/pull/3084))
+- Auto-update pre-commit hooks ([#3095](https://github.com/cookiecutter/cookiecutter-django/pull/3095))
 
 ## [2021-03-05]
 ### Changed
-- Updated test_urls.py and views.py to re-use User.get_absolute_url() ([#3070](https://github.com/cookicutter/cookiecutter-django/pull/3070))
+- Updated test_urls.py and views.py to re-use User.get_absolute_url() ([#3070](https://github.com/cookiecutter/cookiecutter-django/pull/3070))
 ### Updated
-- Bump stefanzweifel/git-auto-commit-action from v4.9.1 to v4.9.2 ([#3082](https://github.com/cookicutter/cookiecutter-django/pull/3082))
+- Bump stefanzweifel/git-auto-commit-action from v4.9.1 to v4.9.2 ([#3082](https://github.com/cookiecutter/cookiecutter-django/pull/3082))
 
 ## [2021-03-03]
 ### Updated
-- Update tox to 3.23.0 ([#3079](https://github.com/cookicutter/cookiecutter-django/pull/3079))
-- Update ipdb to 0.13.5 ([#3078](https://github.com/cookicutter/cookiecutter-django/pull/3078))
+- Update tox to 3.23.0 ([#3079](https://github.com/cookiecutter/cookiecutter-django/pull/3079))
+- Update ipdb to 0.13.5 ([#3078](https://github.com/cookiecutter/cookiecutter-django/pull/3078))
 
 ## [2021-03-02]
 ### Fixed
-- Fixes for pytest job in Github CI workflow ([#3076](https://github.com/cookicutter/cookiecutter-django/pull/3076))
+- Fixes for pytest job in Github CI workflow ([#3076](https://github.com/cookiecutter/cookiecutter-django/pull/3076))
 ### Updated
-- Update pillow to 8.1.1 ([#3075](https://github.com/cookicutter/cookiecutter-django/pull/3075))
-- Update coverage to 5.5 ([#3074](https://github.com/cookicutter/cookiecutter-django/pull/3074))
+- Update pillow to 8.1.1 ([#3075](https://github.com/cookiecutter/cookiecutter-django/pull/3075))
+- Update coverage to 5.5 ([#3074](https://github.com/cookiecutter/cookiecutter-django/pull/3074))
 
 ## [2021-02-24]
 ### Updated
-- Bump stefanzweifel/git-auto-commit-action from v4.9.0 to v4.9.1 ([#3069](https://github.com/cookicutter/cookiecutter-django/pull/3069))
+- Bump stefanzweifel/git-auto-commit-action from v4.9.0 to v4.9.1 ([#3069](https://github.com/cookiecutter/cookiecutter-django/pull/3069))
 
 ## [2021-02-23]
 ### Changed
-- Update to Django 3.1 ([#3043](https://github.com/cookicutter/cookiecutter-django/pull/3043))
-- Lint with pre-commit on CI with Github actions ([#3066](https://github.com/cookicutter/cookiecutter-django/pull/3066))
-- Use exception var in status code pages if available ([#2992](https://github.com/cookicutter/cookiecutter-django/pull/2992))
+- Update to Django 3.1 ([#3043](https://github.com/cookiecutter/cookiecutter-django/pull/3043))
+- Lint with pre-commit on CI with Github actions ([#3066](https://github.com/cookiecutter/cookiecutter-django/pull/3066))
+- Use exception var in status code pages if available ([#2992](https://github.com/cookiecutter/cookiecutter-django/pull/2992))
 
 ## [2021-02-22]
 ### Changed
-- refactor: remove default cache settings in test.py ([#3064](https://github.com/cookicutter/cookiecutter-django/pull/3064))
-- Update django to 3.0.13 ([#3060](https://github.com/cookicutter/cookiecutter-django/pull/3060))
+- refactor: remove default cache settings in test.py ([#3064](https://github.com/cookiecutter/cookiecutter-django/pull/3064))
+- Update django to 3.0.13 ([#3060](https://github.com/cookiecutter/cookiecutter-django/pull/3060))
 ### Fixed
-- Fix missing Django Debug toolbar with node container ([#2865](https://github.com/cookicutter/cookiecutter-django/pull/2865))
-- Remove Email from User API ([#3055](https://github.com/cookicutter/cookiecutter-django/pull/3055))
+- Fix missing Django Debug toolbar with node container ([#2865](https://github.com/cookiecutter/cookiecutter-django/pull/2865))
+- Remove Email from User API ([#3055](https://github.com/cookiecutter/cookiecutter-django/pull/3055))
 ### Updated
-- Bump stefanzweifel/git-auto-commit-action from v4.8.0 to v4.9.0 ([#3065](https://github.com/cookicutter/cookiecutter-django/pull/3065))
-- Update django-crispy-forms to 1.11.1 ([#3063](https://github.com/cookicutter/cookiecutter-django/pull/3063))
-- Update uvicorn to 0.13.4 ([#3062](https://github.com/cookicutter/cookiecutter-django/pull/3062))
-- Update mypy to 0.812 ([#3061](https://github.com/cookicutter/cookiecutter-django/pull/3061))
-- Update sentry-sdk to 0.20.3 ([#3059](https://github.com/cookicutter/cookiecutter-django/pull/3059))
-- Update tox to 3.22.0 ([#3057](https://github.com/cookicutter/cookiecutter-django/pull/3057))
-- Update sphinx to 3.5.1 ([#3056](https://github.com/cookicutter/cookiecutter-django/pull/3056))
+- Bump stefanzweifel/git-auto-commit-action from v4.8.0 to v4.9.0 ([#3065](https://github.com/cookiecutter/cookiecutter-django/pull/3065))
+- Update django-crispy-forms to 1.11.1 ([#3063](https://github.com/cookiecutter/cookiecutter-django/pull/3063))
+- Update uvicorn to 0.13.4 ([#3062](https://github.com/cookiecutter/cookiecutter-django/pull/3062))
+- Update mypy to 0.812 ([#3061](https://github.com/cookiecutter/cookiecutter-django/pull/3061))
+- Update sentry-sdk to 0.20.3 ([#3059](https://github.com/cookiecutter/cookiecutter-django/pull/3059))
+- Update tox to 3.22.0 ([#3057](https://github.com/cookiecutter/cookiecutter-django/pull/3057))
+- Update sphinx to 3.5.1 ([#3056](https://github.com/cookiecutter/cookiecutter-django/pull/3056))
 
 ## [2021-02-16]
 ### Updated
-- Update sentry-sdk to 0.20.2 ([#3054](https://github.com/cookicutter/cookiecutter-django/pull/3054))
-- Update sphinx to 3.5.0 ([#3053](https://github.com/cookicutter/cookiecutter-django/pull/3053))
+- Update sentry-sdk to 0.20.2 ([#3054](https://github.com/cookiecutter/cookiecutter-django/pull/3054))
+- Update sphinx to 3.5.0 ([#3053](https://github.com/cookiecutter/cookiecutter-django/pull/3053))
 
 ## [2021-02-13]
 ### Updated
-- Update sentry-sdk to 0.20.1 ([#3052](https://github.com/cookicutter/cookiecutter-django/pull/3052))
+- Update sentry-sdk to 0.20.1 ([#3052](https://github.com/cookiecutter/cookiecutter-django/pull/3052))
 
 ## [2021-02-12]
 ### Updated
-- Update pre-commit to 2.10.1 ([#3045](https://github.com/cookicutter/cookiecutter-django/pull/3045))
-- Update sentry-sdk to 0.20.0 ([#3051](https://github.com/cookicutter/cookiecutter-django/pull/3051))
+- Update pre-commit to 2.10.1 ([#3045](https://github.com/cookiecutter/cookiecutter-django/pull/3045))
+- Update sentry-sdk to 0.20.0 ([#3051](https://github.com/cookiecutter/cookiecutter-django/pull/3051))
 
 ## [2021-02-10]
 ### Updated
-- Bump peter-evans/create-pull-request from v3.8.1 to v3.8.2 ([#3049](https://github.com/cookicutter/cookiecutter-django/pull/3049))
+- Bump peter-evans/create-pull-request from v3.8.1 to v3.8.2 ([#3049](https://github.com/cookiecutter/cookiecutter-django/pull/3049))
 
 ## [2021-02-08]
 ### Updated
-- Update django-extensions to 3.1.1 ([#3047](https://github.com/cookicutter/cookiecutter-django/pull/3047))
-- Bump peter-evans/create-pull-request from v3.8.0 to v3.8.1 ([#3046](https://github.com/cookicutter/cookiecutter-django/pull/3046))
+- Update django-extensions to 3.1.1 ([#3047](https://github.com/cookiecutter/cookiecutter-django/pull/3047))
+- Bump peter-evans/create-pull-request from v3.8.0 to v3.8.1 ([#3046](https://github.com/cookiecutter/cookiecutter-django/pull/3046))
 
 ## [2021-02-06]
 ### Changed
-- Removed Redundant test_case_sensitivity() and made test_not_authenticated() get the LOGIN_URL dynamically. ([#3041](https://github.com/cookicutter/cookiecutter-django/pull/3041))
-- Refactored users.forms to make the code more readeable ([#3029](https://github.com/cookicutter/cookiecutter-django/pull/3029))
-- Update django to 3.0.12 ([#3037](https://github.com/cookicutter/cookiecutter-django/pull/3037))
+- Removed Redundant test_case_sensitivity() and made test_not_authenticated() get the LOGIN_URL dynamically. ([#3041](https://github.com/cookiecutter/cookiecutter-django/pull/3041))
+- Refactored users.forms to make the code more readeable ([#3029](https://github.com/cookiecutter/cookiecutter-django/pull/3029))
+- Update django to 3.0.12 ([#3037](https://github.com/cookiecutter/cookiecutter-django/pull/3037))
 ### Updated
-- Update tox to 3.21.4 ([#3044](https://github.com/cookicutter/cookiecutter-django/pull/3044))
+- Update tox to 3.21.4 ([#3044](https://github.com/cookiecutter/cookiecutter-django/pull/3044))
 
 ## [2021-02-01]
 ### Updated
-- Update pytz to 2021.1 ([#3035](https://github.com/cookicutter/cookiecutter-django/pull/3035))
-- Update jinja2 to 2.11.3 ([#3033](https://github.com/cookicutter/cookiecutter-django/pull/3033))
-- Bump peter-evans/create-pull-request from v3.7.0 to v3.8.0 ([#3034](https://github.com/cookicutter/cookiecutter-django/pull/3034))
+- Update pytz to 2021.1 ([#3035](https://github.com/cookiecutter/cookiecutter-django/pull/3035))
+- Update jinja2 to 2.11.3 ([#3033](https://github.com/cookiecutter/cookiecutter-django/pull/3033))
+- Bump peter-evans/create-pull-request from v3.7.0 to v3.8.0 ([#3034](https://github.com/cookiecutter/cookiecutter-django/pull/3034))
 
 ## [2021-01-31]
 ### Changed
-- Adding local celery instructions to developing-locally ([#3031](https://github.com/cookicutter/cookiecutter-django/pull/3031))
+- Adding local celery instructions to developing-locally ([#3031](https://github.com/cookiecutter/cookiecutter-django/pull/3031))
 ### Updated
-- Update django-crispy-forms to 1.11.0 ([#3032](https://github.com/cookicutter/cookiecutter-django/pull/3032))
+- Update django-crispy-forms to 1.11.0 ([#3032](https://github.com/cookiecutter/cookiecutter-django/pull/3032))
 
 ## [2021-01-28]
 ### Updated
-- Update pre-commit to 2.10.0 ([#3028](https://github.com/cookicutter/cookiecutter-django/pull/3028))
-- Update django-anymail to 8.2 ([#3027](https://github.com/cookicutter/cookiecutter-django/pull/3027))
-- Update tox to 3.21.3 ([#3026](https://github.com/cookicutter/cookiecutter-django/pull/3026))
+- Update pre-commit to 2.10.0 ([#3028](https://github.com/cookiecutter/cookiecutter-django/pull/3028))
+- Update django-anymail to 8.2 ([#3027](https://github.com/cookiecutter/cookiecutter-django/pull/3027))
+- Update tox to 3.21.3 ([#3026](https://github.com/cookiecutter/cookiecutter-django/pull/3026))
 
 ## [2021-01-26]
 ### Changed
-- Bump peter-evans/create-pull-request from v3.6.0 to v3.7.0 ([#3022](https://github.com/cookicutter/cookiecutter-django/pull/3022))
-- Using SuccessMessageMixin to send success message to django template ([#3021](https://github.com/cookicutter/cookiecutter-django/pull/3021))
+- Bump peter-evans/create-pull-request from v3.6.0 to v3.7.0 ([#3022](https://github.com/cookiecutter/cookiecutter-django/pull/3022))
+- Using SuccessMessageMixin to send success message to django template ([#3021](https://github.com/cookiecutter/cookiecutter-django/pull/3021))
 ### Fixed
-- Update admin to ignore *_name User attributes ([#3018](https://github.com/cookicutter/cookiecutter-django/pull/3018))
+- Update admin to ignore *_name User attributes ([#3018](https://github.com/cookiecutter/cookiecutter-django/pull/3018))
 ### Updated
-- Update coverage to 5.4 ([#3024](https://github.com/cookicutter/cookiecutter-django/pull/3024))
-- Update pytest to 6.2.2 ([#3020](https://github.com/cookicutter/cookiecutter-django/pull/3020))
-- Update django-cors-headers to 3.7.0 ([#3019](https://github.com/cookicutter/cookiecutter-django/pull/3019))
+- Update coverage to 5.4 ([#3024](https://github.com/cookiecutter/cookiecutter-django/pull/3024))
+- Update pytest to 6.2.2 ([#3020](https://github.com/cookiecutter/cookiecutter-django/pull/3020))
+- Update django-cors-headers to 3.7.0 ([#3019](https://github.com/cookiecutter/cookiecutter-django/pull/3019))
 
 ## [2021-01-24]
 ### Changed
-- Use defer for script tags (Fix #2922) ([#2927](https://github.com/cookicutter/cookiecutter-django/pull/2927))
-- Made Traefik conf much easier to understand and improved redirect res… ([#2838](https://github.com/cookicutter/cookiecutter-django/pull/2838))
-- Sentry Redis integration enabled by default in production. ([#2989](https://github.com/cookicutter/cookiecutter-django/pull/2989))
-- Add test for UserUpdateView.form_valid() ([#2949](https://github.com/cookicutter/cookiecutter-django/pull/2949))
+- Use defer for script tags (Fix #2922) ([#2927](https://github.com/cookiecutter/cookiecutter-django/pull/2927))
+- Made Traefik conf much easier to understand and improved redirect res… ([#2838](https://github.com/cookiecutter/cookiecutter-django/pull/2838))
+- Sentry Redis integration enabled by default in production. ([#2989](https://github.com/cookiecutter/cookiecutter-django/pull/2989))
+- Add test for UserUpdateView.form_valid() ([#2949](https://github.com/cookiecutter/cookiecutter-django/pull/2949))
 ### Fixed
-- Omit first_name and last_name in User model ([#2998](https://github.com/cookicutter/cookiecutter-django/pull/2998))
+- Omit first_name and last_name in User model ([#2998](https://github.com/cookiecutter/cookiecutter-django/pull/2998))
 ### Updated
-- Update django-celery-beat to 2.2.0 ([#3009](https://github.com/cookicutter/cookiecutter-django/pull/3009))
-- Update pyyaml to 5.4.1 ([#3011](https://github.com/cookicutter/cookiecutter-django/pull/3011))
-- Update mypy to 0.800 ([#3013](https://github.com/cookicutter/cookiecutter-django/pull/3013))
-- Update factory-boy to 3.2.0 ([#2986](https://github.com/cookicutter/cookiecutter-django/pull/2986))
-- Update tox to 3.21.2 ([#3010](https://github.com/cookicutter/cookiecutter-django/pull/3010))
+- Update django-celery-beat to 2.2.0 ([#3009](https://github.com/cookiecutter/cookiecutter-django/pull/3009))
+- Update pyyaml to 5.4.1 ([#3011](https://github.com/cookiecutter/cookiecutter-django/pull/3011))
+- Update mypy to 0.800 ([#3013](https://github.com/cookiecutter/cookiecutter-django/pull/3013))
+- Update factory-boy to 3.2.0 ([#2986](https://github.com/cookiecutter/cookiecutter-django/pull/2986))
+- Update tox to 3.21.2 ([#3010](https://github.com/cookiecutter/cookiecutter-django/pull/3010))
 
 ## [2021-01-22]
 ### Changed
-- Use self.request.user instead of second query ([#3012](https://github.com/cookicutter/cookiecutter-django/pull/3012))
+- Use self.request.user instead of second query ([#3012](https://github.com/cookiecutter/cookiecutter-django/pull/3012))
 
 ## [2021-01-14]
 ### Updated
-- Update tox to 3.21.1 ([#3006](https://github.com/cookicutter/cookiecutter-django/pull/3006))
+- Update tox to 3.21.1 ([#3006](https://github.com/cookiecutter/cookiecutter-django/pull/3006))
 
 ## [2021-01-10]
 ### Updated
-- Update pylint-django to 2.4.2 ([#3003](https://github.com/cookicutter/cookiecutter-django/pull/3003))
-- Update tox to 3.21.0 ([#3002](https://github.com/cookicutter/cookiecutter-django/pull/3002))
+- Update pylint-django to 2.4.2 ([#3003](https://github.com/cookiecutter/cookiecutter-django/pull/3003))
+- Update tox to 3.21.0 ([#3002](https://github.com/cookiecutter/cookiecutter-django/pull/3002))
 
 ## [2021-01-08]
 ### Changed
-- Upgrade Travis to Focal ([#2999](https://github.com/cookicutter/cookiecutter-django/pull/2999))
+- Upgrade Travis to Focal ([#2999](https://github.com/cookiecutter/cookiecutter-django/pull/2999))
 ### Updated
-- Update pylint-django to 2.4.1 ([#3001](https://github.com/cookicutter/cookiecutter-django/pull/3001))
-- Update sphinx to 3.4.3 ([#3000](https://github.com/cookicutter/cookiecutter-django/pull/3000))
-- Update pylint-django to 2.4.0 ([#2996](https://github.com/cookicutter/cookiecutter-django/pull/2996))
+- Update pylint-django to 2.4.1 ([#3001](https://github.com/cookiecutter/cookiecutter-django/pull/3001))
+- Update sphinx to 3.4.3 ([#3000](https://github.com/cookiecutter/cookiecutter-django/pull/3000))
+- Update pylint-django to 2.4.0 ([#2996](https://github.com/cookiecutter/cookiecutter-django/pull/2996))
 
 ## [2021-01-04]
 ### Updated
-- Update isort to 5.7.0 ([#2988](https://github.com/cookicutter/cookiecutter-django/pull/2988))
-- Update uvicorn to 0.13.3 ([#2987](https://github.com/cookicutter/cookiecutter-django/pull/2987))
-- Auto-update pre-commit hooks ([#2990](https://github.com/cookicutter/cookiecutter-django/pull/2990))
-- Update sphinx to 3.4.2 ([#2995](https://github.com/cookicutter/cookiecutter-django/pull/2995))
-- Update pillow to 8.1.0 ([#2993](https://github.com/cookicutter/cookiecutter-django/pull/2993))
+- Update isort to 5.7.0 ([#2988](https://github.com/cookiecutter/cookiecutter-django/pull/2988))
+- Update uvicorn to 0.13.3 ([#2987](https://github.com/cookiecutter/cookiecutter-django/pull/2987))
+- Auto-update pre-commit hooks ([#2990](https://github.com/cookiecutter/cookiecutter-django/pull/2990))
+- Update sphinx to 3.4.2 ([#2995](https://github.com/cookiecutter/cookiecutter-django/pull/2995))
+- Update pillow to 8.1.0 ([#2993](https://github.com/cookiecutter/cookiecutter-django/pull/2993))
 
 ## [2020-12-29]
 ### Updated
-- Update pygithub to 1.54.1 ([#2982](https://github.com/cookicutter/cookiecutter-django/pull/2982))
-- Update django-storages to 1.11.1 ([#2981](https://github.com/cookicutter/cookiecutter-django/pull/2981))
+- Update pygithub to 1.54.1 ([#2982](https://github.com/cookiecutter/cookiecutter-django/pull/2982))
+- Update django-storages to 1.11.1 ([#2981](https://github.com/cookiecutter/cookiecutter-django/pull/2981))
 
 ## [2020-12-26]
 ### Updated
-- Update sphinx to 3.4.1 ([#2985](https://github.com/cookicutter/cookiecutter-django/pull/2985))
-- Update pytz to 2020.5 ([#2984](https://github.com/cookicutter/cookiecutter-django/pull/2984))
+- Update sphinx to 3.4.1 ([#2985](https://github.com/cookiecutter/cookiecutter-django/pull/2985))
+- Update pytz to 2020.5 ([#2984](https://github.com/cookiecutter/cookiecutter-django/pull/2984))
 
 ## [2020-12-23]
 ### Changed
-- Bump peter-evans/create-pull-request from v3.5.2 to v3.6.0 ([#2980](https://github.com/cookicutter/cookiecutter-django/pull/2980))
+- Bump peter-evans/create-pull-request from v3.5.2 to v3.6.0 ([#2980](https://github.com/cookiecutter/cookiecutter-django/pull/2980))
 ### Updated
-- Update flower to 0.9.7 ([#2979](https://github.com/cookicutter/cookiecutter-django/pull/2979))
-- Update sphinx to 3.4.0 ([#2978](https://github.com/cookicutter/cookiecutter-django/pull/2978))
-- Update coverage to 5.3.1 ([#2977](https://github.com/cookicutter/cookiecutter-django/pull/2977))
-- Update uvicorn to 0.13.2 ([#2976](https://github.com/cookicutter/cookiecutter-django/pull/2976))
+- Update flower to 0.9.7 ([#2979](https://github.com/cookiecutter/cookiecutter-django/pull/2979))
+- Update sphinx to 3.4.0 ([#2978](https://github.com/cookiecutter/cookiecutter-django/pull/2978))
+- Update coverage to 5.3.1 ([#2977](https://github.com/cookiecutter/cookiecutter-django/pull/2977))
+- Update uvicorn to 0.13.2 ([#2976](https://github.com/cookiecutter/cookiecutter-django/pull/2976))
 
 ## [2020-12-18]
 ### Changed
-- Bump stefanzweifel/git-auto-commit-action from v4.7.2 to v4.8.0 ([#2972](https://github.com/cookicutter/cookiecutter-django/pull/2972))
+- Bump stefanzweifel/git-auto-commit-action from v4.7.2 to v4.8.0 ([#2972](https://github.com/cookiecutter/cookiecutter-django/pull/2972))
 ### Updated
-- Update django-storages to 1.11 ([#2973](https://github.com/cookicutter/cookiecutter-django/pull/2973))
-- Update pytest to 6.2.1 ([#2971](https://github.com/cookicutter/cookiecutter-django/pull/2971))
-- Auto-update pre-commit hooks ([#2970](https://github.com/cookicutter/cookiecutter-django/pull/2970))
+- Update django-storages to 1.11 ([#2973](https://github.com/cookiecutter/cookiecutter-django/pull/2973))
+- Update pytest to 6.2.1 ([#2971](https://github.com/cookiecutter/cookiecutter-django/pull/2971))
+- Auto-update pre-commit hooks ([#2970](https://github.com/cookiecutter/cookiecutter-django/pull/2970))
 
 ## [2020-12-14]
 ### Updated
-- Update pytest to 6.2.0 ([#2968](https://github.com/cookicutter/cookiecutter-django/pull/2968))
-- Update django-cors-headers to 3.6.0 ([#2967](https://github.com/cookicutter/cookiecutter-django/pull/2967))
-- Update uvicorn to 0.13.1 ([#2966](https://github.com/cookicutter/cookiecutter-django/pull/2966))
+- Update pytest to 6.2.0 ([#2968](https://github.com/cookiecutter/cookiecutter-django/pull/2968))
+- Update django-cors-headers to 3.6.0 ([#2967](https://github.com/cookiecutter/cookiecutter-django/pull/2967))
+- Update uvicorn to 0.13.1 ([#2966](https://github.com/cookiecutter/cookiecutter-django/pull/2966))
 
 ## [2020-12-10]
 ### Changed
-- Hot-reload support to celery ([#2554](https://github.com/cookicutter/cookiecutter-django/pull/2554))
+- Hot-reload support to celery ([#2554](https://github.com/cookiecutter/cookiecutter-django/pull/2554))
 ### Updated
-- Update uvicorn to 0.13.0 ([#2962](https://github.com/cookicutter/cookiecutter-django/pull/2962))
-- Update sentry-sdk to 0.19.5 ([#2965](https://github.com/cookicutter/cookiecutter-django/pull/2965))
+- Update uvicorn to 0.13.0 ([#2962](https://github.com/cookiecutter/cookiecutter-django/pull/2962))
+- Update sentry-sdk to 0.19.5 ([#2965](https://github.com/cookiecutter/cookiecutter-django/pull/2965))
 
 ## [2020-12-09]
 ### Changed
-- Bump peter-evans/create-pull-request from v3.5.1 to v3.5.2 ([#2964](https://github.com/cookicutter/cookiecutter-django/pull/2964))
+- Bump peter-evans/create-pull-request from v3.5.1 to v3.5.2 ([#2964](https://github.com/cookiecutter/cookiecutter-django/pull/2964))
 
 ## [2020-12-08]
 ### Updated
-- Update pre-commit to 2.9.3 ([#2961](https://github.com/cookicutter/cookiecutter-django/pull/2961))
+- Update pre-commit to 2.9.3 ([#2961](https://github.com/cookiecutter/cookiecutter-django/pull/2961))
 
 ## [2020-12-04]
 ### Updated
-- Update django-debug-toolbar to 3.2 ([#2959](https://github.com/cookicutter/cookiecutter-django/pull/2959))
+- Update django-debug-toolbar to 3.2 ([#2959](https://github.com/cookiecutter/cookiecutter-django/pull/2959))
 
 ## [2020-12-02]
 ### Updated
-- Update django-model-utils to 4.1.1 ([#2957](https://github.com/cookicutter/cookiecutter-django/pull/2957))
-- Update pygithub to 1.54 ([#2958](https://github.com/cookicutter/cookiecutter-django/pull/2958))
+- Update django-model-utils to 4.1.1 ([#2957](https://github.com/cookiecutter/cookiecutter-django/pull/2957))
+- Update pygithub to 1.54 ([#2958](https://github.com/cookiecutter/cookiecutter-django/pull/2958))
 
 ## [2020-11-26]
 ### Updated
-- Update django-extensions to 3.1.0 ([#2947](https://github.com/cookicutter/cookiecutter-django/pull/2947))
-- Update pre-commit to 2.9.2 ([#2948](https://github.com/cookicutter/cookiecutter-django/pull/2948))
-- Update django-allauth to 0.44.0 ([#2945](https://github.com/cookicutter/cookiecutter-django/pull/2945))
+- Update django-extensions to 3.1.0 ([#2947](https://github.com/cookiecutter/cookiecutter-django/pull/2947))
+- Update pre-commit to 2.9.2 ([#2948](https://github.com/cookiecutter/cookiecutter-django/pull/2948))
+- Update django-allauth to 0.44.0 ([#2945](https://github.com/cookiecutter/cookiecutter-django/pull/2945))
 
 ## [2020-11-25]
 ### Changed
-- Bump peter-evans/create-pull-request from v3.5.0 to v3.5.1 ([#2944](https://github.com/cookicutter/cookiecutter-django/pull/2944))
+- Bump peter-evans/create-pull-request from v3.5.0 to v3.5.1 ([#2944](https://github.com/cookiecutter/cookiecutter-django/pull/2944))
 
 ## [2020-11-23]
 ### Updated
-- Update uvicorn to 0.12.3 ([#2943](https://github.com/cookicutter/cookiecutter-django/pull/2943))
-- Update pre-commit to 2.9.0 ([#2942](https://github.com/cookicutter/cookiecutter-django/pull/2942))
+- Update uvicorn to 0.12.3 ([#2943](https://github.com/cookiecutter/cookiecutter-django/pull/2943))
+- Update pre-commit to 2.9.0 ([#2942](https://github.com/cookiecutter/cookiecutter-django/pull/2942))
 
 ## [2020-11-21]
 ### Changed
-- Fix after uvicorn 0.12.0 - Ship extra dependencies ([#2939](https://github.com/cookicutter/cookiecutter-django/pull/2939))
+- Fix after uvicorn 0.12.0 - Ship extra dependencies ([#2939](https://github.com/cookiecutter/cookiecutter-django/pull/2939))
 
 ## [2020-11-20]
 ### Updated
-- Update sentry-sdk to 0.19.4 ([#2938](https://github.com/cookicutter/cookiecutter-django/pull/2938))
+- Update sentry-sdk to 0.19.4 ([#2938](https://github.com/cookiecutter/cookiecutter-django/pull/2938))
 
 ## [2020-11-19]
 ### Updated
-- Update django-crispy-forms to 1.10.0 ([#2937](https://github.com/cookicutter/cookiecutter-django/pull/2937))
+- Update django-crispy-forms to 1.10.0 ([#2937](https://github.com/cookiecutter/cookiecutter-django/pull/2937))
 
 ## [2020-11-17]
 ### Changed
-- Bump peter-evans/create-pull-request from v2 to v3.5.0 ([#2936](https://github.com/cookicutter/cookiecutter-django/pull/2936))
+- Bump peter-evans/create-pull-request from v2 to v3.5.0 ([#2936](https://github.com/cookiecutter/cookiecutter-django/pull/2936))
 
 ## [2020-11-15]
 ### Changed
-- Fix formatting in docs ([#2935](https://github.com/cookicutter/cookiecutter-django/pull/2935))
+- Fix formatting in docs ([#2935](https://github.com/cookiecutter/cookiecutter-django/pull/2935))
 
 ## [2020-11-13]
 ### Changed
-- Upgrade factory-boy to 3.1.0 ([#2932](https://github.com/cookicutter/cookiecutter-django/pull/2932))
+- Upgrade factory-boy to 3.1.0 ([#2932](https://github.com/cookiecutter/cookiecutter-django/pull/2932))
 ### Updated
-- Update sentry-sdk to 0.19.3 ([#2933](https://github.com/cookicutter/cookiecutter-django/pull/2933))
-- Update sphinx to 3.3.1 ([#2934](https://github.com/cookicutter/cookiecutter-django/pull/2934))
+- Update sentry-sdk to 0.19.3 ([#2933](https://github.com/cookiecutter/cookiecutter-django/pull/2933))
+- Update sphinx to 3.3.1 ([#2934](https://github.com/cookiecutter/cookiecutter-django/pull/2934))
 
 ## [2020-11-12]
 ### Changed
-- Migrate CI to Github Actions ([#2931](https://github.com/cookicutter/cookiecutter-django/pull/2931))
+- Migrate CI to Github Actions ([#2931](https://github.com/cookiecutter/cookiecutter-django/pull/2931))
 
 ## [2020-11-06]
 ### Updated
-- Update djangorestframework to 3.12.2 ([#2930](https://github.com/cookicutter/cookiecutter-django/pull/2930))
+- Update djangorestframework to 3.12.2 ([#2930](https://github.com/cookiecutter/cookiecutter-django/pull/2930))
 
 ## [2020-11-04]
 ### Changed
-- Fix docs service and add RTD support ([#2920](https://github.com/cookicutter/cookiecutter-django/pull/2920))
-- Bump stefanzweifel/git-auto-commit-action from v4.6.0 to v4.7.2 ([#2914](https://github.com/cookicutter/cookiecutter-django/pull/2914))
+- Fix docs service and add RTD support ([#2920](https://github.com/cookiecutter/cookiecutter-django/pull/2920))
+- Bump stefanzweifel/git-auto-commit-action from v4.6.0 to v4.7.2 ([#2914](https://github.com/cookiecutter/cookiecutter-django/pull/2914))
 ### Updated
-- Auto-update pre-commit hooks ([#2908](https://github.com/cookicutter/cookiecutter-django/pull/2908))
-- Update mypy to 0.790 ([#2886](https://github.com/cookicutter/cookiecutter-django/pull/2886))
-- Update django-stubs to 1.7.0 ([#2916](https://github.com/cookicutter/cookiecutter-django/pull/2916))
+- Auto-update pre-commit hooks ([#2908](https://github.com/cookiecutter/cookiecutter-django/pull/2908))
+- Update mypy to 0.790 ([#2886](https://github.com/cookiecutter/cookiecutter-django/pull/2886))
+- Update django-stubs to 1.7.0 ([#2916](https://github.com/cookiecutter/cookiecutter-django/pull/2916))
 
 ## [2020-11-03]
 ### Updated
-- Update sentry-sdk to 0.19.2 ([#2926](https://github.com/cookicutter/cookiecutter-django/pull/2926))
-- Update sphinx to 3.3.0 ([#2925](https://github.com/cookicutter/cookiecutter-django/pull/2925))
-- Update django to 3.0.11 ([#2924](https://github.com/cookicutter/cookiecutter-django/pull/2924))
-- Update pytz to 2020.4 ([#2923](https://github.com/cookicutter/cookiecutter-django/pull/2923))
-- Update pre-commit to 2.8.2 ([#2919](https://github.com/cookicutter/cookiecutter-django/pull/2919))
-- Update pytest to 6.1.2 ([#2917](https://github.com/cookicutter/cookiecutter-django/pull/2917))
-- Update sh to 1.14.1 ([#2912](https://github.com/cookicutter/cookiecutter-django/pull/2912))
-- Update pytest-django to 4.1.0 ([#2911](https://github.com/cookicutter/cookiecutter-django/pull/2911))
-- Update pillow to 8.0.1 ([#2910](https://github.com/cookicutter/cookiecutter-django/pull/2910))
-- Update django-celery-beat to 2.1.0 ([#2907](https://github.com/cookicutter/cookiecutter-django/pull/2907))
-- Update uvicorn to 0.12.2 ([#2906](https://github.com/cookicutter/cookiecutter-django/pull/2906))
+- Update sentry-sdk to 0.19.2 ([#2926](https://github.com/cookiecutter/cookiecutter-django/pull/2926))
+- Update sphinx to 3.3.0 ([#2925](https://github.com/cookiecutter/cookiecutter-django/pull/2925))
+- Update django to 3.0.11 ([#2924](https://github.com/cookiecutter/cookiecutter-django/pull/2924))
+- Update pytz to 2020.4 ([#2923](https://github.com/cookiecutter/cookiecutter-django/pull/2923))
+- Update pre-commit to 2.8.2 ([#2919](https://github.com/cookiecutter/cookiecutter-django/pull/2919))
+- Update pytest to 6.1.2 ([#2917](https://github.com/cookiecutter/cookiecutter-django/pull/2917))
+- Update sh to 1.14.1 ([#2912](https://github.com/cookiecutter/cookiecutter-django/pull/2912))
+- Update pytest-django to 4.1.0 ([#2911](https://github.com/cookiecutter/cookiecutter-django/pull/2911))
+- Update pillow to 8.0.1 ([#2910](https://github.com/cookiecutter/cookiecutter-django/pull/2910))
+- Update django-celery-beat to 2.1.0 ([#2907](https://github.com/cookiecutter/cookiecutter-django/pull/2907))
+- Update uvicorn to 0.12.2 ([#2906](https://github.com/cookiecutter/cookiecutter-django/pull/2906))
 
 ## [2020-10-19]
 ### Updated
-- Update sentry-sdk to 0.19.1 ([#2905](https://github.com/cookicutter/cookiecutter-django/pull/2905))
+- Update sentry-sdk to 0.19.1 ([#2905](https://github.com/cookiecutter/cookiecutter-django/pull/2905))
 
 ## [2020-10-17]
 ### Updated
-- Update django-allauth to 0.43.0 ([#2901](https://github.com/cookicutter/cookiecutter-django/pull/2901))
-- Update pytest-django to 4.0.0 ([#2903](https://github.com/cookicutter/cookiecutter-django/pull/2903))
+- Update django-allauth to 0.43.0 ([#2901](https://github.com/cookiecutter/cookiecutter-django/pull/2901))
+- Update pytest-django to 4.0.0 ([#2903](https://github.com/cookiecutter/cookiecutter-django/pull/2903))
 
 ## [2020-10-15]
 ### Updated
-- Update pillow to 8.0.0 ([#2898](https://github.com/cookicutter/cookiecutter-django/pull/2898))
+- Update pillow to 8.0.0 ([#2898](https://github.com/cookiecutter/cookiecutter-django/pull/2898))
 
 ## [2020-10-14]
 ### Updated
-- Auto-update pre-commit hooks ([#2897](https://github.com/cookicutter/cookiecutter-django/pull/2897))
-- Update sentry-sdk to 0.19.0 ([#2896](https://github.com/cookicutter/cookiecutter-django/pull/2896))
+- Auto-update pre-commit hooks ([#2897](https://github.com/cookiecutter/cookiecutter-django/pull/2897))
+- Update sentry-sdk to 0.19.0 ([#2896](https://github.com/cookiecutter/cookiecutter-django/pull/2896))
 
 ## [2020-10-13]
 ### Updated
-- Update isort to 5.6.4 ([#2895](https://github.com/cookicutter/cookiecutter-django/pull/2895))
+- Update isort to 5.6.4 ([#2895](https://github.com/cookiecutter/cookiecutter-django/pull/2895))
 
 ## [2020-10-12]
 ### Changed
-- Bump stefanzweifel/git-auto-commit-action from v4.5.1 to v4.6.0 ([#2893](https://github.com/cookicutter/cookiecutter-django/pull/2893))
+- Bump stefanzweifel/git-auto-commit-action from v4.5.1 to v4.6.0 ([#2893](https://github.com/cookiecutter/cookiecutter-django/pull/2893))
 ### Updated
-- Auto-update pre-commit hooks ([#2892](https://github.com/cookicutter/cookiecutter-django/pull/2892))
+- Auto-update pre-commit hooks ([#2892](https://github.com/cookiecutter/cookiecutter-django/pull/2892))
 
 ## [2020-10-11]
 ### Updated
-- Auto-update pre-commit hooks ([#2890](https://github.com/cookicutter/cookiecutter-django/pull/2890))
-- Update isort to 5.6.3 ([#2891](https://github.com/cookicutter/cookiecutter-django/pull/2891))
-- Update django-anymail to 8.1 ([#2887](https://github.com/cookicutter/cookiecutter-django/pull/2887))
-- Update tox to 3.20.1 ([#2885](https://github.com/cookicutter/cookiecutter-django/pull/2885))
+- Auto-update pre-commit hooks ([#2890](https://github.com/cookiecutter/cookiecutter-django/pull/2890))
+- Update isort to 5.6.3 ([#2891](https://github.com/cookiecutter/cookiecutter-django/pull/2891))
+- Update django-anymail to 8.1 ([#2887](https://github.com/cookiecutter/cookiecutter-django/pull/2887))
+- Update tox to 3.20.1 ([#2885](https://github.com/cookiecutter/cookiecutter-django/pull/2885))
 
 ## [2020-10-09]
 ### Updated
-- Auto-update pre-commit hooks ([#2884](https://github.com/cookicutter/cookiecutter-django/pull/2884))
-- Update isort to 5.6.1 ([#2883](https://github.com/cookicutter/cookiecutter-django/pull/2883))
+- Auto-update pre-commit hooks ([#2884](https://github.com/cookiecutter/cookiecutter-django/pull/2884))
+- Update isort to 5.6.1 ([#2883](https://github.com/cookiecutter/cookiecutter-django/pull/2883))
 
 ## [2020-10-08]
 ### Changed
-- Add dedicated websockets package ([#2881](https://github.com/cookicutter/cookiecutter-django/pull/2881))
+- Add dedicated websockets package ([#2881](https://github.com/cookiecutter/cookiecutter-django/pull/2881))
 ### Updated
-- Update isort to 5.6.0 ([#2882](https://github.com/cookicutter/cookiecutter-django/pull/2882))
+- Update isort to 5.6.0 ([#2882](https://github.com/cookiecutter/cookiecutter-django/pull/2882))
 
 ## [2020-10-04]
 ### Updated
-- Update pytest to 6.1.1 ([#2880](https://github.com/cookicutter/cookiecutter-django/pull/2880))
-- Update mypy and django-stubs ([#2874](https://github.com/cookicutter/cookiecutter-django/pull/2874))
-- Auto-update pre-commit hooks ([#2876](https://github.com/cookicutter/cookiecutter-django/pull/2876))
-- Update flake8 to 3.8.4 ([#2877](https://github.com/cookicutter/cookiecutter-django/pull/2877))
+- Update pytest to 6.1.1 ([#2880](https://github.com/cookiecutter/cookiecutter-django/pull/2880))
+- Update mypy and django-stubs ([#2874](https://github.com/cookiecutter/cookiecutter-django/pull/2874))
+- Auto-update pre-commit hooks ([#2876](https://github.com/cookiecutter/cookiecutter-django/pull/2876))
+- Update flake8 to 3.8.4 ([#2877](https://github.com/cookiecutter/cookiecutter-django/pull/2877))
 
 ## [2020-10-01]
 ### Changed
-- Bump actions/setup-python from v2.1.2 to v2.1.3 ([#2869](https://github.com/cookicutter/cookiecutter-django/pull/2869))
+- Bump actions/setup-python from v2.1.2 to v2.1.3 ([#2869](https://github.com/cookiecutter/cookiecutter-django/pull/2869))
 ### Updated
-- Update ipdb to 0.13.4 ([#2873](https://github.com/cookicutter/cookiecutter-django/pull/2873))
-- Auto-update pre-commit hooks ([#2867](https://github.com/cookicutter/cookiecutter-django/pull/2867))
-- Update uvicorn to 0.12.1 ([#2866](https://github.com/cookicutter/cookiecutter-django/pull/2866))
-- Update isort to 5.5.4 ([#2864](https://github.com/cookicutter/cookiecutter-django/pull/2864))
-- Update sentry-sdk to 0.18.0 ([#2863](https://github.com/cookicutter/cookiecutter-django/pull/2863))
-- Update djangorestframework to 3.12.1 ([#2862](https://github.com/cookicutter/cookiecutter-django/pull/2862))
-- Update pytest to 6.1.0 ([#2859](https://github.com/cookicutter/cookiecutter-django/pull/2859))
-- Update django-debug-toolbar to 3.1.1 ([#2855](https://github.com/cookicutter/cookiecutter-django/pull/2855))
+- Update ipdb to 0.13.4 ([#2873](https://github.com/cookiecutter/cookiecutter-django/pull/2873))
+- Auto-update pre-commit hooks ([#2867](https://github.com/cookiecutter/cookiecutter-django/pull/2867))
+- Update uvicorn to 0.12.1 ([#2866](https://github.com/cookiecutter/cookiecutter-django/pull/2866))
+- Update isort to 5.5.4 ([#2864](https://github.com/cookiecutter/cookiecutter-django/pull/2864))
+- Update sentry-sdk to 0.18.0 ([#2863](https://github.com/cookiecutter/cookiecutter-django/pull/2863))
+- Update djangorestframework to 3.12.1 ([#2862](https://github.com/cookiecutter/cookiecutter-django/pull/2862))
+- Update pytest to 6.1.0 ([#2859](https://github.com/cookiecutter/cookiecutter-django/pull/2859))
+- Update django-debug-toolbar to 3.1.1 ([#2855](https://github.com/cookiecutter/cookiecutter-django/pull/2855))
 
 ## [2020-09-23]
 ### Updated
-- Update sentry-sdk to 0.17.7 ([#2847](https://github.com/cookicutter/cookiecutter-django/pull/2847))
-- Update django-debug-toolbar to 3.1 ([#2846](https://github.com/cookicutter/cookiecutter-django/pull/2846))
+- Update sentry-sdk to 0.17.7 ([#2847](https://github.com/cookiecutter/cookiecutter-django/pull/2847))
+- Update django-debug-toolbar to 3.1 ([#2846](https://github.com/cookiecutter/cookiecutter-django/pull/2846))
 
 ## [2020-09-21]
 ### Changed
-- Adding GitHub-Action CI Option ([#2837](https://github.com/cookicutter/cookiecutter-django/pull/2837))
+- Adding GitHub-Action CI Option ([#2837](https://github.com/cookiecutter/cookiecutter-django/pull/2837))
 ### Updated
-- Update django-debug-toolbar to 3.0 ([#2842](https://github.com/cookicutter/cookiecutter-django/pull/2842))
-- Auto-update pre-commit hooks ([#2843](https://github.com/cookicutter/cookiecutter-django/pull/2843))
-- Update isort to 5.5.3 ([#2844](https://github.com/cookicutter/cookiecutter-django/pull/2844))
+- Update django-debug-toolbar to 3.0 ([#2842](https://github.com/cookiecutter/cookiecutter-django/pull/2842))
+- Auto-update pre-commit hooks ([#2843](https://github.com/cookiecutter/cookiecutter-django/pull/2843))
+- Update isort to 5.5.3 ([#2844](https://github.com/cookiecutter/cookiecutter-django/pull/2844))
 
 ## [2020-09-18]
 ### Updated
-- Update django-extensions to 3.0.9 ([#2839](https://github.com/cookicutter/cookiecutter-django/pull/2839))
+- Update django-extensions to 3.0.9 ([#2839](https://github.com/cookiecutter/cookiecutter-django/pull/2839))
 
 ## [2020-09-16]
 ### Updated
-- Update sentry-sdk to 0.17.6 ([#2833](https://github.com/cookicutter/cookiecutter-django/pull/2833))
-- Update pytest-django to 3.10.0 ([#2832](https://github.com/cookicutter/cookiecutter-django/pull/2832))
+- Update sentry-sdk to 0.17.6 ([#2833](https://github.com/cookiecutter/cookiecutter-django/pull/2833))
+- Update pytest-django to 3.10.0 ([#2832](https://github.com/cookiecutter/cookiecutter-django/pull/2832))
 
 ## [2020-09-14]
 ### Fixed
-- Downgrade Celery to 4.4.6 ([#2829](https://github.com/cookicutter/cookiecutter-django/pull/2829))
+- Downgrade Celery to 4.4.6 ([#2829](https://github.com/cookiecutter/cookiecutter-django/pull/2829))
 ### Updated
-- Update sentry-sdk to 0.17.5 ([#2828](https://github.com/cookicutter/cookiecutter-django/pull/2828))
-- Update coverage to 5.3 ([#2826](https://github.com/cookicutter/cookiecutter-django/pull/2826))
-- Update django-storages to 1.10.1 ([#2825](https://github.com/cookicutter/cookiecutter-django/pull/2825))
+- Update sentry-sdk to 0.17.5 ([#2828](https://github.com/cookiecutter/cookiecutter-django/pull/2828))
+- Update coverage to 5.3 ([#2826](https://github.com/cookiecutter/cookiecutter-django/pull/2826))
+- Update django-storages to 1.10.1 ([#2825](https://github.com/cookiecutter/cookiecutter-django/pull/2825))
 
 ## [2020-09-12]
 ### Updated
-- Updating Traefik version from 2.0 to 2.2.11 ([#2814](https://github.com/cookicutter/cookiecutter-django/pull/2814))
-- Update pytest to 6.0.2 ([#2819](https://github.com/cookicutter/cookiecutter-django/pull/2819))
-- Update django-anymail to 8.0 ([#2818](https://github.com/cookicutter/cookiecutter-django/pull/2818))
+- Updating Traefik version from 2.0 to 2.2.11 ([#2814](https://github.com/cookiecutter/cookiecutter-django/pull/2814))
+- Update pytest to 6.0.2 ([#2819](https://github.com/cookiecutter/cookiecutter-django/pull/2819))
+- Update django-anymail to 8.0 ([#2818](https://github.com/cookiecutter/cookiecutter-django/pull/2818))
 
 ## [2020-09-11]
 ### Updated
-- Auto-update pre-commit hooks ([#2809](https://github.com/cookicutter/cookiecutter-django/pull/2809))
+- Auto-update pre-commit hooks ([#2809](https://github.com/cookiecutter/cookiecutter-django/pull/2809))
 
 ## [2020-09-10]
 ### Updated
-- Update isort to 5.5.2 ([#2807](https://github.com/cookicutter/cookiecutter-django/pull/2807))
-- Update sentry-sdk to 0.17.4 ([#2805](https://github.com/cookicutter/cookiecutter-django/pull/2805))
+- Update isort to 5.5.2 ([#2807](https://github.com/cookiecutter/cookiecutter-django/pull/2807))
+- Update sentry-sdk to 0.17.4 ([#2805](https://github.com/cookiecutter/cookiecutter-django/pull/2805))
 
 ## [2020-09-09]
 ### Changed
-- Update actions/setup-python requirement to v2.1.2 ([#2804](https://github.com/cookicutter/cookiecutter-django/pull/2804))
-- Clean up nested venv files from `.gitignore` ([#2800](https://github.com/cookicutter/cookiecutter-django/pull/2800))
+- Update actions/setup-python requirement to v2.1.2 ([#2804](https://github.com/cookiecutter/cookiecutter-django/pull/2804))
+- Clean up nested venv files from `.gitignore` ([#2800](https://github.com/cookiecutter/cookiecutter-django/pull/2800))
 
 ## [2020-09-08]
 ### Changed
-- Traeffik and Django dockerfile changes ([#2801](https://github.com/cookicutter/cookiecutter-django/pull/2801))
+- Traeffik and Django dockerfile changes ([#2801](https://github.com/cookiecutter/cookiecutter-django/pull/2801))
 
 ## [2020-09-07]
 ### Changed
-- Add :z/:Z to mounted volumes in {local,production}.yml ([#2663](https://github.com/cookicutter/cookiecutter-django/pull/2663))
-- Remove --no-binary option for psycopg2 ([#2798](https://github.com/cookicutter/cookiecutter-django/pull/2798))
-- Updated Gitlab CI to use Python 3.8 instead of Python 3.7 ([#2794](https://github.com/cookicutter/cookiecutter-django/pull/2794))
+- Add :z/:Z to mounted volumes in {local,production}.yml ([#2663](https://github.com/cookiecutter/cookiecutter-django/pull/2663))
+- Remove --no-binary option for psycopg2 ([#2798](https://github.com/cookiecutter/cookiecutter-django/pull/2798))
+- Updated Gitlab CI to use Python 3.8 instead of Python 3.7 ([#2794](https://github.com/cookiecutter/cookiecutter-django/pull/2794))
 ### Fixed
-- Fix options for sphinx-autobuild in docs Makefile ([#2799](https://github.com/cookicutter/cookiecutter-django/pull/2799))
+- Fix options for sphinx-autobuild in docs Makefile ([#2799](https://github.com/cookiecutter/cookiecutter-django/pull/2799))
 ### Updated
-- Update psycopg2-binary to 2.8.6 ([#2797](https://github.com/cookicutter/cookiecutter-django/pull/2797))
+- Update psycopg2-binary to 2.8.6 ([#2797](https://github.com/cookiecutter/cookiecutter-django/pull/2797))
 
 ## [2020-09-05]
 ### Updated
-- Auto-update pre-commit hooks ([#2793](https://github.com/cookicutter/cookiecutter-django/pull/2793))
+- Auto-update pre-commit hooks ([#2793](https://github.com/cookiecutter/cookiecutter-django/pull/2793))
 
 ## [2020-09-04]
 ### Updated
-- Update django-extensions to 3.0.8 ([#2792](https://github.com/cookicutter/cookiecutter-django/pull/2792))
-- Update isort to 5.5.1 ([#2791](https://github.com/cookicutter/cookiecutter-django/pull/2791))
-- Auto-update pre-commit hooks ([#2790](https://github.com/cookicutter/cookiecutter-django/pull/2790))
-- Update isort to 5.5.0 ([#2789](https://github.com/cookicutter/cookiecutter-django/pull/2789))
+- Update django-extensions to 3.0.8 ([#2792](https://github.com/cookiecutter/cookiecutter-django/pull/2792))
+- Update isort to 5.5.1 ([#2791](https://github.com/cookiecutter/cookiecutter-django/pull/2791))
+- Auto-update pre-commit hooks ([#2790](https://github.com/cookiecutter/cookiecutter-django/pull/2790))
+- Update isort to 5.5.0 ([#2789](https://github.com/cookiecutter/cookiecutter-django/pull/2789))
 
 ## [2020-09-02]
 ### Changed
-- Add environment and traces_sample_rate keyword to sentry_sdk.init ([#2777](https://github.com/cookicutter/cookiecutter-django/pull/2777))
+- Add environment and traces_sample_rate keyword to sentry_sdk.init ([#2777](https://github.com/cookiecutter/cookiecutter-django/pull/2777))
 ### Updated
-- Update sentry-sdk to 0.17.3 ([#2788](https://github.com/cookicutter/cookiecutter-django/pull/2788))
-- Update django-extensions to 3.0.7 ([#2787](https://github.com/cookicutter/cookiecutter-django/pull/2787))
+- Update sentry-sdk to 0.17.3 ([#2788](https://github.com/cookiecutter/cookiecutter-django/pull/2788))
+- Update django-extensions to 3.0.7 ([#2787](https://github.com/cookiecutter/cookiecutter-django/pull/2787))
 
 ## [2020-09-01]
 ### Changed
-- Exclude venv directory and update document link ([#2780](https://github.com/cookicutter/cookiecutter-django/pull/2780))
+- Exclude venv directory and update document link ([#2780](https://github.com/cookiecutter/cookiecutter-django/pull/2780))
 ### Updated
-- Update tox to 3.20.0 ([#2786](https://github.com/cookicutter/cookiecutter-django/pull/2786))
-- Update django-storages to 1.10 ([#2781](https://github.com/cookicutter/cookiecutter-django/pull/2781))
-- Update sentry-sdk to 0.17.2 ([#2784](https://github.com/cookicutter/cookiecutter-django/pull/2784))
-- Update django to 3.0.10 ([#2785](https://github.com/cookicutter/cookiecutter-django/pull/2785))
-- Update sphinx-autobuild to 2020.9.1 ([#2782](https://github.com/cookicutter/cookiecutter-django/pull/2782))
-- Update django-extensions to 3.0.6 ([#2783](https://github.com/cookicutter/cookiecutter-django/pull/2783))
+- Update tox to 3.20.0 ([#2786](https://github.com/cookiecutter/cookiecutter-django/pull/2786))
+- Update django-storages to 1.10 ([#2781](https://github.com/cookiecutter/cookiecutter-django/pull/2781))
+- Update sentry-sdk to 0.17.2 ([#2784](https://github.com/cookiecutter/cookiecutter-django/pull/2784))
+- Update django to 3.0.10 ([#2785](https://github.com/cookiecutter/cookiecutter-django/pull/2785))
+- Update sphinx-autobuild to 2020.9.1 ([#2782](https://github.com/cookiecutter/cookiecutter-django/pull/2782))
+- Update django-extensions to 3.0.6 ([#2783](https://github.com/cookiecutter/cookiecutter-django/pull/2783))
 
 ## [2020-08-31]
 ### Updated
-- Update sh to 1.14.0 ([#2779](https://github.com/cookicutter/cookiecutter-django/pull/2779))
-- Update sentry-sdk to 0.17.1 ([#2778](https://github.com/cookicutter/cookiecutter-django/pull/2778))
+- Update sh to 1.14.0 ([#2779](https://github.com/cookiecutter/cookiecutter-django/pull/2779))
+- Update sentry-sdk to 0.17.1 ([#2778](https://github.com/cookiecutter/cookiecutter-django/pull/2778))
 
 ## [2020-04-13]
 ### Changed
@@ -1134,7 +1134,7 @@ All enhancements and patches to Cookiecutter Django will be documented in this f
 - Rename `MIDDLEWARE_CLASSES` to `MIDDLEWARE` to enable support to [new style middleware](https://github.com/django/deps/blob/master/final/0005-improved-middleware.rst) introduced in Django 1.10 (@luzfcb)
 - New setting `MAILGUN_SENDER_DOMAIN` to allow sending mail from any domain other than those registered with mailgun (@jangeador)
 - add `urlpatterns` configuration to django-debug-toolbar, because the automatic configuration of `urlpatterns` was removed from django-debug-toolbar (@luzfcb)
-- Added Temporary workaround on `requirements/local.txt` to fix django-debug-toolbar issue: https://github.com/cookicutter/cookiecutter-django/issues/827 (@luzfcb)
+- Added Temporary workaround on `requirements/local.txt` to fix django-debug-toolbar issue: https://github.com/cookiecutter/cookiecutter-django/issues/827 (@luzfcb)
 
 ### Changed
 - Upgrade to Django 1.10.1 (@luzfcb)
@@ -1280,7 +1280,7 @@ d changed 'admin' url on `config/urls.py`, to stay the same as generated by djan
 
 ### [2016-05-01]
 ### Changed
-- Restored the Pycharm project configuration files, that was accidentally removed in [15f350f](https://github.com/cookicutter/cookiecutter-django/commit/15f350f05e2b49b4bdff0bdaa2b2ff260606e0f6) (@luzfcb @Newton715)
+- Restored the Pycharm project configuration files, that was accidentally removed in [15f350f](https://github.com/cookiecutter/cookiecutter-django/commit/15f350f05e2b49b4bdff0bdaa2b2ff260606e0f6) (@luzfcb @Newton715)
 
 ### [2016-04-30]
 ### Changed
@@ -1404,7 +1404,7 @@ d changed 'admin' url on `config/urls.py`, to stay the same as generated by djan
 ## [2016-02-15]
 ### Changed
 - In `users` app adapter, fix `is_open_for_signup` missing parameter (@oryx2)
-- Fixes and improvements in Hitch tests , see [#485](https://github.com/cookicutter/cookiecutter-django/pull/485) (@crdoconnor)
+- Fixes and improvements in Hitch tests , see [#485](https://github.com/cookiecutter/cookiecutter-django/pull/485) (@crdoconnor)
 
 
 ## [2016-02-12]


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Fixing typos in the changelog pull request URLs from 'cookicutter' to 'cookiecutter' so they no longer 404.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fixes PR URLs so they don't lead to a 404.