### PR TITLE
Fix invalid HTML in django-allauth field element template

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/elements/field.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/elements/field.html
@@ -33,7 +33,7 @@
              {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
              value="{{ attrs.value|default_if_none:"" }}"
              type="{{ attrs.type }}" />
-      <label class="form-check-label" for="gridRadios1">
+      <label class="form-check-label" for="{{ attrs.id }}">
         {% slot label %}
       {% endslot %}
     </label>
@@ -62,6 +62,5 @@
 </div>
 {% endif %}
 {% if slots.help_text %}
-  <div class="form-text">{% slot help_text %}</div>
-{% endslot %}
+  <div class="form-text">{% slot help_text %}{% endslot %}</div>
 {% endif %}{% endraw %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I found the HTML validation errors below in the new `django-allauth` overridden field element template. Without fixing these, you might see some side-effects depending on how your browser handles the invalid HTML.
- hard-coded `for` attribute value for a radio button (found on the e-mail management page)
- missing `</div>` for help text which was caused by an out of place `{% endslot %}` (found on the MFA activation page)
