### PR TITLE
[fix] upgrade docker image node:16-bullseye-slim to node:18-bullseye-slim

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
+
+RUN apt-get update && apt-get install -y python3 g++ make
 
 WORKDIR /app
 

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=3.9-slim-bullseye
 
 {% if cookiecutter.frontend_pipeline == 'Gulp' -%}
-FROM node:16-bullseye-slim as client-builder
+FROM node:18-bullseye-slim as client-builder
 
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}


### PR DESCRIPTION
Upgrade docker image node:16-bullseye-slim to node:18-bullseye-slim,
it's necessary to add `apt-get install python3`