### PR TITLE
Fix GitLab CI error caused by Docker Compose's `platform` option

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -22,7 +22,7 @@ flake8:
 pytest:
   stage: test
   {% if cookiecutter.use_docker == 'y' -%}
-  image: docker/compose:latest
+  image: docker/compose:1.29.2
   tags:
     - docker
   services:


### PR DESCRIPTION
The `latest` tag of the docker compose image is not updated for more than two years. Version 1.26.2, where the latest tag points to, has trouble with the `platfrom` configuration option. Pinning it to the latest version will solve this. 

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Fix #3584 
