### PR TITLE
Update Celery instructions

### DIFF
--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -147,12 +147,12 @@ If the project is configured to use Celery as a task scheduler then, by default,
 
 The project comes with a simple task for manual testing purposes, inside `<project_slug>/users/tasks.py`. To queue that task locally, start the Django shell, import the task, and call `delay()` on it::
 
-    $ python manage.py shell 
+    $ python manage.py shell
     >> from <project_slug>.users.tasks import get_users_count
     >> get_users_count.delay()
-    
+
 Next, make sure `redis-server` is installed (per instructions at https://redis.io/topics/quickstart) and run the server in one terminal::
-    
+
     $ redis-server
 
 Now that a task is queued and Redis is running, the final step is to start the Celery worker locally. In another terminal, run the following command::

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -141,15 +141,23 @@ In production, we have Mailgun_ configured to have your back!
 Celery
 ------
 
-If the project is configured to use Celery as a task scheduler then by default tasks are set to run on the main thread
-when developing locally. If you have the appropriate setup on your local machine then set the following
-in ``config/settings/local.py``::
+If the project is configured to use Celery as a task scheduler then, by default, tasks are set to run on the main thread when developing locally instead of getting sent to a broker. However, if you have Redis setup on your local machine, you can set the following in ``config/settings/local.py``::
 
     CELERY_TASK_ALWAYS_EAGER = False
 
-To run Celery locally, make sure redis-server is installed (instructions are available at https://redis.io/topics/quickstart), run the server in one terminal with `redis-server`, and then start celery in another terminal with the following command::
+The project comes with a simple task for manual testing purposes, inside `<project_slug>/users/tasks.py`. To queue that task locally, start the Django shell, import the task, and call `delay()` on it::
 
-    celery -A config.celery_app worker --loglevel=info
+    $ python manage.py shell 
+    >> from <project_slug>.users.tasks import get_users_count
+    >> get_users_count.delay()
+    
+Next, make sure `redis-server` is installed (per instructions at https://redis.io/topics/quickstart) and run the server in one terminal::
+    
+    $ redis-server
+
+Now that a task is queued and Redis is running, the final step is to start the Celery worker locally. In another terminal, run the following command::
+
+    $ celery -A config.celery_app worker --loglevel=info
 
 
 Sass Compilation & Live Reloading

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -145,19 +145,28 @@ If the project is configured to use Celery as a task scheduler then, by default,
 
     CELERY_TASK_ALWAYS_EAGER = False
 
+Next, make sure `redis-server` is installed (per the `Getting started with Redis`_ guide) and run the server in one terminal::
+
+    $ redis-server
+
+Start the Celery worker by running the following command in another terminal::
+
+    $ celery -A config.celery_app worker --loglevel=info
+
+That Celery worker should be running whenever your app is running, typically as a background process,
+so that it can pick up any tasks that get queued. Learn more from the `Celery Workers Guide`_.
+
 The project comes with a simple task for manual testing purposes, inside `<project_slug>/users/tasks.py`. To queue that task locally, start the Django shell, import the task, and call `delay()` on it::
 
     $ python manage.py shell
     >> from <project_slug>.users.tasks import get_users_count
     >> get_users_count.delay()
 
-Next, make sure `redis-server` is installed (per instructions at https://redis.io/docs/getting-started/) and run the server in one terminal::
+You can also use Django admin to queue up tasks, thanks to the `django-celerybeat`_ package.
 
-    $ redis-server
-
-Now that a task is queued and Redis is running, the final step is to start the Celery worker locally. In another terminal, run the following command::
-
-    $ celery -A config.celery_app worker --loglevel=info
+.. _Getting started with Redis guide: https://redis.io/docs/getting-started/
+.. _Celery Workers Guide: https://docs.celeryq.dev/en/stable/userguide/workers.html
+.. _django-celerybeat: https://django-celery-beat.readthedocs.io/en/latest/
 
 
 Sass Compilation & Live Reloading

--- a/docs/developing-locally.rst
+++ b/docs/developing-locally.rst
@@ -151,7 +151,7 @@ The project comes with a simple task for manual testing purposes, inside `<proje
     >> from <project_slug>.users.tasks import get_users_count
     >> get_users_count.delay()
 
-Next, make sure `redis-server` is installed (per instructions at https://redis.io/topics/quickstart) and run the server in one terminal::
+Next, make sure `redis-server` is installed (per instructions at https://redis.io/docs/getting-started/) and run the server in one terminal::
 
     $ redis-server
 


### PR DESCRIPTION
## Description

I got confused when I first followed the Celery instructions as I'm new to Celery and didn't know that I needed to explicitly queue the task. I've modified the instructions to show how to do that with the built-in get_users_count task.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Hopefully this makes Celery setup more clear for other celery noobs.