### PR TITLE
Fix out-of-sync sequence for Site ID

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -4,10 +4,10 @@ To understand why this file is here, please read:
 http://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
 """
 from django.conf import settings
-from django.db import connection, migrations
+from django.db import migrations
 
 
-def _update_or_create_site_with_sequence(site_model, domain, name):
+def _update_or_create_site_with_sequence(site_model, connection, domain, name):
     """Update or create the site with default ID and keep the DB sequence in sync."""
     site, created = site_model.objects.update_or_create(
         id=settings.SITE_ID,
@@ -40,6 +40,7 @@ def update_site_forward(apps, schema_editor):
     Site = apps.get_model("sites", "Site")
     _update_or_create_site_with_sequence(
         Site,
+        schema_editor.connection,
         "{{cookiecutter.domain_name}}",
         "{{cookiecutter.project_name}}",
     )
@@ -50,6 +51,7 @@ def update_site_backward(apps, schema_editor):
     Site = apps.get_model("sites", "Site")
     _update_or_create_site_with_sequence(
         Site,
+        schema_editor.connection,
         "example.com",
         "example.com",
     )

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -27,12 +27,11 @@ def _update_or_create_site_with_sequence(site_model, connection, domain, name):
         with connection.cursor() as cursor:
             cursor.execute("SELECT last_value from django_site_id_seq")
             (current_id,) = cursor.fetchone()
-            if current_id < max_id:
+            if current_id <= max_id:
                 cursor.execute(
                     "alter sequence django_site_id_seq restart with %s",
                     [max_id + 1],
                 )
-                cursor.fetchone()
 
 
 def update_site_forward(apps, schema_editor):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -25,11 +25,11 @@ def _update_or_create_site_with_sequence(site_model, connection, domain, name):
         # greater than the maximum value.
         max_id = site_model.objects.order_by('-id').first().id
         with connection.cursor() as cursor:
-            cursor.execute("SELECT last_value from django_site_id")
+            cursor.execute("SELECT last_value from django_site_id_seq")
             (current_id,) = cursor.fetchone()
             if current_id < max_id:
                 cursor.execute(
-                    "alter sequence django_site_id restart with %s",
+                    "alter sequence django_site_id_seq restart with %s",
                     [max_id + 1],
                 )
                 cursor.fetchone()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -4,26 +4,54 @@ To understand why this file is here, please read:
 http://cookiecutter-django.readthedocs.io/en/latest/faq.html#why-is-there-a-django-contrib-sites-directory-in-cookiecutter-django
 """
 from django.conf import settings
-from django.db import migrations
+from django.db import connection, migrations
+
+
+def _update_or_create_site_with_sequence(site_model, domain, name):
+    """Update or create the site with default ID and keep the DB sequence in sync."""
+    site, created = site_model.objects.update_or_create(
+        id=settings.SITE_ID,
+        defaults={
+            "domain": domain,
+            "name": name,
+        },
+    )
+    if created:
+        # We provided the ID explicitly when creating the Site entry, therefore the DB
+        # sequence to auto-generate them wasn't used and is now out of sync. If we
+        # don't do anything, we'll get a unique constraint violation the next time a
+        # site is created.
+        # To avoid this, we need to manually update DB sequence and make sure it's
+        # greater than the maximum value.
+        max_id = site_model.objects.order_by('-id').first().id
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT last_value from django_site_id")
+            (current_id,) = cursor.fetchone()
+            if current_id < max_id:
+                cursor.execute(
+                    "alter sequence django_site_id restart with %s",
+                    [max_id + 1],
+                )
+                cursor.fetchone()
 
 
 def update_site_forward(apps, schema_editor):
     """Set site domain and name."""
     Site = apps.get_model("sites", "Site")
-    Site.objects.update_or_create(
-        id=settings.SITE_ID,
-        defaults={
-            "domain": "{{cookiecutter.domain_name}}",
-            "name": "{{cookiecutter.project_name}}",
-        },
+    _update_or_create_site_with_sequence(
+        Site,
+        "{{cookiecutter.domain_name}}",
+        "{{cookiecutter.project_name}}",
     )
 
 
 def update_site_backward(apps, schema_editor):
     """Revert site domain and name to default."""
     Site = apps.get_model("sites", "Site")
-    Site.objects.update_or_create(
-        id=settings.SITE_ID, defaults={"domain": "example.com", "name": "example.com"}
+    _update_or_create_site_with_sequence(
+        Site,
+        "example.com",
+        "example.com",
     )
 
 


### PR DESCRIPTION
## Description

Update sequence used to auto-generate primary keys for the `Site` model after creating the entry for the current site.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

See [explanation](https://github.com/cookiecutter/cookiecutter-django/discussions/3506#discussioncomment-1904938) in associated discussion.

Fix #3507