### PR TITLE
Remove CELERY_BROKER_URL in favor of REDIS_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     env:
-      CELERY_BROKER_URL: "redis://localhost:6379/0"
+      REDIS_URL: "redis://localhost:6379/0"
       # postgres://user:password@host:port/database
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/postgres"
 

--- a/docs/1-getting-started/settings.rst
+++ b/docs/1-getting-started/settings.rst
@@ -39,7 +39,6 @@ The following table lists settings and their defaults for third-party applicatio
 ======================================= =========================== ============================================== ======================================================================
 Environment Variable                    Django Setting              Development Default                            Production Default
 ======================================= =========================== ============================================== ======================================================================
-CELERY_BROKER_URL                       CELERY_BROKER_URL           auto w/ Docker; raises error w/o               raises error
 DJANGO_AWS_ACCESS_KEY_ID                AWS_ACCESS_KEY_ID           n/a                                            raises error
 DJANGO_AWS_SECRET_ACCESS_KEY            AWS_SECRET_ACCESS_KEY       n/a                                            raises error
 DJANGO_AWS_STORAGE_BUCKET_NAME          AWS_STORAGE_BUCKET_NAME     n/a                                            raises error

--- a/docs/2-local-development/developing-locally.rst
+++ b/docs/2-local-development/developing-locally.rst
@@ -55,8 +55,6 @@ First things first.
 #. Set the environment variables for your database(s): ::
 
     $ export DATABASE_URL=postgres://postgres:<password>@127.0.0.1:5432/<DB name given to createdb>
-    # Optional: set broker URL if using Celery
-    $ export CELERY_BROKER_URL=redis://localhost:6379/0
 
    .. note::
 

--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -86,8 +86,6 @@ it's in the ``Procfile``, but is turned off by default:
 
 .. code-block:: bash
 
-    # Set the broker URL to Redis
-    heroku config:set CELERY_BROKER_URL=`heroku config:get REDIS_URL`
     # Scale dyno to 1 instance
     heroku ps:scale worker=1
 

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -33,7 +33,6 @@ docker compose -f docker-compose.local.yml run django python manage.py makemessa
 docker compose -f docker-compose.local.yml run \
   -e DJANGO_SECRET_KEY="$(openssl rand -base64 64)" \
   -e REDIS_URL=redis://redis:6379/0 \
-  -e CELERY_BROKER_URL=redis://redis:6379/0 \
   -e DJANGO_AWS_ACCESS_KEY_ID=x \
   -e DJANGO_AWS_SECRET_ACCESS_KEY=x \
   -e DJANGO_AWS_STORAGE_BUCKET_NAME=x \

--- a/{{cookiecutter.project_slug}}/.drone.yml
+++ b/{{cookiecutter.project_slug}}/.drone.yml
@@ -7,7 +7,7 @@ environment:
   POSTGRES_DB: 'test_{{ cookiecutter.project_slug }}'
   POSTGRES_HOST_AUTH_METHOD: trust
   {%- if cookiecutter.use_celery == 'y' %}
-  CELERY_BROKER_URL: 'redis://redis:6379/0'
+  REDIS_URL: 'redis://redis:6379/0'
   {%- endif %}
 
 steps:

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     env:
       {%- if cookiecutter.use_celery == 'y' %}
-      CELERY_BROKER_URL: 'redis://localhost:6379/0'
+      REDIS_URL: 'redis://localhost:6379/0'
       {%- endif %}
       # postgres://user:password@host:port/database
       DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/postgres'

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   POSTGRES_DB: 'test_{{ cookiecutter.project_slug }}'
   POSTGRES_HOST_AUTH_METHOD: trust
   {%- if cookiecutter.use_celery == 'y' %}
-  CELERY_BROKER_URL: 'redis://redis:6379/0'
+  REDIS_URL: 'redis://redis:6379/0'
   {%- endif %}
 
 precommit:

--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
@@ -13,4 +13,4 @@ echo 'Starting flower'
 
 exec watchfiles --filter python celery.__main__.main \
     --args \
-    "-A config.celery_app -b \"${CELERY_BROKER_URL}\" flower --basic_auth=\"${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}\""
+    "-A config.celery_app -b \"${REDIS_URL}\" flower --basic_auth=\"${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}\""

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -125,9 +125,6 @@ RUN chown -R django:django ${APP_HOME}
 USER django
 
 RUN DATABASE_URL="" \
-  {%- if cookiecutter.use_celery == "y" %}
-  CELERY_BROKER_URL="" \
-  {%- endif %}
   DJANGO_SETTINGS_MODULE="config.settings.test" \
   python manage.py compilemessages
 

--- a/{{cookiecutter.project_slug}}/compose/production/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/celery/flower/start
@@ -14,6 +14,6 @@ echo 'Starting flower'
 
 exec celery \
     -A config.celery_app \
-    -b "${CELERY_BROKER_URL}" \
+    -b "${REDIS_URL}" \
     flower \
     --basic_auth="${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}"

--- a/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
+++ b/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
@@ -4,12 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-
-{% if cookiecutter.use_celery == 'y' %}
-# N.B. If only .env files supported variable expansion...
-export CELERY_BROKER_URL="${REDIS_URL}"
-{% endif %}
-
 if [ -z "${POSTGRES_USER}" ]; then
     base_postgres_image_default_user='postgres'
     export POSTGRES_USER="${base_postgres_image_default_user}"

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -289,7 +289,7 @@ if USE_TZ:
     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+CELERY_BROKER_URL = env("REDIS_URL")
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -282,6 +282,8 @@ LOGGING = {
     "root": {"level": "INFO", "handlers": ["console"]},
 }
 
+REDIS_URL = env("REDIS_URL", default="redis://{% if cookiecutter.use_docker == 'y' %}redis{%else%}localhost{% endif %}:6379/0")
+
 {% if cookiecutter.use_celery == 'y' -%}
 # Celery
 # ------------------------------------------------------------------------------
@@ -289,9 +291,9 @@ if USE_TZ:
     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env("REDIS_URL")
+CELERY_BROKER_URL = REDIS_URL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
-CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_RESULT_BACKEND = REDIS_URL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
 CELERY_RESULT_EXTENDED = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -16,6 +16,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from .base import *  # noqa: F403
 from .base import DATABASES
 from .base import INSTALLED_APPS
+from .base import REDIS_URL
 {%- if cookiecutter.use_drf == "y" %}
 from .base import SPECTACULAR_SETTINGS
 {%- endif %}
@@ -37,7 +38,7 @@ DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": env("REDIS_URL"),
+        "LOCATION": REDIS_URL,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             # Mimicing memcache behavior.

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -26,9 +26,6 @@ else:
     sys.path.insert(0, os.path.abspath(".."))
 {%- endif %}
 os.environ["DATABASE_URL"] = "sqlite:///readthedocs.db"
-{%- if cookiecutter.use_celery == 'y' %}
-os.environ["CELERY_BROKER_URL"] = os.getenv("REDIS_URL", "redis://redis:6379")
-{%- endif %}
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 django.setup()
 


### PR DESCRIPTION
As discussed in https://github.com/cookiecutter/cookiecutter-django/pull/4811 this is how it looks like to remove `CELERY_BROKER_URL`. 

Considering the amount of deletions, this looks like the right path. 