### PR TITLE
Corrected 'or' translation to pt-br

### DIFF
--- a/{{cookiecutter.project_slug}}/locale/pt_BR/LC_MESSAGES/django.po
+++ b/{{cookiecutter.project_slug}}/locale/pt_BR/LC_MESSAGES/django.po
@@ -127,7 +127,7 @@ msgstr "Ou, <a href=\"%(signup_url)s\">cadastre-se</a> para uma conta em %(site_
 
 #: {{cookiecutter.project_slug}}/templates/account/login.html:32
 msgid "or"
-msgstr "or"
+msgstr "ou"
 
 #: {{cookiecutter.project_slug}}/templates/account/login.html:41
 #, python-format


### PR DESCRIPTION
## Description

Corrected "or" pt-br translation

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The Portuguese translation to "or" was set to "or", when the correct is "ou"