### PR TITLE
Add sourcemaps support to Gulp

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -346,4 +346,5 @@ project.css
 project.min.css
 vendors.js
 *.min.js
+*.min.js.map
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -85,13 +85,13 @@ function scripts() {
 
 // Vendor Javascript minification
 function vendorScripts() {
-  return src(paths.vendorsJs)
+  return src(paths.vendorsJs, { sourcemaps: true })
     .pipe(concat('vendors.js'))
     .pipe(dest(paths.js))
     .pipe(plumber()) // Checks for errors
     .pipe(uglify()) // Minifies the js
     .pipe(rename({ suffix: '.min' }))
-    .pipe(dest(paths.js))
+    .pipe(dest(paths.js, { sourcemaps: '.' }))
 }
 
 // Image compression


### PR DESCRIPTION
## Description

This PR fixes #4045 in a cleaner/simpler way than I showed in that issue thread. I discovered that Gulp 4 has built-in support for sourcemap generation, so all we need to do is add "sourcemaps" as an option to src/dest, and it take cares of the generation for us. Amazing!
You can see it in action here:
https://djangocc-vssonnwxjqvw2-app-service.azurewebsites.net/

vendors.min.js references the sourcemap at the end:
![Screenshot of vendors.min.js](https://user-images.githubusercontent.com/297042/213555483-17637870-4f43-4e2a-9829-202e6853e122.png)

And you can see the un-minified files in the sources tab:

![Screenshot of Sources tab](https://user-images.githubusercontent.com/297042/213555517-cef6f0f6-e422-4978-b734-c7b2e932a583.png)

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Without this fix, devs get a bug when running manage.py collectstatic in production with gulp/whitenoise configuration.
