### PR TITLE
Fix Swagger schema API endpoint & add a test for it

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -329,7 +329,7 @@ def remove_drf_starter_files():
     )
     os.remove(
         os.path.join(
-            "{{cookiecutter.project_slug}}", "users", "tests", "test_swagger_ui.py"
+            "{{cookiecutter.project_slug}}", "users", "tests", "test_swagger.py"
         )
     )
 

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -333,6 +333,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 # django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -34,8 +34,7 @@ class TestUserViewSet:
         }
 
 
-class TestAPISchemaView:
-    def test_api_schema_generated_successfully(self, admin_client):
-        url = reverse("api-schema")
-        response = admin_client.get(url)
-        assert response.status_code == 200
+def test_api_schema_generated_successfully(admin_client):
+    url = reverse("api-schema")
+    response = admin_client.get(url)
+    assert response.status_code == 200

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.test import RequestFactory
+from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.models import User
@@ -31,3 +32,10 @@ class TestUserViewSet:
             "name": user.name,
             "url": f"http://testserver/api/users/{user.username}/",
         }
+
+
+class TestAPISchemaView:
+    def test_api_schema_generated_successfully(self, admin_client):
+        url = reverse("api-schema")
+        response = admin_client.get(url)
+        assert response.status_code == 200

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,6 +1,5 @@
 import pytest
 from django.test import RequestFactory
-from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.models import User
@@ -32,9 +31,3 @@ class TestUserViewSet:
             "name": user.name,
             "url": f"http://testserver/api/users/{user.username}/",
         }
-
-
-def test_api_schema_generated_successfully(admin_client):
-    url = reverse("api-schema")
-    response = admin_client.get(url)
-    assert response.status_code == 200

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger.py
@@ -14,3 +14,9 @@ def test_swagger_ui_not_accessible_by_normal_user(client):
     url = reverse("api-docs")
     response = client.get(url)
     assert response.status_code == 403
+
+
+def test_api_schema_generated_successfully(admin_client):
+    url = reverse("api-schema")
+    response = admin_client.get(url)
+    assert response.status_code == 200


### PR DESCRIPTION
## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Currently, after a new project generation with `use_drf: y`, the API call to the schema endpoint fails with the error
```
AssertionError: Incompatible AutoSchema used on View <class 'drf_spectacular.views.SpectacularSwaggerView'>. Is DRF's DEFAULT_SCHEMA_CLASS pointing to "drf_spectacular.openapi.AutoSchema" or any other drf-spectacular compatible AutoSchema?
```
So, the change sets the default schema class as `drf_spectacular.openapi.AutoSchema` as per [drf-cpectacular docs](https://drf-spectacular.readthedocs.io/en/latest/readme.html#installation) and adds a test to make sure sure that schema generation works properly