### PR TITLE
Remove pytz from dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -1,4 +1,3 @@
-pytz==2023.3  # https://github.com/stub42/pytz
 python-slugify==8.0.1  # https://github.com/un33k/python-slugify
 Pillow==9.5.0  # https://github.com/python-pillow/Pillow
 {%- if cookiecutter.frontend_pipeline == 'Django Compressor' %}


### PR DESCRIPTION
## Description

Remove `pytz` from the dependencies. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

[Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#zoneinfo-default-timezone-implementation) introduced support for `zoneinfo` from the [Python standard library (added in Python 3.9)](https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo), and using `pytz` is deprecated. 

Users can keep using the deprecated library until Django 5.0 with the [`USE_DEPRECATED_PYTZ` setting](https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-USE_DEPRECATED_PYTZ), but it's not set in the project, which means it's disabled, which means that `pytz` is not needed.