### PR TITLE
refactor: remove user API methods parameter

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -19,7 +19,7 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
         assert isinstance(self.request.user.id, int)
         return self.queryset.filter(id=self.request.user.id)
 
-    @action(detail=False, methods=["GET"])
+    @action(detail=False)
     def me(self, request):
         serializer = UserSerializer(request.user, context={"request": request})
         return Response(status=status.HTTP_200_OK, data=serializer.data)


### PR DESCRIPTION
`methods` defaults to ["GET"] if not specified. There is no need to
explicitly set this in the action decorator.

https://github.com/encode/django-rest-framework/blob/71e6c30034a1dd35a39ca74f86c371713e762c79/rest_framework/decorators.py#L145

```
    :param methods: A list of HTTP method names this action responds to.
                    Defaults to GET only.
```