### PR TITLE
Add `rmbackup` script to remove backups from `postgres/backups`. Fixes: #4663

### DIFF
--- a/docs/docker-postgres-backups.rst
+++ b/docs/docker-postgres-backups.rst
@@ -92,7 +92,15 @@ You will see something like ::
 
 Backup to Amazon S3
 ----------------------------------
+
 For uploading your backups to Amazon S3 you can use the aws cli container. There is an upload command for uploading the postgres /backups directory recursively and there is a download command for downloading a specific backup. The default S3 environment variables are used. ::
 
     $ docker compose -f production.yml run --rm awscli upload
     $ docker compose -f production.yml run --rm awscli download backup_2018_03_13T09_05_07.sql.gz
+
+Remove Backup
+----------------------------------
+
+To remove backup you can use the ``rmbackup`` command. This will remove the backup from the ``/backups`` directory. ::
+
+    $ docker compose -f local.yml exec postgres rmbackup backup_2018_03_13T09_05_07.sql.gz

--- a/{{cookiecutter.project_slug}}/compose/production/postgres/maintenance/rmbackup
+++ b/{{cookiecutter.project_slug}}/compose/production/postgres/maintenance/rmbackup
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+### Remove a database backup.
+###
+### Parameters:
+###     <1> filename of a backup to remove.
+###
+### Usage:
+###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres rmbackup <1>
+
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+working_dir="$(dirname ${0})"
+source "${working_dir}/_sourced/constants.sh"
+source "${working_dir}/_sourced/messages.sh"
+
+
+if [[ -z ${1+x} ]]; then
+    message_error "Backup filename is not specified yet it is a required parameter. Make sure you provide one and try again."
+    exit 1
+fi
+backup_filename="${BACKUP_DIR_PATH}/${1}"
+if [[ ! -f "${backup_filename}" ]]; then
+    message_error "No backup with the specified filename found. Check out the 'backups' maintenance script output to see if there is one and try again."
+    exit 1
+fi
+
+message_welcome "Removing the '${backup_filename}' backup file..."
+
+rm -r "${backup_filename}"
+
+message_success "The '${backup_filename}' database backup has been removed."


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Add `rmbackup` script to remove backups from `postgres` container

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

To keep the database maintenance cycle consistent.