### PR TITLE
Added link to the ruff repository

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -28,7 +28,7 @@ sphinx-autobuild==2024.2.4 # https://github.com/GaretJax/sphinx-autobuild
 
 # Code quality
 # ------------------------------------------------------------------------------
-ruff==0.2.1
+ruff==0.2.1  # https://github.com/astral-sh/ruff
 coverage==7.4.1  # https://github.com/nedbat/coveragepy
 djlint==1.34.1  # https://github.com/Riverside-Healthcare/djLint
 pre-commit==3.6.1  # https://github.com/pre-commit/pre-commit


### PR DESCRIPTION
## Description

Added link to the ruff repository in the requirements file

Checklist:

- [ X ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ X ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

All dependencies have links to their respective repositories. The link for ruff was missing.