### PR TITLE
Fix permissions for media files when served by nginx

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -117,7 +117,7 @@ COPY --chown=django:django . ${APP_HOME}
 {%- endif %}
 
 # make django owner of the WORKDIR directory as well.
-RUN chown django:django ${APP_HOME}
+RUN chown -R django:django ${APP_HOME}
 
 USER django
 


### PR DESCRIPTION
## Description

Minor changes: adding a recursive flag in the Django Docker file is needed for proper permissions.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Without this flag in the Docker file, local media files cannot be saved (with no cloud providers) as there are no permissions. Having all folders and files under django:django -> solves those (and similar) problems.

Ref #4478 
Ref #4209 