### PR TITLE
Fix fully qualified docker images

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -2,7 +2,7 @@
 FROM docker.io/python:3.11.8-slim-bookworm as python
 
 # Python build stage
-FROM docker.io/python as python-build-stage
+FROM python as python-build-stage
 
 ARG BUILD_ENVIRONMENT=local
 
@@ -22,7 +22,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM docker.io/python as python-run-stage
+FROM python as python-run-stage
 
 ARG BUILD_ENVIRONMENT=local
 ARG APP_HOME=/app

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/python:3.11.8-slim-bookworm as python
 
 
 # Python build stage
-FROM docker.io/python as python-build-stage
+FROM python as python-build-stage
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
@@ -26,7 +26,7 @@ RUN pip wheel --no-cache-dir --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM docker.io/python as python-run-stage
+FROM python as python-run-stage
 
 ARG BUILD_ENVIRONMENT
 ENV PYTHONUNBUFFERED 1

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -28,7 +28,7 @@ RUN npm run build
 FROM docker.io/python:3.11.8-slim-bookworm as python
 
 # Python build stage
-FROM docker.io/python as python-build-stage
+FROM python as python-build-stage
 
 ARG BUILD_ENVIRONMENT=production
 
@@ -48,7 +48,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM docker.io/python as python-run-stage
+FROM python as python-run-stage
 
 ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Fix Python Docker image version not being recognized after adding registry to image names

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #4903
