### PR TITLE
Fix `open` option for `initBrowserSync` when using Docker

### DIFF
--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -139,9 +139,11 @@ function initBrowserSync() {
       `${paths.js}/*.js`,
       `${paths.templates}/*.html`
     ], {
+      {%- if cookiecutter.use_docker == 'y' %}
       // https://www.browsersync.io/docs/options/#option-open
       // Disable as it doesn't work from inside a container
       open: false,
+      {%- endif %}
       // https://www.browsersync.io/docs/options/#option-proxy
       proxy:  {
         {%- if cookiecutter.use_docker == 'n' %}

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -139,14 +139,14 @@ function initBrowserSync() {
       `${paths.js}/*.js`,
       `${paths.templates}/*.html`
     ], {
+      // https://www.browsersync.io/docs/options/#option-open
+      // Disable as it doesn't work from inside a container
+      open: false,
       // https://www.browsersync.io/docs/options/#option-proxy
       proxy:  {
         {%- if cookiecutter.use_docker == 'n' %}
         target: '127.0.0.1:8000',
         {%- else %}
-        // https://www.browsersync.io/docs/options/#option-open
-        // Disable as it doesn't work from inside a container
-        open: false,
         target: 'django:8000',
         {%- endif %}
         proxyReq: [


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description
Fix for initBrowserSync open option

Error:
```
'initBrowserSync' errored after 225 ms
Error: Cannot set unknown key "open" on Record
```
<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
