### PR TITLE
Fix typo in flower start for watching celery

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
@@ -3,6 +3,6 @@
 set -o errexit
 set -o nounset
 
-exec watchfiles celery.__.main__.main \
+exec watchfiles celery.__main__.main \
     --args \
     "-A config.celery_app -b \"${CELERY_BROKER_URL}\" flower --basic_auth=\"${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}\""


### PR DESCRIPTION
Checklist:

- [ x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I started a new cookiecutter project today and Flower didn't start with `docker-compose -f local.yml up`. This fixes it.