### PR TITLE
Add django-upgrade to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
     hooks:
       - id: flake8
 
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.15.0" # replace with latest tag on GitHub
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]
+
 ci:
   autoupdate_schedule: weekly
   skip: []


### PR DESCRIPTION
Browsing for some extra content I discovered that `django-upgrade` takes care of https://github.com/cookiecutter/cookiecutter-django/issues/4443. I was surprised we didn't include `django-upgrade` already but here it is.   

I used in the past for a legacy codebase and it is really helpful. 