### PR TITLE
Update traefik doc links

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -6,7 +6,7 @@ entryPoints:
     # http
     address: ':80'
     http:
-      # https://doc.traefik.io/traefik/routing/entrypoints/#entrypoints
+      # https://doc.traefik.io/traefik/routing/entrypoints/#entrypoint
       redirections:
         entryPoint:
           to: web-secure

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/traefik.yml
@@ -6,7 +6,7 @@ entryPoints:
     # http
     address: ':80'
     http:
-      # https://docs.traefik.io/routing/entrypoints/#entrypoint
+      # https://doc.traefik.io/traefik/routing/entrypoints/#entrypoints
       redirections:
         entryPoint:
           to: web-secure
@@ -22,11 +22,11 @@ entryPoints:
 
 certificatesResolvers:
   letsencrypt:
-    # https://docs.traefik.io/master/https/acme/#lets-encrypt
+    # https://doc.traefik.io/traefik/https/acme/#lets-encrypt
     acme:
       email: '{{ cookiecutter.email }}'
       storage: /etc/traefik/acme/acme.json
-      # https://docs.traefik.io/master/https/acme/#httpchallenge
+      # https://doc.traefik.io/traefik/https/acme/#httpchallenge
       httpChallenge:
         entryPoint: web
 
@@ -44,7 +44,7 @@ http:
         - csrf
       service: django
       tls:
-        # https://docs.traefik.io/master/routing/routers/#certresolver
+        # https://doc.traefik.io/traefik/routing/routers/#certresolver
         certResolver: letsencrypt
     {%- if cookiecutter.use_celery == 'y' %}
 
@@ -54,7 +54,7 @@ http:
         - flower
       service: flower
       tls:
-        # https://docs.traefik.io/master/routing/routers/#certresolver
+        # https://doc.traefik.io/traefik/master/routing/routers/#certresolver
         certResolver: letsencrypt
     {%- endif %}
     {%- if cookiecutter.cloud_provider == 'None' %}
@@ -76,7 +76,7 @@ http:
 
   middlewares:
     csrf:
-      # https://docs.traefik.io/master/middlewares/headers/#hostsproxyheaders
+      # https://doc.traefik.io/traefik/master/middlewares/http/headers/#hostsproxyheaders
       # https://docs.djangoproject.com/en/dev/ref/csrf/#ajax
       headers:
         hostsProxyHeaders: ['X-CSRFToken']
@@ -102,7 +102,7 @@ http:
     {%- endif %}
 
 providers:
-  # https://docs.traefik.io/master/providers/file/
+  # https://doc.traefik.io/traefik/master/providers/file/
   file:
     filename: /etc/traefik/traefik.yml
     watch: true


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Minor doc changes in the traefik config file.
Looks like since the file was created, the docs were moved to a different place. Most links redirect correctly, but a couple of them are returning 404.
I updated all of them to point to the intended target, so it no longer redirects from the old ones.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Very minor maintenance change. Stale links are a minor inconvenience when following docs.
