### PR TITLE
Remove BrokenLinkEmailsMiddleware

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -152,7 +152,6 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 


### PR DESCRIPTION
## Description

Reverting this middleware that was added in #2355 

FYI @danihodovic 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

While it's good to keep an eye on broken links, I don't think we should enable it by default. I got spammed with a few emails from seemingly bots trying to access the site URLs with `/favicon.ico` at the end, for example: `/about//favicon.ico`.

If the site suddenly receives a spike of traffic and this goes out of hand, it could cause significant costs from the email service.