### PR TITLE
fix /tmp bind mount

### DIFF
--- a/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
             "type": "bind"
         },
         {
-            "source": "~/.ssh",
+            "source": "/tmp",
             "target": "/tmp",
             "type": "bind"
         },


### PR DESCRIPTION
minor fix, the previous mount (host `~/.ssh` into contaner `/tmp`) had no sense at all...