### PR TITLE
change path in docs Makefile to use APP variable

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -29,9 +29,9 @@ livehtml:
 # Outputs rst files from django application code
 apidocs:
 	{%- if cookiecutter.use_docker == 'y' %}
-	sphinx-apidoc -o $(SOURCEDIR)/api /app
+	sphinx-apidoc -o $(SOURCEDIR)/api $(APP)
 	{%- else %}
-	sphinx-apidoc -o $(SOURCEDIR)/api ../{{cookiecutter.project_slug}}
+	sphinx-apidoc -o $(SOURCEDIR)/api $(APP)
 	{%- endif %}
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -28,11 +28,7 @@ livehtml:
 
 # Outputs rst files from django application code
 apidocs:
-	{%- if cookiecutter.use_docker == 'y' %}
 	sphinx-apidoc -o $(SOURCEDIR)/api $(APP)
-	{%- else %}
-	sphinx-apidoc -o $(SOURCEDIR)/api $(APP)
-	{%- endif %}
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Changes the docs Makefile to use the APP variable for the apidocs target (for best practice).
<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
