### PR TITLE
Double quote array expansions to avoid re-splitting elements

### DIFF
--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -11,7 +11,7 @@ mkdir -p .cache/bare
 cd .cache/bare
 
 # create the project using the default settings in cookiecutter.json
-cookiecutter ../../ --no-input --overwrite-if-exists use_docker=n $@
+cookiecutter ../../ --no-input --overwrite-if-exists use_docker=n "$@"
 cd my_awesome_project
 
 # Install OS deps

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -11,7 +11,7 @@ mkdir -p .cache/docker
 cd .cache/docker
 
 # create the project using the default settings in cookiecutter.json
-cookiecutter ../../ --no-input --overwrite-if-exists use_docker=y $@
+cookiecutter ../../ --no-input --overwrite-if-exists use_docker=y "$@"
 cd my_awesome_project
 
 # Lint by running pre-commit on all files

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 {%- if cookiecutter.use_docker == 'y' %}
 
   # Enable version updates for Docker
-  # We need to specify each Dockerfile in a separate entry because Dependabot doesn't 
+  # We need to specify each Dockerfile in a separate entry because Dependabot doesn't
   # support wildcards or recursively checking subdirectories. Check this issue for updates:
   # https://github.com/dependabot/dependabot-core/issues/2178
   - package-ecosystem: "docker"
@@ -38,7 +38,7 @@ updates:
     # Check for updates to GitHub Actions every weekday
     schedule:
       interval: "daily"
-  
+
   # Enable version updates for Docker
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `compose/production/aws` directory

--- a/{{cookiecutter.project_slug}}/.idea/{{cookiecutter.project_slug}}.iml
+++ b/{{cookiecutter.project_slug}}/.idea/{{cookiecutter.project_slug}}.iml
@@ -14,11 +14,11 @@
   </component>
   <component name="NewModuleRootManager">
     {% if cookiecutter.js_task_runner != 'None' %}
-    <content url="file://$MODULE_DIR$"> 
+    <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/node_modules" />
     </content>
-    {% else %} 
-    <content url="file://$MODULE_DIR$" /> 
+    {% else %}
+    <content url="file://$MODULE_DIR$" />
     {% endif %}
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -119,7 +119,7 @@
     {% block inline_javascript %}
     {% comment %}
     Script tags with only code, no src (defer by default). To run
-    with a "defer" so that you run run inline code:
+    with a "defer" so that you run inline code:
     <script>
       window.addEventListener('DOMContentLoaded', () => {/* Run whatever you want */});
     </script>


### PR DESCRIPTION
## Description

Add double quotes around array expansion in bash scripts used for testing.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

If one argument includes spaces, the expansion will be wrong. Add double quotes to avoid that.

https://github.com/koalaman/shellcheck/wiki/SC2068
