### PR TITLE
Fix cache dependency path for linter job in CI workflow

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: "3.9"
           cache: pip
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/local.txt
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -27,8 +27,8 @@ if compress_enabled; then
   python /app/manage.py compress
 fi
 {%- endif %}
-{% if cookiecutter.use_async == 'y' %}
+{%- if cookiecutter.use_async == 'y' %}
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
-{% else %}
+{%- else %}
 /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -2,11 +2,11 @@
 import logging
 
 import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.logging import LoggingIntegration
 {%- if cookiecutter.use_celery == 'y' %}
 from sentry_sdk.integrations.celery import CeleryIntegration
-{% endif %}
+{%- endif %}
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
 {% endif -%}
@@ -127,7 +127,8 @@ MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/media/"
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = env(
-    "DJANGO_DEFAULT_FROM_EMAIL", default="{{cookiecutter.project_name}} <noreply@{{cookiecutter.domain_name}}>"
+    "DJANGO_DEFAULT_FROM_EMAIL",
+    default="{{cookiecutter.project_name}} <noreply@{{cookiecutter.domain_name}}>",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
## Description

Specify cache-dependency-path on GitHub workflows as the default `**/requirements.txt` doesn't match any files and break.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

See it in action on [this demo repo](https://github.com/browniebroke/blah):

- intital error: https://github.com/browniebroke/blah/runs/4742128074?check_suite_focus=true#step:3:10
- after fixing the dependency path: https://github.com/browniebroke/blah/runs/4742193102?check_suite_focus=true#step:4:47
- the rest are to avoid stylistic issues, but `isort` might fail for very short project names and there is little we can do about it IMO

## Rationale

Fix #3517
