### PR TITLE
Do not show webpack devserver overlay for warnings

### DIFF
--- a/{{cookiecutter.project_slug}}/webpack/dev.config.js
+++ b/{{cookiecutter.project_slug}}/webpack/dev.config.js
@@ -13,6 +13,13 @@ module.exports = merge(commonConfig, {
       '/': 'http://django:8000',
       {%- endif %}
     },
+    client: {
+      overlay: {
+        errors: true,
+        warnings: false,
+        runtimeErrors: true,
+      },
+    },
     // We need hot=false (Disable HMR) to set liveReload=true
     hot: false,
     liveReload: true,


### PR DESCRIPTION
This PR fixes #4808 by modifying the webpack dev config.