### PR TITLE
Simplify `TEMPLATES` settings with `APP_DIRS=True`

### DIFF
--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -29,6 +29,9 @@ pre-commit run --show-diff-on-failure -a
 # run the project's tests
 pytest
 
+# Make sure the check doesn't raise any warnings
+python manage.py check --fail-level WARNING
+
 if [ -f "package.json" ]
 then
     npm install

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -35,3 +35,6 @@ docker-compose -f local.yml run django python manage.py makemigrations --dry-run
 
 # Test support for translations
 docker-compose -f local.yml run django python manage.py makemessages --all
+
+# Make sure the check doesn't raise any warnings
+docker-compose -f local.yml run django python manage.py check --fail-level WARNING

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -182,15 +182,11 @@ TEMPLATES = [
     {
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        # https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
+        # https://docs.djangoproject.com/en/dev/ref/settings/#dirs
         "DIRS": [str(APPS_DIR / "templates")],
+        # https://docs.djangoproject.com/en/dev/ref/settings/#app-dirs
+        "APP_DIRS": True,
         "OPTIONS": {
-            # https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
-            # https://docs.djangoproject.com/en/dev/ref/templates/api/#loader-types
-            "loaders": [
-                "django.template.loaders.filesystem.Loader",
-                "django.template.loaders.app_directories.Loader",
-            ],
             # https://docs.djangoproject.com/en/dev/ref/settings/#template-context-processors
             "context_processors": [
                 "django.template.context_processors.debug",

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -123,19 +123,6 @@ DEFAULT_FILE_STORAGE = "{{cookiecutter.project_slug}}.utils.storages.MediaRootGo
 MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/media/"
 {%- endif %}
 
-# TEMPLATES
-# ------------------------------------------------------------------------------
-# https://docs.djangoproject.com/en/dev/ref/settings/#templates
-TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
-    (
-        "django.template.loaders.cached.Loader",
-        [
-            "django.template.loaders.filesystem.Loader",
-            "django.template.loaders.app_directories.Loader",
-        ],
-    )
-]
-
 # EMAIL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email

--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -20,18 +20,6 @@ TEST_RUNNER = "django.test.runner.DiscoverRunner"
 # https://docs.djangoproject.com/en/dev/ref/settings/#password-hashers
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
-# TEMPLATES
-# ------------------------------------------------------------------------------
-TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa F405
-    (
-        "django.template.loaders.cached.Loader",
-        [
-            "django.template.loaders.filesystem.Loader",
-            "django.template.loaders.app_directories.Loader",
-        ],
-    )
-]
-
 # EMAIL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend


### PR DESCRIPTION
## Description

- Update test script to fail if the `check` command flags any warnings
- Simplify the `TEMPLATES` settings as explained [here](https://github.com/cookiecutter/cookiecutter-django/issues/3475#issuecomment-996186254) 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Our template settings are configuring the `loaders` option explicitely, and this option is optimised in the production/test setttings to wrap the `cached.Loader`, which duplciates this list of loaders in 3 places.

However, it seems that our config can be replicated by setting `APP_DIRS=True`:

- It has the same list of loaders when `DEBUG=True`
- When `DEBUG=False`, the list is wrapped with `cached.Loader`

Fixes #3475 
