### PR TITLE
Fix deprecation warning about renaming of `webpack_loader.loader` to `webpack_loader.loaders`

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -37,7 +37,7 @@ MEDIA_URL = "http://media.testserver"
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
 # django-webpack-loader
 # ------------------------------------------------------------------------------
-WEBPACK_LOADER["DEFAULT"]["LOADER_CLASS"] = "webpack_loader.loader.FakeWebpackLoader"  # noqa: F405
+WEBPACK_LOADER["DEFAULT"]["LOADER_CLASS"] = "webpack_loader.loaders.FakeWebpackLoader"  # noqa: F405
 
 {%- endif %}
 # Your stuff...


### PR DESCRIPTION
This PR fixes an `webpack_loader` deprecation message.

```
DeprecationWarning: The 'webpack_loader.loader' module has been renamed to 'webpack_loader.loaders'.
```