### PR TITLE
fix(devcontainer): overrideCommand set to false so django container can run

### DIFF
--- a/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
     ],
     // Tells devcontainer.json supporting services / tools whether they should run
     // /bin/sh -c "while sleep 1000; do :; done" when starting the container instead of the container’s default command
-    "overrideCommand": true,
+    "overrideCommand": false,
     "service": "django",
     // "remoteEnv": {"PATH": "/home/dev-user/.local/bin:${containerEnv:PATH}"},
     "remoteUser": "dev-user",


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->
A simple bugfix on devcontainer that prevented the django container from running when using VSCode with `use_docker=y`

How to reproduce the bug:

- Just generate a new project using : `cookiecutter gh:cookiecutter/cookiecutter-django` with `use_docker=y`
- Open the generated project with VSCode then you will see this popup: "Do you want to install the recommended 'Dev Containers' extension from Microsoft for this repository?" then to open it : 
![image](https://github.com/cookiecutter/cookiecutter-django/assets/11042364/1a47fb7f-b4b8-4d70-a55f-2aba14d7582f)
- After the devcontainer is built and started you will see that services are up but can't access them with http://localhost:8000 or https://localhost:8000

DevContainer documentation on this : https://containers.dev/implementors/json_reference/

![image](https://github.com/cookiecutter/cookiecutter-django/assets/11042364/bb5d31b4-fb25-4553-814f-8a068809e7b2)

Which states that this property should be set to

> `false` when referencing a Docker Compose file

which is set here : 

```json
    "dockerComposeFile": [
        "../local.yml"
    ],
```

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
No open issue pointing this bug, asked on the Discord Channel if this property was set to `true` for a particular reason