### PR TITLE
Mailjet default api url does not work out of the box

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -167,7 +167,6 @@ EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 ANYMAIL = {
     "MAILJET_API_KEY": env("MAILJET_API_KEY"),
     "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
-    "MAILJET_API_URL": env("MAILJET_API_URL", default="https://api.mailjet.com/v3"),
 }
 {%- elif cookiecutter.mail_service == 'Mandrill' %}
 # https://anymail.readthedocs.io/en/stable/esps/mandrill/


### PR DESCRIPTION
It seems best to not include this setting and let AnyMail handle it. https://github.com/anymail/django-anymail/blob/a08052e7f808c800cb336df3725b63865dc36afc/anymail/backends/mailjet.py#L19
