### PR TITLE
Cache Python dependencies on our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+          cache: pip
       - name: Install dependencies
         run: |
           python -m pip install -U pip
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+          cache: pip
       - name: Docker ${{ matrix.script.name }}
         run: sh tests/test_docker.sh ${{ matrix.script.args }}
 
@@ -85,6 +87,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+          cache: pip
+          cache-dependency-path: '**/requirements*.txt'
       - uses: actions/setup-node@v2
         with:
           node-version: "16"


### PR DESCRIPTION
## Description

Add caching of pip dependencies using [the solution](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/) provided by the official GitHub action `setup-python`.

Let's try it on the template first. Once we get it right, do the same in the generated projects.

## Rationale

Faster builds on CI