### PR TITLE
Bump pre-commit/action to 2.0.3

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # Getting only staged files can be tricky in case a new PR is opened
       # since the action is run on a branch in detached head state
       - name: Install and Run Pre-commit 
-        uses: pre-commit/action@v2.0.0
+        uses: pre-commit/action@v2.0.3
 
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:


### PR DESCRIPTION
Bump pre-commit/action to 2.0.3 so Dependabot will not PR this right after first push to GitHub.

## Description

Simply update pre-commit/action to 2.0.3.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Dependabot is already creating a PR to Bump pre-commit/action from version 2.0.0 to version 2.0.3 as soon as a project created with cookiecutter-django is pushed to GitHub.

This should also be committed in preparation for #3401.
