### PR TITLE
Trim leading and trailing space in `domain_name` and `email`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "description": "Behold My Awesome Project!",
   "author_name": "Daniel Roy Greenfeld",
   "domain_name": "example.com",
-  "email": "{{ cookiecutter.author_name.lower()|replace(' ', '-') }}@example.com",
+  "email": "{{ cookiecutter.author_name.lower() | trim() |replace(' ', '-') }}@{{ cookiecutter.domain_name.lower() | trim() }}",
   "version": "0.1.0",
   "open_source_license": [
     "MIT",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -17,6 +17,14 @@ INFO = "\x1b[1;33m [INFO]: "
 HINT = "\x1b[3;33m"
 SUCCESS = "\x1b[1;32m [SUCCESS]: "
 
+# The content of this string is evaluated by Jinja, and plays an important role.
+# It updates the cookiecutter context to trim leading and trailing spaces
+# from domain/email values
+"""
+{{ cookiecutter.update({ "domain_name": cookiecutter.domain_name | trim }) }}
+{{ cookiecutter.update({ "email": cookiecutter.email | trim }) }}
+"""
+
 project_slug = "{{ cookiecutter.project_slug }}"
 if hasattr(project_slug, "isidentifier"):
     assert (
@@ -80,8 +88,3 @@ if (
         "Mail Service for sending emails."
     )
     sys.exit(1)
-
-"""
-{{ cookiecutter.update({ "domain_name": cookiecutter.domain_name | trim }) }}
-{{ cookiecutter.update({ "email": cookiecutter.email | trim }) }}
-"""

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -80,3 +80,8 @@ if (
         "Mail Service for sending emails."
     )
     sys.exit(1)
+
+"""
+{{ cookiecutter.update({ "domain_name": cookiecutter.domain_name | trim }) }}
+{{ cookiecutter.update({ "email": cookiecutter.email | trim }) }}
+"""


### PR DESCRIPTION
## Description

remove trailing space in domain_name and email

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Before: if I input domain_name with "   example.com  " then there are some settings like that
```
ADMINS = [("""root""", "root@   example.com  ")]
ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["   example.com  "])
```
After: 
```
ADMINS = [("""root""", "root@example.com")]
ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["example.com"])
```