### PR TITLE
Add registry to Docker images names

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -1,8 +1,8 @@
 # define an alias for the specific python version used in this file.
-FROM python:3.11.7-slim-bookworm as python
+FROM docker.io/python:3.11.7-slim-bookworm as python
 
 # Python build stage
-FROM python as python-build-stage
+FROM docker.io/python as python-build-stage
 
 ARG BUILD_ENVIRONMENT=local
 
@@ -22,7 +22,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM docker.io/python as python-run-stage
 
 ARG BUILD_ENVIRONMENT=local
 ARG APP_HOME=/app

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -1,9 +1,9 @@
 # define an alias for the specific python version used in this file.
-FROM python:3.11.7-slim-bookworm as python
+FROM docker.io/python:3.11.7-slim-bookworm as python
 
 
 # Python build stage
-FROM python as python-build-stage
+FROM docker.io/python as python-build-stage
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
@@ -26,7 +26,7 @@ RUN pip wheel --no-cache-dir --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM docker.io/python as python-run-stage
 
 ARG BUILD_ENVIRONMENT
 ENV PYTHONUNBUFFERED 1

--- a/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM docker.io/node:20-bookworm-slim
 
 WORKDIR /app
 

--- a/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM garland/aws-cli-docker:1.16.140
+FROM docker.io/garland/aws-cli-docker:1.16.140
 
 COPY ./compose/production/aws/maintenance /usr/local/bin/maintenance
 COPY ./compose/production/postgres/maintenance/_sourced /usr/local/bin/maintenance/_sourced

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -1,5 +1,5 @@
 {% if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] -%}
-FROM node:20-bookworm-slim as client-builder
+FROM docker.io/node:20-bookworm-slim as client-builder
 
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
@@ -25,10 +25,10 @@ RUN npm run build
 
 {%- endif %}
 # define an alias for the specific python version used in this file.
-FROM python:3.11.7-slim-bookworm as python
+FROM docker.io/python:3.11.7-slim-bookworm as python
 
 # Python build stage
-FROM python as python-build-stage
+FROM docker.io/python as python-build-stage
 
 ARG BUILD_ENVIRONMENT=production
 
@@ -48,7 +48,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM docker.io/python as python-run-stage
 
 ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app

--- a/{{cookiecutter.project_slug}}/compose/production/nginx/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.17.8-alpine
+FROM docker.io/nginx:1.17.8-alpine
 COPY ./compose/production/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/{{cookiecutter.project_slug}}/compose/production/postgres/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:{{ cookiecutter.postgresql_version }}
+FROM docker.io/postgres:{{ cookiecutter.postgresql_version }}
 
 COPY ./compose/production/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*

--- a/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:2.10.7
+FROM docker.io/traefik:2.10.7
 RUN mkdir -p /etc/traefik/acme \
   && touch /etc/traefik/acme/acme.json \
   && chmod 600 /etc/traefik/acme/acme.json

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -58,7 +58,7 @@ services:
   {%- if cookiecutter.use_mailpit == 'y' %}
 
   mailpit:
-    image: axllent/mailpit:latest
+    image: docker.io/axllent/mailpit:latest
     container_name: {{ cookiecutter.project_slug }}_local_mailpit
     ports:
       - "8025:8025"
@@ -67,7 +67,7 @@ services:
   {%- if cookiecutter.use_celery == 'y' %}
 
   redis:
-    image: redis:6
+    image: docker.io/redis:6
     container_name: {{ cookiecutter.project_slug }}_local_redis
 
   celeryworker:

--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -67,7 +67,7 @@ services:
       {%- endif %}
 
   redis:
-    image: redis:6
+    image: docker.io/redis:6
   {%- if cookiecutter.use_celery == 'y' %}
 
   celeryworker:


### PR DESCRIPTION
## Description

Prepending `docker.io/` to image names in local.yml, production.yml and Dockerfiles. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

`tox -e py` was run successfully against Python 3.11.7

## Rationale

This change allows projects to run in alternate container runtimes such as podman-compose without additional registry configuration. The docker client is also able to pull the images in their fully qualified form.
