### PR TITLE
Fix carriage return in `.gitignore` on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,17 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
 
-  tox:
-    runs-on: ubuntu-latest
-    name: "Test with tox"
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+
+    name: "Run tests"
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -26,14 +34,11 @@ jobs:
           python-version: "3.9"
           cache: pip
       - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U tox
-      - name: Run tox
-        run: tox -e py39
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests
 
   docker:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +49,7 @@ jobs:
             args: "use_celery=y use_drf=y js_task_runner=Gulp"
 
     name: "${{ matrix.script.name }} Docker"
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
@@ -58,7 +64,6 @@ jobs:
         run: sh tests/test_docker.sh ${{ matrix.script.args }}
 
   bare:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +73,7 @@ jobs:
           - name: With Gulp
             args: "js_task_runner=Gulp custom_bootstrap_compilation=y"
 
+    runs-on: ubuntu-latest
     name: "${{ matrix.script.name }} Bare metal"
     services:
       redis:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -139,13 +139,6 @@ def remove_dotgithub_folder():
     shutil.rmtree(".github")
 
 
-def append_to_project_gitignore(path):
-    gitignore_file_path = ".gitignore"
-    with open(gitignore_file_path, "a") as gitignore_file:
-        gitignore_file.write(path)
-        gitignore_file.write(os.linesep)
-
-
 def generate_random_string(
     length, using_digits=False, using_ascii_letters=False, using_punctuation=False
 ):
@@ -260,10 +253,10 @@ def set_celery_flower_password(file_path, value=None):
     return celery_flower_password
 
 
-def append_to_gitignore_file(s):
+def append_to_gitignore_file(ignored_line):
     with open(".gitignore", "a") as gitignore_file:
-        gitignore_file.write(s)
-        gitignore_file.write(os.linesep)
+        gitignore_file.write(ignored_line)
+        gitignore_file.write("\n")
 
 
 def set_flags_in_envs(postgres_user, celery_flower_user, debug=False):

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -1,14 +1,20 @@
 import os
 import re
+import sys
 
 import pytest
-import sh
+
+try:
+    import sh
+except (ImportError, ModuleNotFoundError):
+    sh = None  # sh doesn't support Windows
 import yaml
 from binaryornot.check import is_binary
 from cookiecutter.exceptions import FailedHookException
 
 PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
 RE_OBJ = re.compile(PATTERN)
+IS_WINDOWS = sys.platform.startswith("win")
 
 
 @pytest.fixture
@@ -111,7 +117,7 @@ UNSUPPORTED_COMBINATIONS = [
 
 
 def _fixture_id(ctx):
-    """Helper to get a user friendly test name from the parametrized context."""
+    """Helper to get a user-friendly test name from the parametrized context."""
     return "-".join(f"{key}:{value}" for key, value in ctx.items())
 
 
@@ -151,6 +157,7 @@ def test_project_generation(cookies, context, context_override):
     check_paths(paths)
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="sh doesn't support windows")
 @pytest.mark.parametrize("context_override", SUPPORTED_COMBINATIONS, ids=_fixture_id)
 def test_flake8_passes(cookies, context_override):
     """Generated project should pass flake8."""
@@ -162,6 +169,7 @@ def test_flake8_passes(cookies, context_override):
         pytest.fail(e.stdout.decode())
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="sh doesn't support windows")
 @pytest.mark.parametrize("context_override", SUPPORTED_COMBINATIONS, ids=_fixture_id)
 def test_black_passes(cookies, context_override):
     """Generated project should pass black."""
@@ -265,7 +273,7 @@ def test_github_invokes_linter_and_pytest(
 
 @pytest.mark.parametrize("slug", ["project slug", "Project_Slug"])
 def test_invalid_slug(cookies, context, slug):
-    """Invalid slug should failed pre-generation hook."""
+    """Invalid slug should fail pre-generation hook."""
     context.update({"project_slug": slug})
 
     result = cookies.bake(extra_context=context)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,28 @@
+"""Unit tests for the hooks"""
+import os
+from pathlib import Path
+
+import pytest
+
+from hooks.post_gen_project import append_to_gitignore_file
+
+
+@pytest.fixture()
+def working_directory(tmp_path):
+    prev_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(prev_cwd)
+
+
+def test_append_to_gitignore_file(working_directory):
+    gitignore_file = working_directory / ".gitignore"
+    gitignore_file.write_text("node_modules/\n")
+    append_to_gitignore_file(".envs/*")
+    linesep = os.linesep.encode()
+    assert (
+        gitignore_file.read_bytes() == b"node_modules/" + linesep + b".envs/*" + linesep
+    )
+    assert gitignore_file.read_text() == "node_modules/\n.envs/*\n"


### PR DESCRIPTION
## Description

Turns out that we shouldn't use `os.linesep` when writing to a file in text mode. From [the docs](https://docs.python.org/3/library/os.html#os.linesep):

> Do not use os.linesep as a line terminator when writing files opened in text mode (the default); use a single '\n' instead, on all platforms.

It can be a bit difficult to test platform specific bugs on post-generation hooks so I decided to start writing one.

Checklist:

- [x] I've made sure that `tests/test_cookiecutter_generation.py` is updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #3292