### PR TITLE
Display custom 403_csrf.html while getting a csrf error in prod

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403_csrf.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/403_csrf.html
@@ -1,0 +1,14 @@
+{% raw %}{% extends "base.html" %}
+
+{% block title %}Forbidden (403){% endblock title %}
+{% block content %}
+  <h1>Forbidden (403)</h1>
+  <p>
+    {% if exception %}
+      {{ exception }}
+    {% else %}
+      You're not allowed to access this page.
+    {% endif %}
+  </p>
+{% endblock content %}
+{%- endraw %}


### PR DESCRIPTION
## Description

As mentioned in #3316 , when `debug=False`, we still see the default 403 csrf template being displayed, not the custom `403.html` file.

Checklist:

- [x] I've made sure that tests are updated accordingly and no existing tests were affected
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Adding a custom `403_csrf.html` which overrides the default csrf template. 
Fix #3316 
