### PR TITLE
Add swagger API documentation when DRF is enabled 

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -327,6 +327,11 @@ def remove_drf_starter_files():
             "{{cookiecutter.project_slug}}", "users", "tests", "test_drf_views.py"
         )
     )
+    os.remove(
+        os.path.join(
+            "{{cookiecutter.project_slug}}", "users", "tests", "test_swagger_ui.py"
+        )
+    )
 
 
 def remove_storages_module():

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -336,11 +336,26 @@ REST_FRAMEWORK = {
 CORS_URLS_REGEX = r"^/api/.*$"
 
 # By Default swagger ui is available only to admin user. You can change permission classs to change that
+# See more configuration options at https://drf-spectacular.readthedocs.io/en/latest/settings.html#settings
 SPECTACULAR_SETTINGS = {
-    "TITLE": "API documentation for{{ cookiecutter.project_slug }}",
-    "DESCRIPTION": "Lets rock and then roll!",
+    "TITLE": "{{ cookiecutter.project_name }} API",
+    "DESCRIPTION": "Documentation of API endpoiints of {{ cookiecutter.project_name }}",
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
+    "SERVERS": [
+        {
+            "url": "https://127.0.0.1:8000",
+            "description": "Local Development server"
+        },
+#        {
+#            "url": "https://staging.{{ cookiecutter.domain_name }}",
+#            "description": "Development server"
+#        },
+        {
+            "url": 'https://{{ cookiecutter.domain_name }}",
+            "description": "Production server"
+        }
+    ],
 }
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -343,18 +343,8 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "SERVERS": [
-        {
-            "url": "https://127.0.0.1:8000",
-            "description": "Local Development server"
-        },
-#        {
-#            "url": "https://staging.{{ cookiecutter.domain_name }}",
-#            "description": "Development server"
-#        },
-        {
-            "url": 'https://{{ cookiecutter.domain_name }}",
-            "description": "Production server"
-        }
+        {"url": "https://127.0.0.1:8000", "description": "Local Development server"},
+        {"url": "https://example.com", "description": "Production server"},
     ],
 }
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -84,6 +84,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
+    "drf_spectacular",
 {%- endif %}
 ]
 
@@ -334,6 +335,13 @@ REST_FRAMEWORK = {
 # django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup
 CORS_URLS_REGEX = r"^/api/.*$"
 
+# By Default swagger ui is available only to admin user. You can change permission classs to change that
+SPECTACULAR_SETTINGS = {
+    "TITLE": "{{ cookiecutter.project_slug }} API",
+    "DESCRIPTION": "Lets rock and then roll!",
+    "VERSION": "1.0.0",
+    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
+}
 {%- endif %}
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -337,7 +337,7 @@ CORS_URLS_REGEX = r"^/api/.*$"
 
 # By Default swagger ui is available only to admin user. You can change permission classs to change that
 SPECTACULAR_SETTINGS = {
-    "TITLE": "{{ cookiecutter.project_slug }} API",
+    "TITLE": "API documentation for{{ cookiecutter.project_slug }}",
     "DESCRIPTION": "Lets rock and then roll!",
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -344,7 +344,7 @@ SPECTACULAR_SETTINGS = {
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "SERVERS": [
         {"url": "https://127.0.0.1:8000", "description": "Local Development server"},
-        {"url": "https://example.com", "description": "Production server"},
+        {"url": "https://{{ cookiecutter.domain_name }}", "description": "Production server"},
     ],
 }
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -36,9 +36,11 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("auth-token/", obtain_auth_token),
-    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
-        "swagger/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"
+        "api/docs/",
+        SpectacularSwaggerView.as_view(url_name="api-schema"),
+        name="api-docs",
     ),
 ]
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -8,6 +8,7 @@ from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
 {%- if cookiecutter.use_drf == 'y' %}
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 {%- endif %}
 
@@ -35,6 +36,10 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("auth-token/", obtain_auth_token),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "swagger/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"
+    ),
 ]
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -43,4 +43,6 @@ django-redis==5.2.0  # https://github.com/jazzband/django-redis
 # Django REST Framework
 djangorestframework==3.13.1  # https://github.com/encode/django-rest-framework
 django-cors-headers==3.11.0 # https://github.com/adamchainz/django-cors-headers
+# DRF-spectacular for api documentation
+drf-spectacular==0.21.1
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger_ui.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger_ui.py
@@ -5,12 +5,12 @@ pytestmark = pytest.mark.django_db
 
 
 def test_swagger_accessible_by_admin(admin_client):
-    url = reverse("swagger-ui")
+    url = reverse("api-docs")
     response = admin_client.get(url)
     assert response.status_code == 200
 
 
 def test_swagger_ui_not_accessible_by_normal_user(client):
-    url = reverse("swagger-ui")
+    url = reverse("api-docs")
     response = client.get(url)
     assert response.status_code == 403

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger_ui.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger_ui.py
@@ -1,0 +1,16 @@
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_swagger_accessible_by_admin(admin_client):
+    url = reverse("swagger-ui")
+    response = admin_client.get(url)
+    assert response.status_code == 200
+
+
+def test_swagger_ui_not_accessible_by_normal_user(client):
+    url = reverse("swagger-ui")
+    response = client.get(url)
+    assert response.status_code == 403


### PR DESCRIPTION
Changes
* Integrate drf-spectacular module
* Added routes and tests for swagger-ui

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Integrate Swagger UI when DRF is enabled. Refer to Issue #3533 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #3533 
