### PR TITLE
Fix missing psycopg2 dependency in docs Docker image

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -37,6 +37,8 @@ ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # To run the Makefile
   make \
+  # psycopg2 dependencies
+  libpq-dev \
   # Translations dependencies
   gettext \
   # Uncomment below lines to enable Sphinx output to latex and pdf


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Fix docs Dockerfile file (again). Not sure how a package leak happened because it worked yesterday, but not today. This should definitely make sure docs work (deleted container and brought volume back up)

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix docs
<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
