### PR TITLE
Remove unused pip cache paths in GHA & add a note for pre-commit.ci

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           python-version: "3.10"
           cache: pip
 
+      {%- if cookiecutter.open_source_license != 'Not open source' %}
+      # Consider using pre-commit.ci for open source project
+      {%- endif %}
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: |
-            requirements/base.txt
-            requirements/local.txt
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

The pre-commit action doesn't install the projects deps so the dependencies path is not needed, so remove it, and add a note about pre-commit.ci

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #3395 