### PR TITLE
Refactor `merge_production_dotenvs_in_dotenv.py`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -293,6 +293,7 @@ def set_flags_in_settings_files():
 def remove_envs_and_associated_files():
     shutil.rmtree(".envs")
     os.remove("merge_production_dotenvs_in_dotenv.py")
+    shutil.rmtree("tests")
 
 
 def remove_celery_compose_dirs():

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -18,13 +18,12 @@ def merge(
     merged_files: Sequence[Path],
     append_linesep: bool = True,
 ) -> None:
-    with open(output_file, "w") as output_file:
-        for merged_file_path in merged_files:
-            with open(merged_file_path) as merged_file:
-                merged_file_content = merged_file.read()
-                output_file.write(merged_file_content)
-                if append_linesep:
-                    output_file.write(os.linesep)
+    merged_content = ""
+    for merged_file_path in merged_files:
+        merged_content += merged_file_path.read_text()
+        if append_linesep:
+            merged_content += os.linesep
+    output_file.write_text(merged_content)
 
 
 def main():

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -24,9 +24,5 @@ def merge(
     output_file.write_text(merged_content)
 
 
-def main():
-    merge(DOTENV_FILE, PRODUCTION_DOTENV_FILES)
-
-
 if __name__ == "__main__":
-    main()
+    merge(DOTENV_FILE, PRODUCTION_DOTENV_FILES)

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -30,30 +30,54 @@ def main():
     merge(DOTENV_FILE, PRODUCTION_DOTENV_FILES)
 
 
-@pytest.mark.parametrize("files_count", range(3))
-@pytest.mark.parametrize("append_linesep", [True, False])
-def test_merge(tmp_path: Path, files_count: int, append_linesep: bool):
+@pytest.mark.parametrize(
+    ("input_contents", "append_linesep", "expected_output"),
+    [
+        # No line separator
+        ([], False, ""),
+        ([""], False, ""),
+        (["\n"], False, "\n"),
+        (["TEST=1"], False, "TEST=1"),
+        (["THIS=2", "THAT='example'"], False, "THIS=2THAT='example'"),
+        (["ONE=1\n", "TWO=2"], False, "ONE=1\nTWO=2"),
+        (["A=0", "B=1", "C=2"], False, "A=0B=1C=2"),
+        # With line separator
+        (
+            [],
+            True,
+            "",
+        ),
+        (
+            [""],
+            True,
+            "\n",
+        ),
+        (
+            ["JANE=doe"],
+            True,
+            "JANE=doe\n",
+        ),
+        (["SEP=true", "AR=ator"], True, "SEP=true\nAR=ator\n"),
+        (["X=x\n", "Y=y", "Z=z\n"], True, "X=x\n\nY=y\nZ=z\n\n"),
+    ],
+)
+def test_merge(
+    tmp_path: Path,
+    input_contents: list[str],
+    append_linesep: bool,
+    expected_output: str,
+):
     output_file = tmp_path / ".env"
 
-    expected_output_file_content = ""
     files_to_merge = []
-    for num in range(1, files_count + 1):
-        merge_filename = f".service{num}"
-        merge_file = tmp_path / merge_filename
-
-        merge_file_content = merge_filename * num
-        merge_file.write_text(merge_file_content)
-
-        expected_output_file_content += merge_file_content
-        if append_linesep:
-            expected_output_file_content += os.linesep
-
+    for num, input_content in enumerate(input_contents, start=1):
+        merge_file = tmp_path / f".service{num}"
+        merge_file.write_text(input_content)
         files_to_merge.append(merge_file)
 
     merge(output_file, files_to_merge, append_linesep)
 
-    actual_output_file_content = output_file.read_text()
-    assert actual_output_file_content == expected_output_file_content
+    assert output_file.read_text() == expected_output
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -14,13 +14,11 @@ DOTENV_FILE = BASE_DIR / ".env"
 def merge(
     output_file: Path,
     files_to_merge: Sequence[Path],
-    append_linesep: bool = True,
 ) -> None:
     merged_content = ""
     for merge_file in files_to_merge:
         merged_content += merge_file.read_text()
-        if append_linesep:
-            merged_content += os.linesep
+        merged_content += os.linesep
     output_file.write_text(merged_content)
 
 

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -30,37 +30,29 @@ def main():
     merge(DOTENV_FILE, PRODUCTION_DOTENV_FILES)
 
 
-@pytest.mark.parametrize("merged_file_count", range(3))
+@pytest.mark.parametrize("files_count", range(3))
 @pytest.mark.parametrize("append_linesep", [True, False])
-def test_merge(tmpdir_factory, merged_file_count: int, append_linesep: bool):
-    tmp_dir = Path(str(tmpdir_factory.getbasetemp()))
-
-    output_file = tmp_dir / ".env"
+def test_merge(tmp_path: Path, files_count: int, append_linesep: bool):
+    output_file = tmp_path / ".env"
 
     expected_output_file_content = ""
-    merged_files = []
-    for i in range(merged_file_count):
-        merged_file_ord = i + 1
+    files_to_merge = []
+    for num in range(1, files_count + 1):
+        merge_filename = f".service{num}"
+        merge_file = tmp_path / merge_filename
 
-        merged_filename = f".service{merged_file_ord}"
-        merged_file = tmp_dir / merged_filename
+        merge_file_content = merge_filename * num
+        merge_file.write_text(merge_file_content)
 
-        merged_file_content = merged_filename * merged_file_ord
-
-        with open(merged_file, "w+") as file:
-            file.write(merged_file_content)
-
-        expected_output_file_content += merged_file_content
+        expected_output_file_content += merge_file_content
         if append_linesep:
             expected_output_file_content += os.linesep
 
-        merged_files.append(merged_file)
+        files_to_merge.append(merge_file)
 
-    merge(output_file, merged_files, append_linesep)
+    merge(output_file, files_to_merge, append_linesep)
 
-    with open(output_file) as output_file:
-        actual_output_file_content = output_file.read()
-
+    actual_output_file_content = output_file.read_text()
     assert actual_output_file_content == expected_output_file_content
 
 

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -2,8 +2,6 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 
-import pytest
-
 BASE_DIR = Path(__file__).parent.resolve()
 PRODUCTION_DOTENVS_DIR = BASE_DIR / ".envs" / ".production"
 PRODUCTION_DOTENV_FILES = [
@@ -28,56 +26,6 @@ def merge(
 
 def main():
     merge(DOTENV_FILE, PRODUCTION_DOTENV_FILES)
-
-
-@pytest.mark.parametrize(
-    ("input_contents", "append_linesep", "expected_output"),
-    [
-        # No line separator
-        ([], False, ""),
-        ([""], False, ""),
-        (["\n"], False, "\n"),
-        (["TEST=1"], False, "TEST=1"),
-        (["THIS=2", "THAT='example'"], False, "THIS=2THAT='example'"),
-        (["ONE=1\n", "TWO=2"], False, "ONE=1\nTWO=2"),
-        (["A=0", "B=1", "C=2"], False, "A=0B=1C=2"),
-        # With line separator
-        (
-            [],
-            True,
-            "",
-        ),
-        (
-            [""],
-            True,
-            "\n",
-        ),
-        (
-            ["JANE=doe"],
-            True,
-            "JANE=doe\n",
-        ),
-        (["SEP=true", "AR=ator"], True, "SEP=true\nAR=ator\n"),
-        (["X=x\n", "Y=y", "Z=z\n"], True, "X=x\n\nY=y\nZ=z\n\n"),
-    ],
-)
-def test_merge(
-    tmp_path: Path,
-    input_contents: list[str],
-    append_linesep: bool,
-    expected_output: str,
-):
-    output_file = tmp_path / ".env"
-
-    files_to_merge = []
-    for num, input_content in enumerate(input_contents, start=1):
-        merge_file = tmp_path / f".service{num}"
-        merge_file.write_text(input_content)
-        files_to_merge.append(merge_file)
-
-    merge(output_file, files_to_merge, append_linesep)
-
-    assert output_file.read_text() == expected_output
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -15,12 +15,12 @@ DOTENV_FILE = BASE_DIR / ".env"
 
 def merge(
     output_file: Path,
-    merged_files: Sequence[Path],
+    files_to_merge: Sequence[Path],
     append_linesep: bool = True,
 ) -> None:
     merged_content = ""
-    for merged_file_path in merged_files:
-        merged_content += merged_file_path.read_text()
+    for merge_file in files_to_merge:
+        merged_content += merge_file.read_text()
         if append_linesep:
             merged_content += os.linesep
     output_file.write_text(merged_content)

--- a/{{cookiecutter.project_slug}}/tests/test_merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/tests/test_merge_production_dotenvs_in_dotenv.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+from merge_production_dotenvs_in_dotenv import merge
+
+
+@pytest.mark.parametrize(
+    ("input_contents", "append_linesep", "expected_output"),
+    [
+        # No line separator
+        ([], False, ""),
+        ([""], False, ""),
+        (["\n"], False, "\n"),
+        (["TEST=1"], False, "TEST=1"),
+        (["THIS=2", "THAT='example'"], False, "THIS=2THAT='example'"),
+        (["ONE=1\n", "TWO=2"], False, "ONE=1\nTWO=2"),
+        (["A=0", "B=1", "C=2"], False, "A=0B=1C=2"),
+        # With line separator
+        ([], True, ""),
+        ([""], True, "\n"),
+        (["JANE=doe"], True, "JANE=doe\n"),
+        (["SEP=true", "AR=ator"], True, "SEP=true\nAR=ator\n"),
+        (["X=x\n", "Y=y", "Z=z\n"], True, "X=x\n\nY=y\nZ=z\n\n"),
+    ],
+)
+def test_merge(
+    tmp_path: Path,
+    input_contents: list[str],
+    append_linesep: bool,
+    expected_output: str,
+):
+    output_file = tmp_path / ".env"
+
+    files_to_merge = []
+    for num, input_content in enumerate(input_contents, start=1):
+        merge_file = tmp_path / f".service{num}"
+        merge_file.write_text(input_content)
+        files_to_merge.append(merge_file)
+
+    merge(output_file, files_to_merge, append_linesep)
+
+    assert output_file.read_text() == expected_output

--- a/{{cookiecutter.project_slug}}/tests/test_merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/tests/test_merge_production_dotenvs_in_dotenv.py
@@ -6,28 +6,19 @@ from merge_production_dotenvs_in_dotenv import merge
 
 
 @pytest.mark.parametrize(
-    ("input_contents", "append_linesep", "expected_output"),
+    ("input_contents", "expected_output"),
     [
-        # No line separator
-        ([], False, ""),
-        ([""], False, ""),
-        (["\n"], False, "\n"),
-        (["TEST=1"], False, "TEST=1"),
-        (["THIS=2", "THAT='example'"], False, "THIS=2THAT='example'"),
-        (["ONE=1\n", "TWO=2"], False, "ONE=1\nTWO=2"),
-        (["A=0", "B=1", "C=2"], False, "A=0B=1C=2"),
-        # With line separator
-        ([], True, ""),
-        ([""], True, "\n"),
-        (["JANE=doe"], True, "JANE=doe\n"),
-        (["SEP=true", "AR=ator"], True, "SEP=true\nAR=ator\n"),
-        (["X=x\n", "Y=y", "Z=z\n"], True, "X=x\n\nY=y\nZ=z\n\n"),
+        ([], ""),
+        ([""], "\n"),
+        (["JANE=doe"], "JANE=doe\n"),
+        (["SEP=true", "AR=ator"], "SEP=true\nAR=ator\n"),
+        (["A=0", "B=1", "C=2"], "A=0\nB=1\nC=2\n"),
+        (["X=x\n", "Y=y", "Z=z\n"], "X=x\n\nY=y\nZ=z\n\n"),
     ],
 )
 def test_merge(
     tmp_path: Path,
     input_contents: list[str],
-    append_linesep: bool,
     expected_output: str,
 ):
     output_file = tmp_path / ".env"
@@ -38,6 +29,6 @@ def test_merge(
         merge_file.write_text(input_content)
         files_to_merge.append(merge_file)
 
-    merge(output_file, files_to_merge, append_linesep)
+    merge(output_file, files_to_merge)
 
     assert output_file.read_text() == expected_output


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

Following up from #4086 and #4102, I wanted to rename a few more variables and then realised that this file could be modernised since it uses Pathlib. 

The tests was pretty much reimplementing the same logic as the function, and I think it would benefit from being "dumber" and simply write a bunch of input and compare it with the extected output.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

I think we could look at replacing this script by more standard tools, but that's probably one for another day:

- On Linux and macOS, it's pretty simple to do `cat file1 file2 ... > .env`  
- On Windows, I found this, but I have no idea if that's a viable option: https://www.shellhacks.com/windows-cat-equivalent-cmd-powershell/

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Modernize script and make it more readable.
