### PR TITLE
Add Webpack instructions for developping locally with HTTPS

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -340,12 +340,16 @@ If you are using Webpack:
 
 2. On the ``node`` service in ``local.yml``, add the following environment configuration:
 
-    environment:
-      - VIRTUAL_HOST=my-dev-env.local
-      - VIRTUAL_PORT=3000
+   ::
+
+     environment:
+       - VIRTUAL_HOST=my-dev-env.local
+       - VIRTUAL_PORT=3000
 
 3. Add the following configuration to the ``devServer`` section of ``webpack/dev.config.js``:
 
-    client: {
-            webSocketURL: 'auto://0.0.0.0:0/ws', // note the `:0` after `0.0.0.0`
-    },
+   ::
+
+     client: {
+         webSocketURL: 'auto://0.0.0.0:0/ws', // note the `:0` after `0.0.0.0`
+     },

--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -330,3 +330,22 @@ See `https with nginx`_ for more information on this configuration.
 Add ``certs/*`` to the ``.gitignore`` file. This allows the folder to be included in the repo but its contents to be ignored.
 
 *This configuration is for local development environments only. Do not use this for production since you might expose your local* ``rootCA-key.pem``.
+
+Webpack
+~~~~~~~
+
+If you are using Webpack:
+
+1. On the ``nginx-proxy`` service in ``local.yml``, change ``depends_on`` to ``node`` instead of ``django``.
+
+2. On the ``node`` service in ``local.yml``, add the following environment configuration:
+
+    environment:
+      - VIRTUAL_HOST=my-dev-env.local
+      - VIRTUAL_PORT=3000
+
+3. Add the following configuration to the ``devServer`` section of ``webpack/dev.config.js``:
+
+    client: {
+            webSocketURL: 'auto://0.0.0.0:0/ws', // note the `:0` after `0.0.0.0`
+    },


### PR DESCRIPTION
## Description

When following the instructions [Developing locally with HTTPS](https://cookiecutter-django.readthedocs.io/en/latest/developing-locally-docker.html#developing-locally-with-https), it will not work if the project is setup with Webpack.

This pull request add the necessary instructions to make it work, including Live Reload.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Webpack is available as a Project Generation Options. Therefore the doc should explain how to develop locally with HTTPS and Webpack.
