### PR TITLE
Add UserSignupForm and UserSocialSignupForm

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -306,8 +306,12 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_ADAPTER = "{{cookiecutter.project_slug}}.users.adapters.AccountAdapter"
+# https://django-allauth.readthedocs.io/en/latest/forms.html
+ACCOUNT_FORMS = {"signup": "{{cookiecutter.project_slug}}.users.forms.UserSignupForm"}
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 SOCIALACCOUNT_ADAPTER = "{{cookiecutter.project_slug}}.users.adapters.SocialAccountAdapter"
+# https://django-allauth.readthedocs.io/en/latest/forms.html
+SOCIALACCOUNT_FORMS = {"signup": "{{cookiecutter.project_slug}}.users.forms.UserSocialSignupForm"}
 {% if cookiecutter.use_compressor == 'y' -%}
 # django-compressor
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -3,7 +3,7 @@ from django.contrib.auth import admin as auth_admin
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
-from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm, UserCreationForm
+from {{ cookiecutter.project_slug }}.users.forms import UserAdminChangeForm, UserAdminCreationForm
 
 User = get_user_model()
 
@@ -11,8 +11,8 @@ User = get_user_model()
 @admin.register(User)
 class UserAdmin(auth_admin.UserAdmin):
 
-    form = UserChangeForm
-    add_form = UserCreationForm
+    form = UserAdminChangeForm
+    add_form = UserAdminCreationForm
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("name", "email")}),

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -17,6 +17,7 @@ class UserCreationForm(admin_forms.UserCreationForm):
     Form for User Creation in the Admin Area.
     To change user signup, see UserSignupForm and UserSocialSignupForm.
     """
+
     class Meta(admin_forms.UserCreationForm.Meta):
         model = User
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -1,5 +1,7 @@
 from django.contrib.auth import forms as admin_forms
 from django.contrib.auth import get_user_model
+from allauth.account.forms import SignupForm
+from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from django.utils.translation import gettext_lazy as _
 
 User = get_user_model()
@@ -11,9 +13,56 @@ class UserChangeForm(admin_forms.UserChangeForm):
 
 
 class UserCreationForm(admin_forms.UserCreationForm):
+    """
+    Form for User Creation in the Admin Area.  
+    To change user signup, see UserSignupForm and UserSocialSignupForm.
+    """
     class Meta(admin_forms.UserCreationForm.Meta):
         model = User
 
         error_messages = {
             "username": {"unique": _("This username has already been taken.")}
         }
+
+class UserSignupForm(SignupForm):
+    """
+    Form that will be rendered on a user sign up section/screen.
+    Default fields will be added automatically.
+    Check UserSocialSignupForm for accounts created from social.
+    """
+
+    def save(self, request):
+
+        # Ensure you call the parent class's save.
+        # .save() returns a User object.
+        user = super(UserSignupForm, self).save(request)
+
+        # Add your own processing here.
+
+        # You must return the original result.
+        return user
+
+
+    class Meta:
+        model = User
+    
+class UserSocialSignupForm(SocialSignupForm):
+    """
+    Renders the form when user has signed up using social accounts.
+    Default fields will be added automatically.
+    See UserSignupForm otherwise.
+    """
+
+    def save(self, request):
+
+        # Ensure you call the parent class's save.
+        # .save() returns a User object.
+        user = super(UserSocialSignupForm, self).save(request)
+
+        # Add your own processing here.
+
+        # You must return the original result.
+        return user
+
+    class Meta:
+        model = User

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -7,12 +7,12 @@ from django.utils.translation import gettext_lazy as _
 User = get_user_model()
 
 
-class UserChangeForm(admin_forms.UserChangeForm):
+class UserAdminChangeForm(admin_forms.UserChangeForm):
     class Meta(admin_forms.UserChangeForm.Meta):
         model = User
 
 
-class UserCreationForm(admin_forms.UserCreationForm):
+class UserAdminCreationForm(admin_forms.UserCreationForm):
     """
     Form for User Creation in the Admin Area.
     To change user signup, see UserSignupForm and UserSocialSignupForm.

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -1,7 +1,7 @@
-from django.contrib.auth import forms as admin_forms
-from django.contrib.auth import get_user_model
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
+from django.contrib.auth import forms as admin_forms
+from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
 User = get_user_model()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -14,7 +14,7 @@ class UserChangeForm(admin_forms.UserChangeForm):
 
 class UserCreationForm(admin_forms.UserCreationForm):
     """
-    Form for User Creation in the Admin Area.  
+    Form for User Creation in the Admin Area.
     To change user signup, see UserSignupForm and UserSocialSignupForm.
     """
     class Meta(admin_forms.UserCreationForm.Meta):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -24,6 +24,7 @@ class UserCreationForm(admin_forms.UserCreationForm):
             "username": {"unique": _("This username has already been taken.")}
         }
 
