### PR TITLE
Install ruff extension in devcontainer.json

### DIFF
--- a/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -35,7 +35,7 @@
                     "analysis.typeCheckingMode": "basic",
                     "defaultInterpreterPath": "/usr/local/bin/python",
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true
+                        "source.organizeImports": "always"
                     },
                     "editor.defaultFormatter": "charliermarsh.ruff",
                     "languageServer": "Pylance",
@@ -54,8 +54,7 @@
                 // python
                 "ms-python.python",
                 "ms-python.vscode-pylance",
-                "ms-python.isort",
-                "ms-python.black-formatter",
+                "charliermarsh.ruff",
                 // django
                 "batisteo.vscode-django"
             ]


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

- No need for black and isort extensions as this is done by ruff.
- Make sure to install ruff extension in VSCode Devcontainers.
- organizeImports is expecting a string.

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
