### PR TITLE
Speed up CI tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           python-version: "3.9"
           cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Docker ${{ matrix.script.name }}
         run: sh tests/test_docker.sh ${{ matrix.script.args }}
 
@@ -99,6 +101,8 @@ jobs:
           python-version: "3.9"
           cache: pip
           cache-dependency-path: '**/requirements*.txt'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - uses: actions/setup-node@v2
         with:
           node-version: "16"

--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -6,13 +6,6 @@
 set -o errexit
 set -x
 
-# Install modern pip with new resolver:
-# https://blog.python.org/2020/11/pip-20-3-release-new-resolver.html
-pip install 'pip>=20.3'
-
-# install test requirements
-pip install -r requirements.txt
-
 # create a cache directory
 mkdir -p .cache/bare
 cd .cache/bare

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -14,7 +14,11 @@ from cookiecutter.exceptions import FailedHookException
 
 PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
 RE_OBJ = re.compile(PATTERN)
-IS_WINDOWS = sys.platform.startswith("win")
+
+if sys.platform.startswith("win"):
+    pytest.skip("sh doesn't support windows", allow_module_level=True)
+elif sys.platform.startswith("darwin") and os.getenv("CI"):
+    pytest.skip("skipping slow macOS tests on CI", allow_module_level=True)
 
 
 @pytest.fixture
@@ -157,7 +161,6 @@ def test_project_generation(cookies, context, context_override):
     check_paths(paths)
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="sh doesn't support windows")
 @pytest.mark.parametrize("context_override", SUPPORTED_COMBINATIONS, ids=_fixture_id)
 def test_flake8_passes(cookies, context_override):
     """Generated project should pass flake8."""
@@ -169,7 +172,6 @@ def test_flake8_passes(cookies, context_override):
         pytest.fail(e.stdout.decode())
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="sh doesn't support windows")
 @pytest.mark.parametrize("context_override", SUPPORTED_COMBINATIONS, ids=_fixture_id)
 def test_black_passes(cookies, context_override):
     """Generated project should pass black."""

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -6,9 +6,6 @@
 set -o errexit
 set -x
 
-# install test requirements
-pip install -r requirements.txt
-
 # create a cache directory
 mkdir -p .cache/docker
 cd .cache/docker


### PR DESCRIPTION
## Description

Skip platform independent tests on CI for macOS.

Checklist:

- [x] I've made sure that the tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

In #3456, I've improved the CI to run our tests on other platforms. However, the macOS tests take much longer to run (~8m vs ~3m on ubuntu) and most of them don't need to be retested, having them run on ubuntu is enough.
