### PR TITLE
Fix ownership for /start-flower script in production Dockerfile

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -103,7 +103,7 @@ RUN sed -i 's/\r$//g' /start-celerybeat
 RUN chmod +x /start-celerybeat
 
 
-COPY ./compose/production/django/celery/flower/start /start-flower
+COPY --chown=django:django ./compose/production/django/celery/flower/start /start-flower
 RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 {%- endif %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->
Fixing a bug which seems like a missing a small typo. I needed to apply these changes to production env to be able to start Flower

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

The documentation doesn't need to be updated but I don't know how to test such change (it works on production tho)

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Fix #4602

This project is optionally shipped with Flower which doesn't run in production without this change. This seems like a small typo as other files are changing ownership to Django user. I hope I'm not missing something.

Thanks for a great project BTW ❤️ 

EDIT: I could add some small test suite for Flower if requested (just need more time) 🤞🏿 