### PR TITLE
Switch from `watchgod` to `watchfiles`

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/worker/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/worker/start
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 
 
-watchgod celery.__main__.main --args -A config.celery_app worker -l INFO
+watchfiles celery.__main__.main --args '-A config.celery_app worker -l INFO'

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -8,7 +8,7 @@ psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
 psycopg2-binary==2.9.3  # https://github.com/psycopg/psycopg2
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' or cookiecutter.use_celery == 'y' %}
-watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
+watchfiles==0.16.1  # https://github.com/samuelcolvin/watchfiles
 {%- endif %}
 
 # Testing


### PR DESCRIPTION
`watchgod` was renamed to `watchfiles`.

See README on [PyPI](https://pypi.org/project/watchgod/).
