### PR TITLE
Prevent Celery restarts on media file changes

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/beat/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/beat/start
@@ -5,4 +5,4 @@ set -o nounset
 
 
 rm -f './celerybeat.pid'
-exec watchfiles celery.__main__.main --args '-A config.celery_app beat -l INFO'
+exec watchfiles --filter python celery.__main__.main --args '-A config.celery_app beat -l INFO'

--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
@@ -3,6 +3,6 @@
 set -o errexit
 set -o nounset
 
-exec watchfiles celery.__main__.main \
+exec watchfiles --filter python celery.__main__.main \
     --args \
     "-A config.celery_app -b \"${CELERY_BROKER_URL}\" flower --basic_auth=\"${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}\""

--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/worker/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/worker/start
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 
 
-exec watchfiles celery.__main__.main --args '-A config.celery_app worker -l INFO'
+exec watchfiles --filter python celery.__main__.main --args '-A config.celery_app worker -l INFO'


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Filter changes related to python files in the watchfiles process running Celery locally

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #4318
