### PR TITLE
Automatically add Django version label to issue

### DIFF
--- a/scripts/create_django_issue.py
+++ b/scripts/create_django_issue.py
@@ -264,9 +264,10 @@ class GitHubManager:
             issue.edit(body=description)
         else:
             print(f"Creating new issue for Django {needed_dj_version}")
-            self.repo.create_issue(
+            issue = self.repo.create_issue(
                 f"[Update Django] Django {needed_dj_version}", description
             )
+            issue.add_to_labels(f"django{needed_dj_version}")
 
     def generate(self):
         for version in self.needed_dj_versions:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Noticed you add django version label, so this should automate that as well (hopefully; this isn't tested). There isn't a GitHub API for PyGitHub for creating labels, so I'm thinking we create it here.
<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Automate more.
<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
