### PR TITLE
set SERVERS in production settings instead of base settings

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -346,10 +346,6 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Documentation of API endpoints of {{ cookiecutter.project_name }}",
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
-    "SERVERS": [
-        {"url": "http://127.0.0.1:8000", "description": "Local Development server"},
-        {"url": "https://{{ cookiecutter.domain_name }}", "description": "Production server"},
-    ],
 }
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -358,5 +358,15 @@ sentry_sdk.init(
     traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
 )
 {% endif %}
+{% if cookiecutter.use_drf == "y" -%}
+
+# django-rest-framework
+# -------------------------------------------------------------------------------
+# Tools that generate code samples can use SERVERS to point to the correct domain
+SPECTACULAR_SETTINGS["SERVERS"] = [
+    {"url": "https://{{ cookiecutter.domain_name }}", "description": "Production server"}
+]
+
+{%- endif %}
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -363,7 +363,7 @@ sentry_sdk.init(
 # django-rest-framework
 # -------------------------------------------------------------------------------
 # Tools that generate code samples can use SERVERS to point to the correct domain
-SPECTACULAR_SETTINGS["SERVERS"] = [
+SPECTACULAR_SETTINGS["SERVERS"] = [  # noqa F405
     {"url": "https://{{ cookiecutter.domain_name }}", "description": "Production server"}
 ]
 


### PR DESCRIPTION
it is removed from local settings since having the url as 127.0.0.1:8000 triggers a CORS issue when the project runs on localhost:8000. It is kept in production settings as that allows tools that generate code samples to point to the correct domain.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Based on the comments in the issue, I thought it would be good to keep `SERVERS` in production settings so the original goal of adding it is met, but also thought it might not be useful in local settings (plus adding it requires setting `CORS_ALLOWED_ORIGINS=["localhost:8000"]`)

fixes #3593
