### PR TITLE
Fix incorrect node version in `package.json`

### DIFF
--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -23,7 +23,7 @@
     {%- endif %}
   },
   "engines": {
-    "node": ">=8"
+    "node": "10"
   },
   "browserslist": [
     "last 2 versions"


### PR DESCRIPTION
## Description

Bring node version in `package.json` in line with the Docker one.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The current node version specified in `package.json` is not in line with our Docker setup, where we use node 10. It's also has no upper bound, so when deploying to Heroku, node 17 is used, which doesn't work.
