### PR TITLE
Add Postgresql 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _These features can be enabled during initial project setup._
 ## Constraints
 
 - Only maintained 3rd party libraries are used.
-- Uses PostgreSQL everywhere: 10.19 - 14.1 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
+- Uses PostgreSQL everywhere: 10 - 15 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
 - Environment variables for configuration (This won't work with Apache/mod_wsgi).
 
 ## Support this Project!
@@ -129,11 +129,12 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     use_pycharm [n]: y
     use_docker [n]: n
     Select postgresql_version:
-    1 - 14
-    2 - 13
-    3 - 12
-    4 - 11
-    5 - 10
+    1 - 15
+    2 - 14
+    3 - 13
+    4 - 12
+    5 - 11
+    6 - 10
     Choose from 1, 2, 3, 4, 5 [1]: 1
     Select cloud_provider:
     1 - AWS

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,28 +13,13 @@
     "Apache Software License 2.0",
     "Not open source"
   ],
-  "username_type": [
-    "username",
-    "email"
-  ],
+  "username_type": ["username", "email"],
   "timezone": "UTC",
   "windows": "n",
   "use_pycharm": "n",
   "use_docker": "n",
-  "postgresql_version": [
-    "15",
-    "14",
-    "13",
-    "12",
-    "11",
-    "10"
-  ],
-  "cloud_provider": [
-    "AWS",
-    "GCP",
-    "Azure",
-    "None"
-  ],
+  "postgresql_version": ["15", "14", "13", "12", "11", "10"],
+  "cloud_provider": ["AWS", "GCP", "Azure", "None"],
   "mail_service": [
     "Mailgun",
     "Amazon SES",
@@ -48,23 +33,13 @@
   ],
   "use_async": "n",
   "use_drf": "n",
-  "frontend_pipeline": [
-    "None",
-    "Django Compressor",
-    "Gulp",
-    "Webpack"
-  ],
+  "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack"],
   "use_celery": "n",
   "use_mailhog": "n",
   "use_sentry": "n",
   "use_whitenoise": "n",
   "use_heroku": "n",
-  "ci_tool": [
-    "None",
-    "Travis",
-    "Gitlab",
-    "Github"
-  ],
+  "ci_tool": ["None", "Travis", "Gitlab", "Github"],
   "keep_local_envs_in_vcs": "y",
   "debug": "n"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,13 +13,28 @@
     "Apache Software License 2.0",
     "Not open source"
   ],
-  "username_type": ["username", "email"],
+  "username_type": [
+    "username",
+    "email"
+  ],
   "timezone": "UTC",
   "windows": "n",
   "use_pycharm": "n",
   "use_docker": "n",
-  "postgresql_version": ["14", "13", "12", "11", "10"],
-  "cloud_provider": ["AWS", "GCP", "Azure", "None"],
+  "postgresql_version": [
+    "15",
+    "14",
+    "13",
+    "12",
+    "11",
+    "10"
+  ],
+  "cloud_provider": [
+    "AWS",
+    "GCP",
+    "Azure",
+    "None"
+  ],
   "mail_service": [
     "Mailgun",
     "Amazon SES",
@@ -33,13 +48,23 @@
   ],
   "use_async": "n",
   "use_drf": "n",
-  "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack"],
+  "frontend_pipeline": [
+    "None",
+    "Django Compressor",
+    "Gulp",
+    "Webpack"
+  ],
   "use_celery": "n",
   "use_mailhog": "n",
   "use_sentry": "n",
   "use_whitenoise": "n",
   "use_heroku": "n",
-  "ci_tool": ["None", "Travis", "Gitlab", "Github"],
+  "ci_tool": [
+    "None",
+    "Travis",
+    "Gitlab",
+    "Github"
+  ],
   "keep_local_envs_in_vcs": "y",
   "debug": "n"
 }

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -62,11 +62,12 @@ use_docker:
 postgresql_version:
     Select a PostgreSQL_ version to use. The choices are:
 
-    1. 14
-    2. 13
-    3. 12
-    4. 11
-    5. 10
+    1. 15
+    2. 14
+    3. 13
+    4. 12
+    5. 11
+    6. 10
 
 cloud_provider:
     Select a cloud provider for static & media files. The choices are:

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -56,6 +56,7 @@ SUPPORTED_COMBINATIONS = [
     {"use_pycharm": "n"},
     {"use_docker": "y"},
     {"use_docker": "n"},
+    {"postgresql_version": "15"},
     {"postgresql_version": "14"},
     {"postgresql_version": "13"},
     {"postgresql_version": "12"},


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Add PostgreSQL 15 to the versions of choice. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Psycopg 3 supports PostgreSQL from version 10 to 15. 

