### PR TITLE
Simplify database access in tests

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
@@ -10,5 +10,5 @@ def media_storage(settings, tmpdir):
 
 
 @pytest.fixture
-def user() -> User:
+def user(db) -> User:
     return UserFactory()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_admin.py
@@ -1,9 +1,6 @@
-import pytest
 from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 class TestUserAdmin:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_urls.py
@@ -1,9 +1,6 @@
-import pytest
 from django.urls import resolve, reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 def test_user_detail(user: User):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,10 +1,7 @@
-import pytest
 from django.test import RequestFactory
 
 from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 class TestUserViewSet:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_forms.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_forms.py
@@ -1,13 +1,10 @@
 """
 Module for all Form Tests.
 """
-import pytest
 from django.utils.translation import gettext_lazy as _
 
 from {{ cookiecutter.project_slug }}.users.forms import UserAdminCreationForm
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 class TestUserAdminCreationForm:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_models.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_models.py
@@ -1,8 +1,4 @@
-import pytest
-
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 def test_user_get_absolute_url(user: User):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_swagger.py
@@ -1,8 +1,6 @@
 import pytest
 from django.urls import reverse
 
-pytestmark = pytest.mark.django_db
-
 
 def test_swagger_accessible_by_admin(admin_client):
     url = reverse("api-docs")
@@ -10,6 +8,7 @@ def test_swagger_accessible_by_admin(admin_client):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
 def test_swagger_ui_not_accessible_by_normal_user(client):
     url = reverse("api-docs")
     response = client.get(url)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_urls.py
@@ -1,9 +1,6 @@
-import pytest
 from django.urls import resolve, reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
-
-pytestmark = pytest.mark.django_db
 
 
 def test_detail(user: User):


### PR DESCRIPTION
Creating an instance of the user model requires database access. When
requesting the user fixture it fails unless we explicitly mark the test
with pytest.mark.django_db.

https://pytest-django.readthedocs.io/en/latest/helpers.html#pytest-mark-django-db-request-database-access

Pytest-django solves this elegantly with the admin_user fixture since
it implicitly depends on the `db` fixture:

https://github.com/pytest-dev/pytest-django/blob/fba51531f067a985ec6b6be4aec9a2ed5766d69c/pytest_django/fixtures.py#L406-L411

We can do the same for the cookiecutter user fixture by depending on the
db fixture.

So instead of:
```python
import pytest

pytestmark = pytest.mark.django_db

def test_user(user):
    pass
```

We can simply do:
```python
def test_user(user):
    pass
```
