### PR TITLE
Set isort profile argument to "black"

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -24,7 +24,8 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-
+        args: ["--profile", "black"]
+  
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:


### PR DESCRIPTION
## Description

There are some corner-cases where isort and black revert each other's changes and you can't resolve your code such that they're both happy. There's a related issue in the iSort repo (#1518) (https://github.com/PyCQA/isort/issues/1518). Appears the solution is to use the "black" profile, which can be set in setup.cfg or .pre-commit-config.yaml. This change adds the profile arg to the .pre-commit-config.yaml file. This conflict can also be caused by intentionally setting inconsistent style settings for iSort and Black, but I don't believe I've changed your defaults and most of the time your settings work great. 

I don't think this proposed change requires any changes to the docs or tests. This fixes the above issue for me when it does come up, and I thought it would be nice to have it right in the cookiecutter template, which I really like using as a base for my Django projects. I have some additional config tweaks I'd like to suggest as well and will submit those separately. 

Checklist:

- [X ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I've run into this Black/iSort conflict a handful of times in the years I've used your template. Each time I encounter it, I need to go look up how to fix it. Seems like it'd be good to just roll the fix right into the Django Cookiecutter master branch?
