### PR TITLE
Replace `runserver` with `runserver_plus`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -194,7 +194,9 @@ def handle_js_runner(choice, use_docker, use_async):
             "gulp-uglify-es",
         ]
         if not use_docker:
-            dev_django_cmd = "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver"
+            dev_django_cmd = (
+                "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
+            )
             scripts.update(
                 {
                     "dev": "concurrently npm:dev:*",

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/runserver_plus.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/runserver_plus.xml
@@ -1,0 +1,33 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runserver_plus" type="Python.DjangoServer" factoryName="Django server" singleton="true">
+    <module name="{{ cookiecutter.project_slug }}" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="DJANGO_SETTINGS_MODULE" value="config.settings.local" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <PathMappingSettings>
+      <option name="pathMappings">
+        <list>
+          <mapping local-root="$PROJECT_DIR$" remote-root="/app" />
+        </list>
+      </option>
+    </PathMappingSettings>
+    <option name="launchJavascriptDebuger" value="false" />
+    <option name="port" value="8000" />
+    <option name="host" value="0.0.0.0" />
+    <option name="additionalOptions" value="" />
+    <option name="browserUrl" value="" />
+    <option name="runTestServer" value="false" />
+    <option name="runNoReload" value="false" />
+    <option name="useCustomRunCommand" value="true" />
+    <option name="customRunCommand" value="runserver_plus" />
+    <method />
+  </configuration>
+</component>

--- a/{{cookiecutter.project_slug}}/compose/local/django/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/start
@@ -9,5 +9,5 @@ python manage.py migrate
 {%- if cookiecutter.use_async == 'y' %}
 exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
 {%- else %}
-exec python manage.py runserver 0.0.0.0:8000
+exec python manage.py runserver_plus 0.0.0.0:8000
 {%- endif %}


### PR DESCRIPTION
## Description

This reverts commit f93a9f78d9a249718acd20e297fb02b177353912

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

In #4255, `runserver_plus` was replaced by `runserver` due to some bugs in django-extensions, preventing us to upgrade Django.

In #4372, django-extensions was upgraded to a version with a fix, so we can go back to using `runserver_plus`.
