### PR TITLE
Configure Flake 8 to be compatible with Black (88 char line limit)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        args: ['--max-line-length=88']
 
 ci:
   autoupdate_schedule: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        args: ['--max-line-length=88']
+        args: ["--max-line-length=88"]
 
 ci:
   autoupdate_schedule: weekly


### PR DESCRIPTION
Make Flake8 accept Black's automatic reformatting, 

https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
"
[Flake8](https://pypi.org/p/flake8/) is a code linter. It warns you of syntax errors, possible bugs, stylistic errors, etc. For the most part, Flake8 follows [PEP 8](https://www.python.org/dev/peps/pep-0008/) when warning about stylistic errors. There are a few deviations that cause incompatibilities with Black.
Also, as like with isort, flake8 should be configured to allow lines up to the length limit of 88, Black’s default. This explains max-line-length = 88.
"
## Description

Add the args to Flake 8 that Black recommends.

## Rationale

Avoids doom loops, in which commits are impossible, due to Black's automatic changes being rejected by Flake 8
