### PR TITLE
Removed mention of Foundation fork from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,6 @@ Features
 * Customizable PostgreSQL version
 * Default integration with pre-commit_ for identifying simple issues before submission to code review
 
-.. _`maintained Foundation fork`: https://github.com/Parbhat/cookiecutter-django-foundation
-
-
 Optional Integrations
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Features
 * For Django 3.1
 * Works with Python 3.9
 * Renders Django projects with 100% starting test coverage
-* Twitter Bootstrap_ v5 (`maintained Foundation fork`_ also available)
+* Twitter Bootstrap_ v5
 * 12-Factor_ based settings via django-environ_
 * Secure by default. We believe in SSL.
 * Optimized development and production settings


### PR DESCRIPTION
Simply erasing the "(maintained Foundation fork also available)" from readme.

## Description

The linked fork hasn't been updated in 2 years. I wouldn't classify it as maintained anymore.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale


The fork hasn't received any updates in the last 2 years, which have been of hectic development in the project. 

Advertising an unmaintained fork as being maintained in the readme is misleading o newcomers, and might lead them into making a bad decision whether to use the trunk or that unmaintained branch.

Maybe it is time to let it go.