### PR TITLE
Remove outdated & optional Sendgrid settings from production config

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -189,7 +189,6 @@ ANYMAIL = {
 EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
 ANYMAIL = {
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
-    "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
     "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
 }
 {%- elif cookiecutter.mail_service == 'SendinBlue' %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -190,7 +190,6 @@ EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
 ANYMAIL = {
     "SENDGRID_API_KEY": env("SENDGRID_API_KEY"),
     "SENDGRID_GENERATE_MESSAGE_ID": env("SENDGRID_GENERATE_MESSAGE_ID"),
-    "SENDGRID_MERGE_FIELD_FORMAT": env("SENDGRID_MERGE_FIELD_FORMAT"),
     "SENDGRID_API_URL": env("SENDGRID_API_URL", default="https://api.sendgrid.com/v3/"),
 }
 {%- elif cookiecutter.mail_service == 'SendinBlue' %}


### PR DESCRIPTION
Signed-off-by: krati yadav <kratiy.5@gmail.com>

## Description
I have worked on this issue:
https://github.com/cookiecutter/cookiecutter-django/issues/2560


Checklist:

- I have removed SENDGRID_MERGE_FIELD_FORMAT since it's for legacy SendGrid as mentioned in the issue link
- I will still need someone to test it or let me know how can i test this as it's an issue that was caused during production deployment
- I ran tox command to run the default tests and they completed successfully.

## Rationale

Why does this project need the change you're proposing?

Fix #2560
The env variable SENDGRID_MERGE_FIELD_FORMAT had to be removed since it's for legacy SendGrid as mentioned in the issue link

