### PR TITLE
Fix the omit configuration for coverage

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -35,6 +35,6 @@ ignore_errors = True
 
 [coverage:run]
 include = {{cookiecutter.project_slug}}/**
-omit = *migrations*, *tests*
+omit = */migrations/*, */tests/*
 plugins =
     django_coverage_plugin


### PR DESCRIPTION
## Description

When running coverage, directories _tests_ and _migrations_ still appear on the report, despite being included in the omit configuration.
Coverage documentation states that: 
`* matches any number of file name characters, not including the directory separator`
The directories _tests_ and _migrations_ are not omitted because of the missing directory separator.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Configuration for coverage is not working as intended.
