### PR TITLE
Fixed flake8 issues

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -13,7 +13,6 @@ from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
 from {{ cookiecutter.project_slug }}.users.views import UserRedirectView, UserUpdateView, user_detail_view,
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -11,11 +11,8 @@ from django.urls import reverse
 from {{ cookiecutter.project_slug }}.users.forms import UserAdminChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
-from {{ cookiecutter.project_slug }}.users.views import (
-    UserRedirectView,
-    UserUpdateView,
-    user_detail_view,
-)
+from {{ cookiecutter.project_slug }}.users.views import UserRedirectView, UserUpdateView, user_detail_view,
+
 
 pytestmark = pytest.mark.django_db
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/urls.py
@@ -1,10 +1,6 @@
 from django.urls import path
 
-from {{ cookiecutter.project_slug }}.users.views import (
-    user_detail_view,
-    user_redirect_view,
-    user_update_view,
-)
+from {{ cookiecutter.project_slug }}.users.views import user_detail_view, user_redirect_view, user_update_view
 
 app_name = "users"
 urlpatterns = [


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Change imports to one-liners in `users/urls.py` and `users/tests/test_views.py`



**Checklist:**

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Flake8 complains when it is run on the generated project. The PR will remove these issues when running `flake8`:

```./{{project_slug}}/users/urls.py:3:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/urls.py:4:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/urls.py:5:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/urls.py:6:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/urls.py:7:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/urls.py:8:1: I005 isort found an unexpected missing import
./{{project_slug}}/users/tests/test_views.py:14:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/tests/test_views.py:15:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/tests/test_views.py:16:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/tests/test_views.py:17:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/tests/test_views.py:18:1: I001 isort found an import in the wrong position
./{{project_slug}}/users/tests/test_views.py:19:1: I005 isort found an unexpected missing import
```
