### PR TITLE
Add dump.rdb to gitignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -326,6 +326,9 @@ Session.vim
 # Auto-generated tag files
 tags
 
+# Redis dump file
+dump.rdb
+
 ### Project template
 {%- if cookiecutter.use_mailhog == 'y' and cookiecutter.use_docker == 'n' %}
 MailHog


### PR DESCRIPTION
## Description

After running Redis locally, I noticed dump.rdb show up in my repository, which is apparently the Redis dump file. This PR adds dump.rdb to gitignore. I thought about putting it behind a "use_celery = y" guard, but realized Redis is also the caching mechanism, so it seems relevant for all configurations.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I don't believe the dump file belongs in version control.
