### PR TITLE
Fix a few typos in the documentation

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -20,7 +20,7 @@ Moved to [settings](http://cookiecutter-django.readthedocs.io/en/latest/settings
 
 -   To create a **normal user account**, just go to Sign Up and fill out the form. Once you submit it, you'll see a "Verify Your E-mail Address" page. Go to your console to see a simulated email verification message. Copy the link into your browser. Now the user's email should be verified and ready to go.
 
--   To create an **superuser account**, use this command:
+-   To create a **superuser account**, use this command:
 
         $ python manage.py createsuperuser
 

--- a/{{cookiecutter.project_slug}}/docs/howto.rst
+++ b/{{cookiecutter.project_slug}}/docs/howto.rst
@@ -28,7 +28,7 @@ Docstrings to Documentation
 
 The sphinx extension `apidoc <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html/>`_ is used to automatically document code using signatures and docstrings.
 
-Numpy or Google style docstrings will be picked up from project files and availble for documentation. See the `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/>`_ extension for details.
+Numpy or Google style docstrings will be picked up from project files and available for documentation. See the `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/>`_ extension for details.
 
 For an in-use example, see the `page source <_sources/users.rst.txt>`_ for :ref:`users`.
 


### PR DESCRIPTION
Typos

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Typos fix.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Just noticed the typos.
