### PR TITLE
Fix link, add non-Docker commands

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -28,10 +28,15 @@ Coverage
 
 You should build your tests to provide the highest level of **code coverage**. You can run the ``pytest`` with code ``coverage`` by typing in the following command: ::
 
-   $ docker-compose -f local.yml run --rm django coverage run -m pytest
+   $ coverage run -m pytest
 
 Once the tests are complete, in order to see the code coverage, run the following command: ::
 
+   $ coverage run -m pytest
+   
+If you're running the project locally with Docker, use these commands instead: ::
+
+   $ docker-compose -f local.yml run --rm django coverage run -m pytest
    $ docker-compose -f local.yml run --rm django coverage report
 
 .. note::
@@ -53,4 +58,4 @@ Once the tests are complete, in order to see the code coverage, run the followin
 .. _develop locally with docker: ./developing-locally-docker.html
 .. _customize: https://docs.pytest.org/en/latest/customize.html
 .. _unittest: https://docs.python.org/3/library/unittest.html#module-unittest
-.. _configuring: https://coverage.readthedocs.io/en/v4.5.x/config.html
+.. _configuring: https://coverage.readthedocs.io/en/latest/config.html


### PR DESCRIPTION

## Description

The current coverage link is a 404 so I updated it to point to latest, similar to the pytest link. I also put the non-Docker version of commands first, to mirror what's done earlier in the article.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Main motivation is fixing the 404.
