### PR TITLE
Update view test should set user to form instance

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -64,6 +64,7 @@ class TestUserUpdateView:
         # Initialize the form
         form = UserAdminChangeForm()
         form.cleaned_data = {}
+        form.instance = user
         view.form_valid(form)
 
         messages_sent = [m.message for m in messages.get_messages(request)]


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Sets ModelForm "instance" attribute to the user instance.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I recently had a project that required an ID that wasn't autoincrementing. This UpdateView runs `view.form_valid` which in turn runs django's model form `save()` method. This will then run `self.instance.save()` which will either create or update the instance, when it should just be updating.