### PR TITLE
Use POSTGRES_* and REDIS_URL as fallback

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -45,16 +45,16 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 try:
-    { % if cookiecutter.use_docker == "y" - %}
+    {%- if cookiecutter.use_docker == "y" %}
     DATABASES = {"default": env.db("DATABASE_URL")}
-    { % - else %}
+    {%- else %}
     DATABASES = {
         "default": env.db(
             "DATABASE_URL",
             default="postgres://{% if cookiecutter.windows == 'y' %}localhost{% endif %}/{{cookiecutter.project_slug}}",
         ),
     }
-    { % - endif %}
+    {%- endif %}
 except environ.ImproperlyConfigured:
     DATABASES = {
         "default": {
@@ -297,7 +297,11 @@ if USE_TZ:
     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+try:
+    CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+except environ.ImproperlyConfigured:
+    CELERY_BROKER_URL = env("REDIS_URL")
+
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -44,16 +44,28 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 # DATABASES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
-{% if cookiecutter.use_docker == "y" -%}
-DATABASES = {"default": env.db("DATABASE_URL")}
-{%- else %}
-DATABASES = {
-    "default": env.db(
-        "DATABASE_URL",
-        default="postgres://{% if cookiecutter.windows == 'y' %}localhost{% endif %}/{{cookiecutter.project_slug}}",
-    ),
-}
-{%- endif %}
+try:
+    { % if cookiecutter.use_docker == "y" - %}
+    DATABASES = {"default": env.db("DATABASE_URL")}
+    { % - else %}
+    DATABASES = {
+        "default": env.db(
+            "DATABASE_URL",
+            default="postgres://{% if cookiecutter.windows == 'y' %}localhost{% endif %}/{{cookiecutter.project_slug}}",
+        ),
+    }
+    { % - endif %}
+except environ.ImproperlyConfigured:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": env.str("POSTGRES_DB"),
+            "USER": env.str("POSTGRES_USER"),
+            "PASSWORD": env.str("POSTGRES_PASSWORD"),
+            "HOST": env.str("POSTGRES_HOST"),
+            "PORT": env.str("POSTGRES_PORT"),
+        }
+    }
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
This PR extends the base configuration in two ways:

1) When `DATABASE_URL` is missing it is using `POSTGRES_*` variables for configuring the database. 
2) `CELERY_BROKER_URL` defaults to `REDIS_URL` 

When using #4810 the `POSTGRES_*` and `REDIS_URL` variables are present but I'm not using the `entrypoint` script. This modification gives the possibility to run without `entrypoint` and without further modifications by using the variables already present.