### PR TITLE
Add a PyCharm run configuration for docker-compose

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{html,css,scss,json,yml}]
+[*.{html,css,scss,json,yml,xml}]
 indent_style = space
 indent_size = 2
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -62,7 +62,9 @@ def remove_docker_files():
     for file_name in file_names:
         os.remove(file_name)
     if "{{ cookiecutter.use_pycharm }}".lower() == "y":
-        os.remove(os.path.join(".idea", "runConfigurations", "docker_compose_up.xml"))
+        file_names = ["docker_compose_up_django.xml", "docker_compose_up_docs.xml"]
+        for file_name in file_names:
+            os.remove(os.path.join(".idea", "runConfigurations", file_name))
 
 
 def remove_utility_files():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -61,6 +61,8 @@ def remove_docker_files():
     file_names = ["local.yml", "production.yml", ".dockerignore"]
     for file_name in file_names:
         os.remove(file_name)
+    if "{{ cookiecutter.use_pycharm }}".lower() == "y":
+        os.remove(os.path.join(".idea", "runConfigurations", "docker_compose_up.xml"))
 
 
 def remove_utility_files():

--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{html,css,scss,json,yml}]
+[*.{html,css,scss,json,yml,xml}]
 indent_style = space
 indent_size = 2
 

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration name="docker-compose up" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value=""/>
+        <option name="services">
+          <list>
+            <option value="django"/>
+            <option value="node"/>
+          </list>
+        </option>
+        <option name="sourceFilePath" value="local.yml"/>
+      </settings>
+    </deployment>
+    <method v="2"/>
+  </configuration>
+</component>

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_django.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_django.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration name="docker-compose up django" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value=""/>
+        <option name="services">
+          <list>
+            <option value="django"/>
+            {%- if cookiecutter.use_celery == 'y' %}
+            <option value="celeryworker"/>
+            <option value="celerybeat"/>
+            {%- endif %}
+            {%- if cookiecutter.js_task_runner == 'Gulp' %}
+            <option value="node"/>
+            {%- endif %}
+          </list>
+        </option>
+        <option name="sourceFilePath" value="local.yml"/>
+      </settings>
+    </deployment>
+    <method v="2"/>
+  </configuration>
+</component>

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
@@ -1,12 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration name="docker-compose up" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+  <configuration name="docker-compose up django" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
         <option name="envFilePath" value=""/>
         <option name="services">
           <list>
-            <option value="django"/>
-            <option value="node"/>
+            <option value="docs"/>
           </list>
         </option>
         <option name="sourceFilePath" value="local.yml"/>

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration name="docker-compose up django" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+  <configuration name="docker-compose up docs" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
         <option name="envFilePath" value=""/>


### PR DESCRIPTION
## Description

Add 2 run configurations for running Django and running the docs.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

We already have a few run configurations but it would be nice to also provide one for docker-compose setups.
