### PR TITLE
Update image URL for build status shield badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cookiecutter Django
 
-[![Build Status](https://img.shields.io/github/workflow/status/cookiecutter/cookiecutter-django/CI/master)](https://github.com/cookiecutter/cookiecutter-django/actions?query=workflow%3ACI)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/cookiecutter/cookiecutter-django/ci.yml?branch=master)](https://github.com/cookiecutter/cookiecutter-django/actions?query=workflow%3ACI)
 [![Documentation Status](https://readthedocs.org/projects/cookiecutter-django/badge/?version=latest)](https://cookiecutter-django.readthedocs.io/en/latest/?badge=latest)
 [![Updates](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/shield.svg)](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/)
 [![Join our Discord](https://img.shields.io/badge/Discord-cookiecutter-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/uFXweDQc5a)


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Hello, this PR updates the recent change of the image URL of the build badge.

ref. Change to GitHub workflow badge routes · Issue #8671 · badges/shields - https://github.com/badges/shields/issues/8671

**Before**
![Screenshot 2022-12-21 at 18 13 22](https://user-images.githubusercontent.com/1425259/208868855-7526d26b-7919-48df-8c6b-7d2ec0f3ba01.png)

**After**
![Screenshot 2022-12-21 at 18 17 29](https://user-images.githubusercontent.com/1425259/208868850-bdeab696-36c6-4aaa-83b7-093cb0c456ff.png)


Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Because the current badge is not working anymore and we need to update the URL.