### PR TITLE
Disable caching for linter job on GitHub actions

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: pip
-          cache-dependency-path: |
-            requirements/base.txt
-            requirements/local.txt
 
       {%- if cookiecutter.open_source_license != 'Not open source' %}
       # Consider using pre-commit.ci for open source project

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/local.txt
 
       {%- if cookiecutter.open_source_license != 'Not open source' %}
       # Consider using pre-commit.ci for open source project


### PR DESCRIPTION
Hello, 
It is my first contribution .
I use cookiecutter-django for training .

## Description

When I push my project to github, i have an Linter's issue . 
![image](https://user-images.githubusercontent.com/8065982/219595403-51a930b6-b4da-42b5-81c2-159f4d99232b.png)

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

My fix is based on the installation instructions used by pytest. that seems good
