### PR TITLE
Add project.css and project.min.css to .gitignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -337,3 +337,8 @@ MailHog
 {%- if cookiecutter.use_docker == 'y' %}
 .ipython/
 {%- endif %}
+
+{%- if cookiecutter.js_task_runner == 'Gulp' %}
+project.css
+project.min.css
+{% endif %}

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -341,4 +341,6 @@ MailHog
 {%- if cookiecutter.js_task_runner == 'Gulp' %}
 project.css
 project.min.css
-{% endif %}
+vendors.js
+*.min.js
+{%- endif %}


### PR DESCRIPTION
Add project.css and project.min.css to .gitignore when js_task_runner == ' Gulp'. These files are generated automatically in this configuration and, as such, mess up git commit periodically.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

cookiecutter-django's default behavior when selecting Gulp as JS Task Runner will result in project.css and project.min.css to be regenerated automatically and periodically. 

These auto-generated files should not be part of the repo, as they will mess up version control development activities.


Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

According to [the docs](https://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html?highlight=css#sass-compilation-live-reloading), selecting Gulp as the JS Task Runner will cause the installation to recompile the SASS project.scss file into project.css (and presumably also project.min.css).

The project.css and project.min.css will show up as changed periodically and mess up development by forcing the user to discard in development or unnecessarily committed to the project repo.

Fix #2857 