### PR TITLE
Change docs port from 7000 to 9000

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -13,7 +13,7 @@ If you set up your project to `develop locally with docker`_, run the following 
 
     $ docker-compose -f local.yml up docs
 
-Navigate to port 7000 on your host to see the documentation. This will be opened automatically at `localhost`_ for local, non-docker development.
+Navigate to port 9000 on your host to see the documentation. This will be opened automatically at `localhost`_ for local, non-docker development.
 
 Note: using Docker for documentation sets up a temporary SQLite file by setting the environment variable ``DATABASE_URL=sqlite:///readthedocs.db`` in ``docs/conf.py`` to avoid a dependency on PostgreSQL.
 
@@ -36,7 +36,7 @@ To setup your documentation on `ReadTheDocs`_, you must
 
 Additionally, you can auto-build Pull Request previews, but `you must enable it`_.
 
-.. _localhost: http://localhost:7000/
+.. _localhost: http://localhost:9000/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/index.html
 .. _develop locally: ./developing-locally.html
 .. _develop locally with docker: ./developing-locally-docker.html

--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= 
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = ./_build
@@ -21,10 +21,10 @@ help:
 
 # Build, watch and serve docs with live reload
 livehtml:
-	sphinx-autobuild -b html 
+	sphinx-autobuild -b html
 	{%- if cookiecutter.use_docker == 'y' %} --host 0.0.0.0
-	{%- else %} --open-browser 
-	{%- endif %} --port 7000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
+	{%- else %} --open-browser
+	{%- endif %} --port 9000 --watch $(APP) -c . $(SOURCEDIR) $(BUILDDIR)/html
 
 # Outputs rst files from django application code
 apidocs:

--- a/{{cookiecutter.project_slug}}/docs/make.bat
+++ b/{{cookiecutter.project_slug}}/docs/make.bat
@@ -32,7 +32,7 @@ if errorlevel 9009 (
 goto end
 
 :livehtml
-sphinx-autobuild -b html --open-browser -p 7000 --watch %APP% -c . %SOURCEDIR% %BUILDDIR%/html
+sphinx-autobuild -b html --open-browser -p 9000 --watch %APP% -c . %SOURCEDIR% %BUILDDIR%/html
 GOTO :EOF
 
 :apidocs

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -55,7 +55,7 @@ services:
       - ./config:/app/config:z
       - ./{{ cookiecutter.project_slug }}:/app/{{ cookiecutter.project_slug }}:z
     ports:
-      - "7000:7000"
+      - "9000:9000"
     command: /start-docs
   {%- if cookiecutter.use_mailhog == 'y' %}
 


### PR DESCRIPTION
Signed-off-by: Andrew-Chen-Wang <acwangpython@gmail.com>

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Change docs port from 7000 to 9000
<!-- What's it you're proposing? -->

Fixes #3499
Fixes #3589 

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

afs port on Mac is used due to airplay.
<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
