### PR TITLE
Explicitly state that docker exec does not work for running management commands

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -77,7 +77,7 @@ As with any shell command that we wish to run in our container, this is done usi
     $ docker-compose -f local.yml run --rm django python manage.py createsuperuser
 
 Here, ``django`` is the target service we are executing the commands against.
-
+Also, please note that the ``docker exec`` does not work for running management commands.
 
 (Optionally) Designate your Docker Development Server IP
 --------------------------------------------------------


### PR DESCRIPTION
## Description

According to #3224, one cannot simply `docker exec` into the `django` container to run management commands, possibly due to how environment variables are injected. Hence, I've added a sentence in the docs explicitly mentioning that `docker exec` does not work and one should use the `docker compose run` route instead (mentioned in the docs).

Checklist:

- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #3224 
