### PR TITLE
Change how we remove prettier pre-commit hook from the config

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -207,6 +207,24 @@ def handle_js_runner(choice, use_docker, use_async):
         remove_gulp_files()
 
 
+def remove_prettier_pre_commit():
+    with open(".pre-commit-config.yaml", "r") as fd:
+        content = fd.readlines()
+
+    removing = False
+    new_lines = []
+    for line in content:
+        if removing and "- repo:" in line:
+            removing = False
+        if "mirrors-prettier" in line:
+            removing = True
+        if not removing:
+            new_lines.append(line)
+
+    with open(".pre-commit-config.yaml", "w") as fd:
+        fd.writelines(new_lines)
+
+
 def remove_celery_files():
     file_names = [
         os.path.join("config", "celery_app.py"),
@@ -461,6 +479,7 @@ def main():
         remove_webpack_files()
         remove_sass_files()
         remove_packagejson_file()
+        remove_prettier_pre_commit()
         if "{{ cookiecutter.use_docker }}".lower() == "y":
             remove_node_dockerfile()
     else:

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       - id: check-case-conflict
       - id: check-docstring-first
       - id: detect-private-key
-{%- if cookiecutter.frontend_pipeline in ["Webpack", "Gulp"] %}
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.9-for-vscode
@@ -24,7 +23,6 @@ repos:
       - id: prettier
         args: ['--tab-width', '2', '--single-quote']
         exclude: '{{cookiecutter.project_slug}}/templates/'
-{%- endif %}
 
   - repo: https://github.com/adamchainz/django-upgrade
     rev: '1.14.0'


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Removes the prettier pre-commit hook in post generate hooks rather than by templating the pre-commit config config as per #4418, to make sure we can run `pre-commit autoupgrade` on the config in the template. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The pre-commit config needs to be valid to be kept up to date automatically, and [the autoupgrade workflow](https://github.com/cookiecutter/cookiecutter-django/actions/workflows/pre-commit-autoupdate.yml) started failing shortly after https://github.com/cookiecutter/cookiecutter-django/pull/4418 was merged (FYI @Andrew-Chen-Wang).
