### PR TITLE
Translate fixed message in test

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -7,6 +7,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest, HttpResponseRedirect
 from django.test import RequestFactory
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from {{ cookiecutter.project_slug }}.users.forms import UserAdminChangeForm
 from {{ cookiecutter.project_slug }}.users.models import User
@@ -72,7 +73,7 @@ class TestUserUpdateView:
         view.form_valid(form)
 
         messages_sent = [m.message for m in messages.get_messages(request)]
-        assert messages_sent == ["Information successfully updated"]
+        assert messages_sent == [_("Information successfully updated")]
 
 
 class TestUserRedirectView:


### PR DESCRIPTION
## Description

With the addition of translations, there is a test in an user view that will fail if the language is changed to pt-BR. 
This happens because the test asserts if a message in English is showed.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Testing will fail if language is changed to pt-BR.
