### PR TITLE
[fix] runserver needs to use keep-meta-shutdown

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -9,5 +9,5 @@ python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
 uvicorn config.asgi:application --host 0.0.0.0 --reload
 {%- else %}
-python manage.py runserver_plus 0.0.0.0:8000
+python manage.py runserver_plus 0.0.0.0:8000 --keep-meta-shutdown
 {%- endif %}


### PR DESCRIPTION
When you will upgrade werkzeug to 2.1.x, an issue with occur when using runserver_plus:
`
    The 'environ['werkzeug.server.shutdown']' function is deprecated and will be removed in Werkzeug 2.1.
`



In werkzeug 2.1.0 deprecated code was removed, including `werkzeug.server.shutdown`

ref: https://github.com/django-extensions/django-extensions/issues/1715
ref: https://github.com/plotly/jupyter-dash/issues/63

There is a simple fix, it's to add `--keep-meta-shutdown` to `runserver`