### PR TITLE
Reload uvicorn on html file change

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -82,7 +82,7 @@ First things first.
 
 or if you're running asynchronously: ::
 
-    $ uvicorn config.asgi:application --host 0.0.0.0 --reload
+    $ uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
 
 .. _PostgreSQL: https://www.postgresql.org/download/
 .. _Redis: https://redis.io/download

--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -7,7 +7,7 @@ set -o nounset
 
 python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
-uvicorn config.asgi:application --host 0.0.0.0 --reload
+uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
 {%- else %}
 python manage.py runserver_plus 0.0.0.0:8000
 {%- endif %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

After changing the html file uvicorn must be reloaded for Django to pick up the changes, otherwise it will show the old version of the template.
