### PR TITLE
add compatibility options for black and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude = docs
 max-line-length = 119
+extend-ignore = E203

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        args: [ '--config=setup.cfg' ]
 
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.32.1

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
-        args: [ '--config=setup.cfg' ]
 
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.32.1

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -4,6 +4,7 @@
 [flake8]
 max-line-length = 119
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv,.venv
+extend-ignore = E203
 
 [pycodestyle]
 max-line-length = 119


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description
Propose adding the E203 to the extend-ignore option of Flake8.


Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
The official documentation of Black states that Flake8's E203 causes incompatibility with Black.

[1] https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8
[2] https://github.com/PyCQA/pycodestyle/issues/373

Fix #4538

