### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -8,3 +8,4 @@
 .readthedocs.yml
 .travis.yml
 venv
+.git


### PR DESCRIPTION


<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

I don't want unnecessary files and folders in Docker images. The .git directory is not needed there.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

I had a huge file in my git tree and while building the image I've seen that the build context was very big, also the repository is simply not needed in the Docker image.
