### PR TITLE
Fix high CPU usage when running `runserver_plus` in Docker

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-Werkzeug==2.0.2 # https://github.com/pallets/werkzeug
+Werkzeug[watchdog]==2.0.2 # https://github.com/pallets/werkzeug
 ipdb==0.13.9  # https://github.com/gotcha/ipdb
 {%- if cookiecutter.use_docker == 'y' %}
 psycopg2==2.9.3  # https://github.com/psycopg/psycopg2


### PR DESCRIPTION
## Description

Installing the `watchdog` package enables the `runserver_plus` auto-reload feature to [use file system events instead of consrtant file polling](https://django-extensions.readthedocs.io/en/latest/runserver_plus.html#io-calls-and-cpu-usage).

This is a fix for issue #3523.

## Rationale

See issue #3523 for full description of the problem. As a summary, it fixes a high-cpu usage problem for the local development server.

Fix #3523