### PR TITLE
Improve type hints for `UserSerializer`

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/serializers.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/serializers.py
@@ -1,12 +1,7 @@
-from __future__ import annotations
-
-import typing
-
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-if typing.TYPE_CHECKING:
-    from {{ cookiecutter.project_slug }}.users.models import User as UserType
+from {{ cookiecutter.project_slug }}.users.models import User as UserType
 
 
 User = get_user_model()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/serializers.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/serializers.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+import typing
+
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
+
+if typing.TYPE_CHECKING:
+    from {{ cookiecutter.project_slug }}.users.models import User as UserType
+
 
 User = get_user_model()
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.ModelSerializer[UserType]):
     class Meta:
         model = User
         {%- if cookiecutter.username_type == "email" %}


### PR DESCRIPTION
## Description

I recently came across the fact that `djangorestframework-stubs` supports using generics in model serializers, which has the effect of improving type hints: `self.instance` is known to be an instance of the model instead of `Any`.

It would be nice to show that feature in the only serializer that we include, the `UserSerializer`.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Improve discoverability of a nice feature, improve type checking, improve auto-completion.
