### PR TITLE
Store extended Celery task attributes in backend

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -283,6 +283,8 @@ if USE_TZ:
 CELERY_BROKER_URL = env("CELERY_BROKER_URL")
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
+CELERY_RESULT_EXTENDED = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-task_serializer


### PR DESCRIPTION
> Enables extended task result attributes (name, args, kwargs, worker,
> retries, queue, delivery_info) to be written to backend.

https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended

Without this the information in the result backend is rather opaque. You
can only see the task_id's of tasks that have executed. With the setting
enabled you can see the task name, queue and other metadata.

To demonstrate - the top task is with CELERY_RESULT_EXTENDED enabled
while the rest have the value disabled.

![image](https://user-images.githubusercontent.com/5557301/187700584-124a9c34-e04a-47bd-aeea-e327512e85cb.png)
