### PR TITLE
Avoid docker image/volume collision by prefixing with project slug

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -167,16 +167,18 @@ docker
 
 The ``container_name`` from the yml file can be used to check on containers with docker commands, for example: ::
 
-    $ docker logs worker
-    $ docker top worker
+    $ docker logs <project_slug>_local_celeryworker
+    $ docker top <project_slug>_local_celeryworker
 
+
+Notice that the ``container_name`` is generated dynamically using your project slug as a prefix
 
 Mailhog
 ~~~~~~~
 
 When developing locally you can go with MailHog_ for email testing provided ``use_mailhog`` was set to ``y`` on setup. To proceed,
 
-#. make sure ``mailhog`` container is up and running;
+#. make sure ``<project_slug>_local_mailhog`` container is up and running;
 
 #. open up ``http://127.0.0.1:8025``.
 

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -33,7 +33,7 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_postgres
-    container_name: {{ cookiecutter.project_slug }}_production_postgres
+    container_name: {{ cookiecutter.project_slug }}_local_postgres
     volumes:
       - {{ cookiecutter.project_slug }}_local_postgres_data:/var/lib/postgresql/data:Z
       - {{ cookiecutter.project_slug }}_local_postgres_data_backups:/backups:z

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -10,7 +10,7 @@ services:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
     image: {{ cookiecutter.project_slug }}_local_django
-    container_name: django
+    container_name: {{ cookiecutter.project_slug }}_local_django
     depends_on:
       - postgres
       {%- if cookiecutter.use_celery == 'y' %}
@@ -33,7 +33,7 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_postgres
-    container_name: postgres
+    container_name: {{ cookiecutter.project_slug }}_production_postgres
     volumes:
       - local_postgres_data:/var/lib/postgresql/data:Z
       - local_postgres_data_backups:/backups:z
@@ -42,7 +42,7 @@ services:
 
   docs:
     image: {{ cookiecutter.project_slug }}_local_docs
-    container_name: docs
+    container_name: {{ cookiecutter.project_slug }}_local_docs
     build:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile
@@ -59,7 +59,7 @@ services:
 
   mailhog:
     image: mailhog/mailhog:v1.0.0
-    container_name: mailhog
+    container_name: {{ cookiecutter.project_slug }}_local_mailhog
     ports:
       - "8025:8025"
 
@@ -68,12 +68,12 @@ services:
 
   redis:
     image: redis:6
-    container_name: redis
+    container_name: {{ cookiecutter.project_slug }}_local_redis
 
   celeryworker:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_celeryworker
-    container_name: celeryworker
+    container_name: {{ cookiecutter.project_slug }}_local_celeryworker
     depends_on:
       - redis
       - postgres
@@ -86,7 +86,7 @@ services:
   celerybeat:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_celerybeat
-    container_name: celerybeat
+    container_name: {{ cookiecutter.project_slug }}_local_celerybeat
     depends_on:
       - redis
       - postgres
@@ -99,7 +99,7 @@ services:
   flower:
     <<: *django
     image: {{ cookiecutter.project_slug }}_local_flower
-    container_name: flower
+    container_name: {{ cookiecutter.project_slug }}_local_flower
     ports:
       - "5555:5555"
     command: /start-flower
@@ -112,7 +112,7 @@ services:
       context: .
       dockerfile: ./compose/local/node/Dockerfile
     image: {{ cookiecutter.project_slug }}_local_node
-    container_name: node
+    container_name: {{ cookiecutter.project_slug }}_local_node
     depends_on:
       - django
     volumes:

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 volumes:
-  local_postgres_data: {}
-  local_postgres_data_backups: {}
+  {{ cookiecutter.project_slug }}_local_postgres_data: {}
+  {{ cookiecutter.project_slug }}_local_postgres_data_backups: {}
 
 services:
   django:{% if cookiecutter.use_celery == 'y' %} &django{% endif %}
@@ -35,8 +35,8 @@ services:
     image: {{ cookiecutter.project_slug }}_production_postgres
     container_name: {{ cookiecutter.project_slug }}_production_postgres
     volumes:
-      - local_postgres_data:/var/lib/postgresql/data:Z
-      - local_postgres_data_backups:/backups:z
+      - {{ cookiecutter.project_slug }}_local_postgres_data:/var/lib/postgresql/data:Z
+      - {{ cookiecutter.project_slug }}_local_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.local/.postgres
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Hi, it's my first contribution ever, this pull request is related to issue #3254 and issue #2849. 
The problem happens when we create a second django-cookiecutter project on our dev machine, there is a conflict between the ``container_name: postgres`` from the first project with the new one:

```
ERROR: for postgres  Cannot create container for service postgres: Conflict. The container name "/postgres" is already in use by container "...". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for docs  Cannot create container for service docs: Conflict. The container name "/docs" is already in use by container "...". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for postgres  Cannot create container for service postgres: Conflict. The container name "/postgres" is already in use by container "...". You have to remove (or rename) that container to be able to reuse that name.
ERROR: Encountered errors while bringing up the project.
```


Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale


To avoid conflict, the ```compose_name``` has now a prefix of the ```project_slug``` defined on the project creation.
Fix #2849 
Fix #3254 

