### PR TITLE
Add missing trailing space in EMAIL_SUBJECT_PREFIX

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -146,7 +146,7 @@ SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = env(
     "DJANGO_EMAIL_SUBJECT_PREFIX",
-    default="[{{cookiecutter.project_name}}]",
+    default="[{{cookiecutter.project_name}}] ",
 )
 
 # ADMIN


### PR DESCRIPTION
## Description

A missing space at the end of `EMAIL_SUBJECT_PREFIX`.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

It doesn't look good when the `EMAIL_SUBJECT_PREFIX` is displayed with the subject without a space.

[The documentation](https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix) also contains the following note:

> "You’ll probably want to include the trailing space."
