### PR TITLE
Change `RequestFactory` to `APIRequestFactory` in tests for API views

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_drf_views.py
@@ -1,22 +1,27 @@
-from django.test import RequestFactory
+import pytest
+from rest_framework.test import APIRequestFactory
 
 from {{ cookiecutter.project_slug }}.users.api.views import UserViewSet
 from {{ cookiecutter.project_slug }}.users.models import User
 
 
 class TestUserViewSet:
-    def test_get_queryset(self, user: User, rf: RequestFactory):
+    @pytest.fixture
+    def api_rf(self) -> APIRequestFactory:
+        return APIRequestFactory()
+
+    def test_get_queryset(self, user: User, api_rf: APIRequestFactory):
         view = UserViewSet()
-        request = rf.get("/fake-url/")
+        request = api_rf.get("/fake-url/")
         request.user = user
 
         view.request = request
 
         assert user in view.get_queryset()
 
-    def test_me(self, user: User, rf: RequestFactory):
+    def test_me(self, user: User, api_rf: APIRequestFactory):
         view = UserViewSet()
-        request = rf.get("/fake-url/")
+        request = api_rf.get("/fake-url/")
         request.user = user
 
         view.request = request


### PR DESCRIPTION
## Description

Change the built in `rf` (request factory) fixture which instantiate a `RequestFactory() to its DRF equivalent in the tests for DRF views.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This was flagged as an issue by a recent mypy upgrade #4106.