### PR TITLE
Update template docker images using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,56 @@ updates:
       interval: "daily"
     labels:
       - "update"
+
+  # Enable version updates for Docker
+  # We need to specify each Dockerfile in a separate entry because Dependabot doesn't
+  # support wildcards or recursively checking subdirectories. Check this issue for updates:
+  # https://github.com/dependabot/dependabot-core/issues/2178
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/local/django/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/local/docs/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/local/node/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/production/aws/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/production/django/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/production/postgres/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"
+
+  - package-ecosystem: "docker"
+    directory: "{{cookiecutter.project_slug}}/compose/production/traefik/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "update"


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

We're not currently doing it, which means we might be running some outdated images, as noted in #4119. I've tested it [on my fork](https://github.com/browniebroke/cookiecutter-django/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+compose) and it seems that Depenabot can handle Dockerfile with Jinja templates

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

To keep our template up to date
