### PR TITLE
Fix BrowserSync config on non-Docker setup

### DIFF
--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -133,31 +133,31 @@ function runServer(cb) {
 
 // Browser sync server for live reload
 function initBrowserSync() {
-    browserSync.init(
-      [
-        `${paths.css}/*.css`,
-        `${paths.js}/*.js`,
-        `${paths.templates}/*.html`
-      ], {
-        // https://www.browsersync.io/docs/options/#option-proxy
+  browserSync.init(
+    [
+      `${paths.css}/*.css`,
+      `${paths.js}/*.js`,
+      `${paths.templates}/*.html`
+    ], {
+      // https://www.browsersync.io/docs/options/#option-proxy
+      proxy:  {
         {%- if cookiecutter.use_docker == 'n' %}
-        proxy: 'localhost:8000'
+        proxy: '127.0.0.1:8000',
         {%- else %}
-        proxy:  {
-          target: 'django:8000',
-          proxyReq: [
-            function(proxyReq, req) {
-              // Assign proxy "host" header same as current request at Browsersync server
-              proxyReq.setHeader('Host', req.headers.host)
-            }
-          ]
-        },
         // https://www.browsersync.io/docs/options/#option-open
         // Disable as it doesn't work from inside a container
-        open: false
+        open: false,
+        target: 'django:8000',
         {%- endif %}
+        proxyReq: [
+          function(proxyReq, req) {
+            // Assign proxy "host" header same as current request at Browsersync server
+            proxyReq.setHeader('Host', req.headers.host)
+          }
+        ]
       }
-    )
+    }
+  )
 }
 
 // Watch


### PR DESCRIPTION
## Description

The curent BrowserSync setup works with Docker, but not without. The localhost URL at port `3000` doesn't load, the page keeps loading forever. It seems to be an issue with the BrowserSync package, there are a few issues that seem related:

- https://github.com/BrowserSync/browser-sync/issues/1163
- https://github.com/BrowserSync/browser-sync/issues/936
- https://github.com/BrowserSync/browser-sync/issues/1667

The only difference I could find between the 2 setup was that Docker had a different hostname. I tried to proxy to a different hostname resolving to localhost and it fixed it.

Checklist:

- [x] I've made sure that tests are updated accordingly: n/a
- [x] I've updated the documentation or confirm that my change doesn't require any updates