### PR TITLE
only export AWS creds if defined allowing use of iam role

### DIFF
--- a/docs/deployment-with-docker.rst
+++ b/docs/deployment-with-docker.rst
@@ -61,7 +61,7 @@ You will probably also need to setup the Mail backend, for example by adding a `
 Optional: Use AWS IAM Role for EC2 instance
 -------------------------------------------
 
-If you are deploying to AWS, you can use the IAM role to substitute AWS credentials, after which it's safe to remove the ``AWS_ACCESS_KEY_ID`` AND ``AWS_SECRET_ACCESS_KEY`` from ``.envs/.production/.django``. To do it, create an `IAM role`_ and `attach`_ it to the existing EC2 instance or create a new EC2 instance with that role. The role should assume, at minimum, the ``AmazonS3FullAccess`` permission.
+If you are deploying to AWS, you can use the IAM role to substitute AWS credentials, after which it's safe to remove the ``DJANGO_AWS_ACCESS_KEY_ID`` AND ``DJANGO_AWS_SECRET_ACCESS_KEY`` from ``.envs/.production/.django``. To do it, create an `IAM role`_ and `attach`_ it to the existing EC2 instance or create a new EC2 instance with that role. The role should assume, at minimum, the ``AmazonS3FullAccess`` permission.
 
 .. _IAM role: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 .. _attach: https://aws.amazon.com/blogs/security/easily-replace-or-attach-an-iam-role-to-an-existing-ec2-instance-by-using-the-ec2-console/
@@ -160,4 +160,3 @@ Move it to ``/etc/supervisor/conf.d/{{cookiecutter.project_slug}}.conf`` and run
 For status check, run::
 
     supervisorctl status
-

--- a/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/download
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/download
@@ -14,8 +14,8 @@ source "${working_dir}/_sourced/constants.sh"
 source "${working_dir}/_sourced/messages.sh"
 
 # only export creds if not empty
-[ -z "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
-[ -z "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
+[ "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
+[ "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
 export AWS_STORAGE_BUCKET_NAME="${DJANGO_AWS_STORAGE_BUCKET_NAME}"
 
 

--- a/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/download
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/download
@@ -13,8 +13,9 @@ working_dir="$(dirname ${0})"
 source "${working_dir}/_sourced/constants.sh"
 source "${working_dir}/_sourced/messages.sh"
 
-export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
-export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
+# only export creds if not empty
+[ -z "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
+[ -z "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
 export AWS_STORAGE_BUCKET_NAME="${DJANGO_AWS_STORAGE_BUCKET_NAME}"
 
 

--- a/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/upload
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/upload
@@ -14,8 +14,8 @@ source "${working_dir}/_sourced/constants.sh"
 source "${working_dir}/_sourced/messages.sh"
 
 # only export creds if not empty
-[ -z "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
-[ -z "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
+[ "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
+[ "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
 export AWS_STORAGE_BUCKET_NAME="${DJANGO_AWS_STORAGE_BUCKET_NAME}"
 
 

--- a/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/upload
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/maintenance/upload
@@ -13,8 +13,9 @@ working_dir="$(dirname ${0})"
 source "${working_dir}/_sourced/constants.sh"
 source "${working_dir}/_sourced/messages.sh"
 
-export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
-export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
+# only export creds if not empty
+[ -z "${DJANGO_AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="${DJANGO_AWS_ACCESS_KEY_ID}"
+[ -z "${DJANGO_AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="${DJANGO_AWS_SECRET_ACCESS_KEY}"
 export AWS_STORAGE_BUCKET_NAME="${DJANGO_AWS_STORAGE_BUCKET_NAME}"
 
 


### PR DESCRIPTION
## Description

Allow use of AWS IAM Role for S3 as stated in docs. 

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The docs state that "it’s safe to remove the AWS_ACCESS_KEY_ID AND AWS_SECRET_ACCESS_KEY from .envs/.production/.django". 
https://cookiecutter-django.readthedocs.io/en/latest/deployment-with-docker.html?highlight=aws#optional-use-aws-iam-role-for-ec2-instance

When leaving the vars empty, aws cli complains:
```
$ docker-compose run --rm awscli upload
Creating REDACTED_awscli_run ... done
INFO: Upload the backups directory to S3 bucket {REDACTED}
upload failed: ../backups/backup_2022_08_06T18_05_07.sql.gz to s3://REDACTED/backups/backup_2022_08_06T18_05_07.sql.gz An error occurred (AuthorizationHeaderMalformed) when calling the PutObject operation: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
ERROR: 1
```

When commenting out the vars the `upload`/`download` scripts complain:
```
$ docker-compose run --rm awscli upload
Creating REDACTED_awscli_run ... done
/usr/local/bin/upload: line 16: DJANGO_AWS_ACCESS_KEY_ID: parameter not set
ERROR: 2
```