### PR TITLE
Fix compatibility webpack-bundle-tracker>=2.0.0 js library required after upgrade django-webpack-loader>=2.0.0

### DIFF
--- a/{{cookiecutter.project_slug}}/webpack/common.config.js
+++ b/{{cookiecutter.project_slug}}/webpack/common.config.js
@@ -20,7 +20,8 @@ module.exports = {
   },
   plugins: [
     new BundleTracker({
-      filename: path.resolve(__dirname, '../webpack-stats.json'),
+      path: path.resolve(path.join(__dirname, '../')),
+      filename: 'webpack-stats.json',
     }),
     new MiniCssExtractPlugin({ filename: 'css/[name].[contenthash].css' }),
   ],


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

- Fix compatibility `webpack-bundle-tracker>=2.0.0` js library required after upgrade `django-webpack-loader `to `>=2.0.0`

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

The `BundleTracker` of `webpack-bundle-tracker>=2.0.0` now requires that the `filename` argument does not include any subpaths.  This means that now we need also to use the `path` argument of `BundleTracker` to get the same behavior we had before.

https://github.com/django-webpack/webpack-bundle-tracker/pull/115/files
