### PR TITLE
Exclude env files from container image (add .envs/ to .dockerignore)

### DIFF
--- a/{{cookiecutter.project_slug}}/.dockerignore
+++ b/{{cookiecutter.project_slug}}/.dockerignore
@@ -9,3 +9,4 @@
 .travis.yml
 venv
 .git
+.envs/


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Currently, environment files are copied to the Django container image during build.
Environment files contains secrets and should not be included container images. They should be handled by env_file in compose files.

Per [discussion 4474](https://github.com/cookiecutter/cookiecutter-django/discussions/4474), this is likely a bug.

This change excludes all environment files from being copied to container image.
