### PR TITLE
Remove secure browser setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -22,7 +22,6 @@ DATABASE_URL                            DATABASES                   auto w/ Dock
 DJANGO_ADMIN_URL                        n/a                         'admin/'                                       raises error
 DJANGO_DEBUG                            DEBUG                       True                                           False
 DJANGO_SECRET_KEY                       SECRET_KEY                  auto-generated                                 raises error
-DJANGO_SECURE_BROWSER_XSS_FILTER        SECURE_BROWSER_XSS_FILTER   n/a                                            True
 DJANGO_SECURE_SSL_REDIRECT              SECURE_SSL_REDIRECT         n/a                                            True
 DJANGO_SECURE_CONTENT_TYPE_NOSNIFF      SECURE_CONTENT_TYPE_NOSNIFF n/a                                            True
 DJANGO_SECURE_FRAME_DENY                SECURE_FRAME_DENY           n/a                                            True

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -225,8 +225,6 @@ FIXTURE_DIRS = (str(APPS_DIR / "fixtures"),)
 SESSION_COOKIE_HTTPONLY = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-httponly
 CSRF_COOKIE_HTTPONLY = True
-# https://docs.djangoproject.com/en/dev/ref/settings/#secure-browser-xss-filter
-SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options
 X_FRAME_OPTIONS = "DENY"
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->


## Description

The setting `SECURE_BROWSER_XSS_FILTER` was deprecated and removed in Django 4.0, so I don't think it makes sense to include this in the base-project settings file.

You can view the deprecation in the Django 4.0 release notes [here](https://docs.djangoproject.com/en/4.1/releases/4.0/#securitymiddleware-no-longer-sets-the-x-xss-protection-header).

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
This project is for Django 4.0 as mentioned in its README, which is why it shouldn't include settings that were deprecated in Django 4.0.