### PR TITLE
Provide more context when wating for PostgreSQL takes too long

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
+++ b/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
@@ -16,30 +16,34 @@ if [ -z "${POSTGRES_USER}" ]; then
 fi
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
-postgres_ready() {
 python << END
 import sys
+import time
 
 import psycopg2
 
-try:
-    psycopg2.connect(
-        dbname="${POSTGRES_DB}",
-        user="${POSTGRES_USER}",
-        password="${POSTGRES_PASSWORD}",
-        host="${POSTGRES_HOST}",
-        port="${POSTGRES_PORT}",
-    )
-except psycopg2.OperationalError:
-    sys.exit(-1)
-sys.exit(0)
+suggest_unrecoverable_after = 30
+start = time.time()
 
+while True:
+    try:
+        psycopg2.connect(
+            dbname="${POSTGRES_DB}",
+            user="${POSTGRES_USER}",
+            password="${POSTGRES_PASSWORD}",
+            host="${POSTGRES_HOST}",
+            port="${POSTGRES_PORT}",
+        )
+        break
+    except psycopg2.OperationalError as error:
+        sys.stderr.write("Waiting for PostgreSQL to become available...\n")
+
+        if time.time() - start > suggest_unrecoverable_after:
+            sys.stderr.write("  This is taking longer than expected. The following exception may be indicative of an unrecoverable error: '{}'\n".format(error))
+
+    time.sleep(1)
 END
-}
-until postgres_ready; do
-  >&2 echo 'Waiting for PostgreSQL to become available...'
-  sleep 1
-done
+
 >&2 echo 'PostgreSQL is available'
 
 exec "$@"


### PR DESCRIPTION
## Description

Advise the operator that they may be observing an unrecoverable problem if attempts to connect to the PostgreSQL database consistently fail. In this case, also display the relevant error message.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Currently, if a connection to the PostgreSQL database cannot be established, operators are instructed to wait indefinitely. They need to exercise their own judgement to determine that an unrecoverable error may have occurred, and they must then formulate their own plan to diagnose the problem. This change introduces a suggestion about the possibility of failure and some contextual information that will assist in debugging. It also causes the script to fail immediately for truly exceptional circumstances such as the absence of required modules.

I've arbitrarily chosen 30 seconds as the duration to wait before suggesting that something may not be working. Does that seem like an appropriate value to folks more familiar with this process?