### PR TITLE
Remove unused gulp-concat when Webpack is selected

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -183,6 +183,7 @@ def handle_js_runner(choice, use_docker, use_async):
             "browser-sync",
             "cssnano",
             "gulp",
+            "gulp-concat",
             "gulp-imagemin",
             "gulp-plumber",
             "gulp-postcss",


### PR DESCRIPTION
## Description

Remove unused Gulp package when Webpack is selected

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #4513
