### PR TITLE
Fix bug with social account adapter name override, in very specific conditions

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/adapters.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/adapters.py
@@ -27,8 +27,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
 
         See: https://django-allauth.readthedocs.io/en/latest/advanced.html?#creating-and-populating-user-instances
         """
-        super().populate_user(request, sociallogin, data)
-        user = sociallogin.user
+        user = super().populate_user(request, sociallogin, data)
         if not user.name:
             if name := data.get("name"):
                 user.name = name

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/adapters.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/adapters.py
@@ -27,11 +27,13 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
 
         See: https://django-allauth.readthedocs.io/en/latest/advanced.html?#creating-and-populating-user-instances
         """
+        super().populate_user(request, sociallogin, data)
         user = sociallogin.user
-        if name := data.get("name"):
-            user.name = name
-        elif first_name := data.get("first_name"):
-            user.name = first_name
-            if last_name := data.get("last_name"):
-                user.name += f" {last_name}"
-        return super().populate_user(request, sociallogin, data)
+        if not user.name:
+            if name := data.get("name"):
+                user.name = name
+            elif first_name := data.get("first_name"):
+                user.name = first_name
+                if last_name := data.get("last_name"):
+                    user.name += f" {last_name}"
+        return user


### PR DESCRIPTION
This is a fix for what I believe is a little bug that I discovered by chance, that was introduced in a recent pull request: (https://github.com/cookiecutter/cookiecutter-django/pull/3968), and that is related to very specific condtions: I have a Google social account provider, along with these settings:

```
ACCOUNT_USERNAME_REQUIRED = True
ACCOUNT_USER_MODEL_USERNAME_FIELD = "name"
```

That is, I want to put the full name (first + last) of the data coming from Google account in the `name` field of the user (I also want him to be able to specify it at creation, or change it later).

Because the `user.name` update (introduced in https://github.com/cookiecutter/cookiecutter-django/pull/3968) happens _before_ the call to `super().populate_user(request, sociallogin, data)`, it gets overwritten at:

https://github.com/pennersr/django-allauth/blob/412af554078783262ce67588d151b77ea9f9d038/allauth/socialaccount/adapter.py#L115

because, at least in the specific conditions of my Google account, there is no `username` coming with `data`, and so `user.name` is then set to `""`, by this code:

https://github.com/pennersr/django-allauth/blob/main/allauth/account/utils.py#L119

(with `ACCOUNT_USER_MODEL_USERNAME_FIELD = "name"`).

In the end, what ends up in the `user.name` field is just the first name (of the data coming from the Google account), because of this code:

https://github.com/pennersr/django-allauth/blob/412af554078783262ce67588d151b77ea9f9d038/allauth/account/adapter.py#L248-L255

With my fix, I get `user.name = <First> + <Last>`, as intended.

Although the conditions described here are quite specific, I'm fairly confident that this fix will result in the correct and desired behavior in every case, because the update seems simply more logical, the way I propose.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
