### PR TITLE
Add note about which service to request when running locally with Docker & Webpack or Gulp

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -213,6 +213,11 @@ By default, it's enabled both in local and production environments (``local.yml`
 
 .. _`Flower`: https://github.com/mher/flower
 
+Using Webpack
+~~~~~~~~~~~~~
+
+When using Webpack as the ``frontend_pipeline`` option, you should access your application at the address of the ``node`` service in order to see your correct styles. This is http://localhost:3000 by default. When using any of the other ``frontend_pipeline`` options, you should use the address of the ``django`` service, http://localhost:8000.
+
 Developing locally with HTTPS
 -----------------------------
 

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -213,10 +213,10 @@ By default, it's enabled both in local and production environments (``local.yml`
 
 .. _`Flower`: https://github.com/mher/flower
 
-Using Webpack
-~~~~~~~~~~~~~
+Using Webpack or Gulp
+~~~~~~~~~~~~~~~~~~~~~
 
-When using Webpack as the ``frontend_pipeline`` option, you should access your application at the address of the ``node`` service in order to see your correct styles. This is http://localhost:3000 by default. When using any of the other ``frontend_pipeline`` options, you should use the address of the ``django`` service, http://localhost:8000.
+When using Webpack or Gulp as the ``frontend_pipeline`` option, you should access your application at the address of the ``node`` service in order to see your correct styles. This is http://localhost:3000 by default. When using any of the other ``frontend_pipeline`` options, you should use the address of the ``django`` service, http://localhost:8000.
 
 Developing locally with HTTPS
 -----------------------------


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

<!-- What's it you're proposing? -->

Add a section about using Webpack or Gulp with Docker locally in order to make it clear which service should be addressed in order to see proper styles.

Checklist:

- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

It was unclear to me (per https://github.com/cookiecutter/cookiecutter-django/issues/4129) that I needed to request the `node` service and not the `django` service when using the Webpack `frontend_pipeline` option. One should use the `django` service when using any other option, but using the `node` service when using the Webpack or Gulp option.
