### PR TITLE
Add post-hook Bootstrap version upgrader

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -13,7 +13,7 @@
     {% block css %}
     {%- endraw %}{% if cookiecutter.custom_bootstrap_compilation == "n" %}{% raw %}
     <!-- Latest compiled and minified Bootstrap CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" integrity="sha512-GQGU0fMMi238uA+a/bdWJfpUGKUkBdgfFdgBm72SUQ6BeyWjoY/ton0tEjH+OSH9iP4Dfh+7HM0I9f5eR0L/4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    !!!SET BOOTSTRAP CSS LINK!!!
     {%- endraw %}{% endif %}{% raw %}
 
     <!-- Your stuff: Third-party CSS libraries go here -->
@@ -37,7 +37,7 @@
       {%- endraw %}{% if cookiecutter.use_compressor == "y" %}{% raw %}{% endcompress %}{% endraw %}{% endif %}{% raw %}
       {%- endraw %}{% else %}{% raw %}
       <!-- Bootstrap JS -->
-      <script defer src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.min.js" integrity="sha512-OvBgP9A2JBgiRad/mM36mkzXSXaJE9BEIENnVEmeZdITvwT09xnxLtT4twkCa8m/loMbPHsvPl0T8lRGVBwjlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+      !!!SET BOOTSTRAP JS LINK!!!
       <!-- Your stuff: Third-party javascript libraries go here -->
       {%- endraw %}{% endif %}{% raw %}
 


### PR DESCRIPTION
Signed-off-by: Andrew-Chen-Wang <acwangpython@gmail.com>

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Fixes #3412

TL;DR post-hook that gets latest bootstrap (not including pre-releases). Maybe use GitHub action instead?

Add a user-side Bootstrap version upgrader in the post-hook. However, after writing this, it might actual be better to make a PR here rather than make a post-hook (this method could slow down template generation; not much, but could).

This PR also doesn't resolve that, if you're in a place with no internet, you'll be stuck with an older Bootstrap version. Though, I suppose most wouldn't be offline (though it's accounted for).

However, by making a post-hook, regardless of the template (if you haven't downloaded the latest), then you'll be happy to have an automated bootstrap versioner.
<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!-- 
Why does this project need the change you're proposing? 
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN` 
-->
