### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -8,9 +8,15 @@ on:
     - cron: "15 2 * * *"
   workflow_dispatch: # to trigger manually
 
+permissions:
+  contents: read
+
 jobs:
   auto-update:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository_owner == 'cookiecutter'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -14,10 +14,10 @@ permissions:
 jobs:
   auto-update:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    if: github.repository_owner == 'cookiecutter'
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
-    if: github.repository_owner == 'cookiecutter'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,9 +11,9 @@ permissions:
 jobs:
   build:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    if: github.repository_owner == 'cookiecutter'
     permissions:
       contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-    if: github.repository_owner == 'cookiecutter'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     if: github.repository_owner == 'cookiecutter'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