+
 class UserSignupForm(SignupForm):
     """
     Form that will be rendered on a user sign up section/screen.
@@ -33,6 +34,8 @@ class UserSignupForm(SignupForm):
 
     class Meta:
         model = User
+
+
 class UserSocialSignupForm(SocialSignupForm):
     """
     Renders the form when user has signed up using social accounts.

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -33,9 +33,6 @@ class UserSignupForm(SignupForm):
     Check UserSocialSignupForm for accounts created from social.
     """
 
-    class Meta:
-        model = User
-
 
 class UserSocialSignupForm(SocialSignupForm):
     """
@@ -43,6 +40,3 @@ class UserSocialSignupForm(SocialSignupForm):
     Default fields will be added automatically.
     See UserSignupForm otherwise.
     """
-
-    class Meta:
-        model = User

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -41,16 +41,5 @@ class UserSocialSignupForm(SocialSignupForm):
     See UserSignupForm otherwise.
     """
 
-    def save(self, request):
-
-        # Ensure you call the parent class's save.
-        # .save() returns a User object.
-        user = super(UserSocialSignupForm, self).save(request)
-
-        # Add your own processing here.
-
-        # You must return the original result.
-        return user
-
     class Meta:
         model = User

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -33,7 +33,6 @@ class UserSignupForm(SignupForm):
 
     class Meta:
         model = User
-    
 class UserSocialSignupForm(SocialSignupForm):
     """
     Renders the form when user has signed up using social accounts.

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/forms.py
@@ -31,18 +31,6 @@ class UserSignupForm(SignupForm):
     Check UserSocialSignupForm for accounts created from social.
     """
 
-    def save(self, request):
-
-        # Ensure you call the parent class's save.
-        # .save() returns a User object.
-        user = super(UserSignupForm, self).save(request)
-
-        # Add your own processing here.
-
-        # You must return the original result.
-        return user
-
-
     class Meta:
         model = User
     

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/models.py
@@ -5,7 +5,11 @@ from django.utils.translation import gettext_lazy as _
 
 
 class User(AbstractUser):
-    """Default user for {{cookiecutter.project_name}}."""
+    """
+    Default custom user model for {{cookiecutter.project_name}}.
+    If adding fields that need to be filled at user signup,
+    check forms.SignupForm and forms.SocialSignupForms accordingly.
+    """
 
     #: First and last name do not cover name patterns around the globe
     name = CharField(_("Name of User"), blank=True, max_length=255)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_forms.py
@@ -4,20 +4,20 @@ Module for all Form Tests.
 import pytest
 from django.utils.translation import gettext_lazy as _
 
-from {{ cookiecutter.project_slug }}.users.forms import UserCreationForm
+from {{ cookiecutter.project_slug }}.users.forms import UserAdminCreationForm
 from {{ cookiecutter.project_slug }}.users.models import User
 
 pytestmark = pytest.mark.django_db
 
 
-class TestUserCreationForm:
+class TestUserAdminCreationForm:
     """
-    Test class for all tests related to the UserCreationForm
+    Test class for all tests related to the UserAdminCreationForm
     """
 
     def test_username_validation_error_msg(self, user: User):
         """
-        Tests UserCreation Form's unique validator functions correctly by testing:
+        Tests UserAdminCreation Form's unique validator functions correctly by testing:
             1) A new user with an existing username cannot be added.
             2) Only 1 error is raised by the UserCreation Form
             3) The desired error message is raised
@@ -25,7 +25,7 @@ class TestUserCreationForm:
 
         # The user already exists,
         # hence cannot be created.
-        form = UserCreationForm(
+        form = UserAdminCreationForm(
             {
                 "username": user.username,
                 "password1": user.password,

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.test import RequestFactory
 from django.urls import reverse
 
-from {{ cookiecutter.project_slug }}.users.forms import UserChangeForm
+from {{ cookiecutter.project_slug }}.users.forms import UserAdminChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
 from {{ cookiecutter.project_slug }}.users.views import (
@@ -62,7 +62,7 @@ class TestUserUpdateView:
         view.request = request
 
         # Initialize the form
-        form = UserChangeForm()
+        form = UserAdminChangeForm()
         form.cleaned_data = []
         view.form_valid(form)
 


### PR DESCRIPTION
Add UserSignupForm and UserSocialSignupForm
And docstrings clarifying how to use Custom User Model and Signup Forms.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

The proposal is based on the discussion in issue #2708, and how hard it is to currently understand/use the Custom User Model shipper with cookiecutter-django. 

Creating the stub UserSignupForm and UserSocialSignupForm will certainly save hours (if not more) of research and trial-and-error for users wanting to expand the default User class.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

The proposal is to ship the explicit Form Classes that can be used to expand the Signup Process and clarify the class that concerns the Admin User Creation process that is already present.

Fix #2708
Fix #450 