### PR TITLE
Excludes devcontainer.json from the pre-commit

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^docs/|/migrations/'
+exclude: '^docs/|/migrations/|devcontainer.json'
 default_stages: [commit]
 
 repos:

--- a/{{cookiecutter.project_slug}}/locale/pt_BR/LC_MESSAGES/django.po
+++ b/{{cookiecutter.project_slug}}/locale/pt_BR/LC_MESSAGES/django.po
@@ -127,7 +127,7 @@ msgstr "Ou, <a href=\"%(signup_url)s\">cadastre-se</a> para uma conta em %(site_
 
 #: {{cookiecutter.project_slug}}/templates/account/login.html:32
 msgid "or"
-msgstr "or"
+msgstr "ou"
 
 #: {{cookiecutter.project_slug}}/templates/account/login.html:41
 #, python-format


### PR DESCRIPTION
## Description

As described in issue #4697, the file devcontainer.json fails the pre-commit as it contains comments.
This PR excludes this file from the pre-commit hooks.

Checklist:

- [ X ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ X ] I've updated the documentation or confirm that my change doesn't require any updates

Fix #4697