### PR TITLE
Remove platform from compose file

### DIFF
--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -11,7 +11,6 @@ services:
       dockerfile: ./compose/local/django/Dockerfile
     image: {{ cookiecutter.project_slug }}_local_django
     container_name: {{ cookiecutter.project_slug }}_local_django
-    platform: linux/x86_64
     depends_on:
       - postgres
       {%- if cookiecutter.use_celery == 'y' %}
@@ -44,7 +43,6 @@ services:
   docs:
     image: {{ cookiecutter.project_slug }}_local_docs
     container_name: {{ cookiecutter.project_slug }}_local_docs
-    platform: linux/x86_64
     build:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -11,7 +11,6 @@ services:
       context: .
       dockerfile: ./compose/production/django/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_django
-    platform: linux/x86_64
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Description

I believe that the workaround introduced in PR #3562 is no longer needed. Using a fresh project created with cookiecutter-django, I was able to run the app with docker compose using the arm64 platform for the django and postgres images, without any database connection issue.

I compared the version of libpq on the arm64 image with the one on the amd64 image and they were identical.

If any core contributors are using an M1 mac, it would be good to test this before merging to ensure that this isn't just a quirk of my machine.

If it helps, I'm using Docker Desktop v4.14.1 with Engine v20.10.21 and compose v1.29.2, on macOS 12.6.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
  - note: nothing to update for the tests here, but I did run tox locally
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

If the workaround is no longer needed, it is preferable on M1 macs to use the default arm64 platform for better performance.
