### PR TITLE
Cancel previous CI runs on successive PR pushes with GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,13 @@ on:
     branches:
       - "master"
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -32,9 +33,6 @@ jobs:
 
     name: "Run tests"
     runs-on: ${{ matrix.os }}
-    concurrency:
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -58,9 +56,6 @@ jobs:
 
     name: "${{ matrix.script.name }} Docker"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
@@ -88,9 +83,6 @@ jobs:
 
     name: "${{ matrix.script.name }} Bare metal"
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     services:
       redis:
         image: redis:5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-    branches:
-      - "master"
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+    branches:
+      - "master"
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -27,6 +30,9 @@ jobs:
 
     name: "Run tests"
     runs-on: ${{ matrix.os }}
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -50,6 +56,9 @@ jobs:
 
     name: "${{ matrix.script.name }} Docker"
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     env:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
@@ -75,8 +84,11 @@ jobs:
           - name: With Gulp
             args: "js_task_runner=Gulp custom_bootstrap_compilation=y"
 
-    runs-on: ubuntu-latest
     name: "${{ matrix.script.name }} Bare metal"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     services:
       redis:
         image: redis:5.0

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ on:
     branches: [ "master", "main" ]
     paths-ignore: [ "docs/**" ]
 
+concurrency:
+  group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
+  cancel-in-progress: true
 
 jobs:
   linter:
     runs-on: ubuntu-latest
-    concurrency:
-      group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
-      cancel-in-progress: true
     steps:
 
       - name: Checkout Code Repository
@@ -41,9 +41,6 @@ jobs:
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:
     runs-on: ubuntu-latest
-    concurrency:
-      group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
-      cancel-in-progress: true
     {%- if cookiecutter.use_docker == 'n' %}
 
     services:

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    concurrency:
+      group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
+      cancel-in-progress: true
     steps:
 
       - name: Checkout Code Repository
@@ -38,6 +41,9 @@ jobs:
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:
     runs-on: ubuntu-latest
+    concurrency:
+      group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
+      cancel-in-progress: true
     {%- if cookiecutter.use_docker == 'n' %}
 
     services:


### PR DESCRIPTION
## Description

Add [a concurrency group](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value) based on the GitHub PR branch.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

[Save some time and processing power.](https://twitter.com/AdamChainz/status/1485572084617121796)


