### PR TITLE
fix typo in servers settings for drf-spectacular

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -346,7 +346,7 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "SERVERS": [
-        {"url": "https://127.0.0.1:8000", "description": "Local Development server"},
+        {"url": "http://127.0.0.1:8000", "description": "Local Development server"},
         {"url": "https://{{ cookiecutter.domain_name }}", "description": "Production server"},
     ],
 }


### PR DESCRIPTION
update the local dev server url to use http instead of https

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
