### PR TITLE
Add .venv to exclude

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,10 +1,10 @@
 [flake8]
 max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
+exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv,.venv
 
 [pycodestyle]
 max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
+exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv,.venv
 
 [isort]
 line_length = 88


### PR DESCRIPTION
## Description

Currently the project is configured to exclude `venv` from flake8/pycodestyle. It's very common for that folder to be `.venv` instead. 

From the Python venv docs:
"a common name for the target directory is .venv"
https://docs.python.org/3/library/venv.html
The `.venv` variation is also already in .gitignore (along with `ENV` which I don't have an opinion on).

So this PR adds `.venv` to the exclude list as well.


Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

The [local getting started docs](https://cookiecutter-django.readthedocs.io/en/latest/developing-locally.html) don't specify what path to use, so people will likely use whatever they're used to using.

## Rationale

Less work needed for a fairly common setup. 