### PR TITLE
Adding a class to create a CITATION.cff file in update_contributors.py

### DIFF
--- a/scripts/test_update_contributors.py
+++ b/scripts/test_update_contributors.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from .update_contributors import CitationCFFFile, ContributorsJSONFile
+
+
+def test_CitationCFFFile(tmp_path):
+    """Test the CitationCFFFile class."""
+    contrib_file = ContributorsJSONFile()
+    citation_output_path = Path(tmp_path / "CITATION.cff")
+    cff_writer = CitationCFFFile(output_path=citation_output_path)
+
+    cff_writer.save_cff(contrib_file.content)
+
+    # Verify
+    assert citation_output_path.exists()

--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -104,7 +104,7 @@ class CitationCFFFile:
         """Read the version string from setup.py, or return today's date if not found."""
         setup_path = root_path / "setup.py"
         version_pattern = re.compile(r"version\s*=\s*['\"]([^'\"]+)['\"]")
-        with open(setup_path, 'r', encoding='utf-8') as file:
+        with open(setup_path, encoding="utf-8") as file:
             for line in file:
                 match = version_pattern.search(line)
                 if match:
@@ -143,10 +143,10 @@ class CitationCFFFile:
             "production-ready Django projects quickly.",
             "notes": "This project has received contributions from many individuals, "
             "for which we are grateful. For a full list of contributors, see the CONTRIBUTORS.md in the repository",
-            "repository-code": "https://github.com/cookiecutter/cookiecutter-django"
+            "repository-code": "https://github.com/cookiecutter/cookiecutter-django",
         }
 
-        with open(self.output_path, 'w', encoding='utf-8') as file:
+        with open(self.output_path, "w", encoding="utf-8") as file:
             yaml.dump(cff_content, file, default_flow_style=False)
 
 
@@ -161,8 +161,6 @@ def write_md_file(contributors):
 
     file_path = ROOT / "CONTRIBUTORS.md"
     file_path.write_text(content)
-
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x ] I've updated the documentation or confirm that my change doesn't require any updates (no updates)

## Rationale

This is in relation to issue #4755

This proposes that a CITATION.cff file be generated along with CONTRIBUTORS.md to make it very simple to generate a citation of this repo for grant and/or academic journal submission purposes. I don't know if this is of interest yet, but thought I'd make the pull to show what I'm suggesting.

This wil generate a file, CITATION.cff, in the main repo that will create an additional entry in the github menu on the right side, under the `license` entry, that says "cite this repo". If you click that, it will give you an option to view the CITATION.cff file, or simply copy the citation which will look like:

```raw
Roy Greenfeld, D., Roy Greenfeld, A., C. Barrionuevo da Luz, F., Kumar, S., Gebauer, J., Khalid, B., Nikita, S., Alla, B., Liuyang, W., Draaijer, J., & Community Contributors. (2023). cookiecutter-django (Version 2023.12.19) [Computer software]. https://github.com/cookiecutter/cookiecutter-django
```
