### PR TITLE
Override _after_postgeneration to force save in User factory

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -29,6 +29,13 @@ class UserFactory(DjangoModelFactory):
         )
         self.set_password(password)
 
+    @classmethod
+    def _after_postgeneration(cls, instance, create, results=None):
+        """Save again the instance if creating and at least one hook ran."""
+        if create and results and not cls._meta.skip_postgeneration_save:
+            # Some post-generation hooks ran, and may have modified us.
+            instance.save()
+    
     class Meta:
         model = get_user_model()
         django_get_or_create = ["{{cookiecutter.username_type}}"]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -35,7 +35,7 @@ class UserFactory(DjangoModelFactory):
         if create and results and not cls._meta.skip_postgeneration_save:
             # Some post-generation hooks ran, and may have modified us.
             instance.save()
-    
+
     class Meta:
         model = get_user_model()
         django_get_or_create = ["{{cookiecutter.username_type}}"]


### PR DESCRIPTION
## Description

Saving in `_after_postgeneration` was automatic in Factory Boy versions below 4.0, but will need to be done explicitly in v4.0+. Until then, _not_ overriding  `_after_postgeneration` (or explicitly setting `skip_postgeneration_save`) results in a warning when using `UserFactory` in tests. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Eliminates a warning for recent versions of FactoryBoy and ensures that behavior will not change in future major releases. 