### PR TITLE
Removed tmp mount in devcontainer.json. Fix #4686

### DIFF
--- a/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -12,11 +12,6 @@
             "type": "bind"
         },
         {
-            "source": "/tmp",
-            "target": "/tmp",
-            "type": "bind"
-        },
-        {
             "source": "~/.ssh",
             "target": "/home/dev-user/.ssh",
             "type": "bind"


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

1. Devcontainer builds have an error about x11 being read only, and is referencing the wrong port (X1 when should be X0?)
Container server: Error: listen EROFS: read-only file system /tmp/.X11-unix/X1
a clue found https://github.com/microsoft/vscode-remote-release/issues/550#issuecomment-1404695068

2. The devcontainer "postCreateCommand": "cat .devcontainer/bashrc.override.sh >> /home/dev-user/.bashrc" does not run and hangs the Configuring Dev Container (show log) status, so no DATABASE_URL sourced in .bashrc.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option) (NA)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #4686