### PR TITLE
Get GitHub repo from environment

### DIFF
--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -7,6 +7,7 @@ import datetime as dt
 CURRENT_FILE = Path(__file__)
 ROOT = CURRENT_FILE.parents[1]
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
+GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", None)
 
 # Generate changelog for PRs merged yesterday
 MERGED_DATE = dt.date.today() - dt.timedelta(days=1)
@@ -39,9 +40,7 @@ def main() -> None:
 
 def iter_pulls():
     """Fetch merged pull requests at the date we're interested in."""
-    repo = Github(login_or_token=GITHUB_TOKEN).get_repo(
-        "cookiecutter/cookiecutter-django"
-    )
+    repo = Github(login_or_token=GITHUB_TOKEN).get_repo(GITHUB_REPO)
     recent_pulls = repo.get_pulls(
         state="closed", sort="updated", direction="desc"
     ).get_page(0)
@@ -77,4 +76,8 @@ def generate_md(grouped_pulls):
 
 
 if __name__ == "__main__":
+    if GITHUB_REPO is None:
+        raise RuntimeError(
+            "No github repo, please set the environment variable GITHUB_REPOSITORY"
+        )
     main()

--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from github import Github
 from github.NamedUser import NamedUser
@@ -7,6 +8,8 @@ from jinja2 import Template
 CURRENT_FILE = Path(__file__)
 ROOT = CURRENT_FILE.parents[1]
 BOT_LOGINS = ["pyup-bot"]
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
+GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", None)
 
 
 def main() -> None:
@@ -39,7 +42,7 @@ def iter_recent_authors():
     Use Github API to fetch recent authors rather than
     git CLI to work with Github usernames.
     """
-    repo = Github(per_page=5).get_repo("cookiecutter/cookiecutter-django")
+    repo = Github(login_or_token=GITHUB_TOKEN, per_page=5).get_repo(GITHUB_REPO)
     recent_pulls = repo.get_pulls(
         state="closed", sort="updated", direction="desc"
     ).get_page(0)
@@ -101,4 +104,8 @@ def write_md_file(contributors):
 
 
 if __name__ == "__main__":
+    if GITHUB_REPO is None:
+        raise RuntimeError(
+            "No github repo, please set the environment variable GITHUB_REPOSITORY"
+        )
     main()


### PR DESCRIPTION
## Description

Rather than hardcoding the GitHub repo in the scripts, get it from [the GitHub actions environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables).

## Rationale

Will make it easier to test out changes on forks.
