### PR TITLE
Split the docs from local.yml and build the service in CI

### DIFF
--- a/docs/developing-locally-docker.rst
+++ b/docs/developing-locally-docker.rst
@@ -65,6 +65,13 @@ To run in a detached (background) mode, just::
 
     $ docker compose up -d
 
+These commands don't run the docs service. In order to run docs service you can run::
+
+    $ docker compose -f docs.yml up
+
+To run the docs with local services just use::
+
+    $ docker compose -f local.yml -f docs.yml up
 
 The site should start and be accessible at http://localhost:3000 if you selected Webpack or Gulp as frontend pipeline and http://localhost:8000 otherwise.
 

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -43,7 +43,7 @@ docker compose -f local.yml run \
   django python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
 
 # Generate the HTML for the documentation
-docker compose -f local.yml run docs make html
+docker compose -f docs.yml run docs make html
 
 # Run npm build script if package.json is present
 if [ -f "package.json" ]

--- a/{{cookiecutter.project_slug}}/.drone.yml
+++ b/{{cookiecutter.project_slug}}/.drone.yml
@@ -32,6 +32,7 @@ steps:
     DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
   commands:
   - docker-compose -f local.yml build
+  - docker-compose -f docs.yml build
   - docker-compose -f local.yml run --rm django python manage.py migrate
   - docker-compose -f local.yml up -d
   - docker-compose -f local.yml run django pytest

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Build the Stack
         run: docker compose -f local.yml build django
+        run: docker compose -f local.yml build docs
 
       - name: Run DB Migrations
         run: docker compose -f local.yml run --rm django python manage.py migrate

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -34,6 +34,7 @@ pytest:
     - docker:dind
   before_script:
     - docker compose -f local.yml build
+    - docker compose -f docs.yml build
     # Ensure celerybeat does not crash due to non-existent tables
     - docker compose -f local.yml run --rm django python manage.py migrate
     - docker compose -f local.yml up -d

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -20,6 +20,7 @@ jobs:
         - docker compose -v
         - docker -v
         - docker compose -f local.yml build
+        - docker compose -f docs.yml build
         # Ensure celerybeat does not crash due to non-existent tables
         - docker compose -f local.yml run --rm django python manage.py migrate
         - docker compose -f local.yml up -d

--- a/{{cookiecutter.project_slug}}/docs.yml
+++ b/{{cookiecutter.project_slug}}/docs.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  docs:
+    image: {{ cookiecutter.project_slug }}_local_docs
+    container_name: {{ cookiecutter.project_slug }}_local_docs
+    build:
+      context: .
+      dockerfile: ./compose/local/docs/Dockerfile
+    env_file:
+      - ./.envs/.local/.django
+    volumes:
+      - ./docs:/docs:z
+      - ./config:/app/config:z
+      - ./{{ cookiecutter.project_slug }}:/app/{{ cookiecutter.project_slug }}:z
+    ports:
+      - '9000:9000'
+    command: /start-docs

--- a/{{cookiecutter.project_slug}}/local.yml
+++ b/{{cookiecutter.project_slug}}/local.yml
@@ -40,21 +40,6 @@ services:
     env_file:
       - ./.envs/.local/.postgres
 
-  docs:
-    image: {{ cookiecutter.project_slug }}_local_docs
-    container_name: {{ cookiecutter.project_slug }}_local_docs
-    build:
-      context: .
-      dockerfile: ./compose/local/docs/Dockerfile
-    env_file:
-      - ./.envs/.local/.django
-    volumes:
-      - ./docs:/docs:z
-      - ./config:/app/config:z
-      - ./{{ cookiecutter.project_slug }}:/app/{{ cookiecutter.project_slug }}:z
-    ports:
-      - '9000:9000'
-    command: /start-docs
   {%- if cookiecutter.use_mailpit == 'y' %}
 
   mailpit:


### PR DESCRIPTION
## Description

<!-- Split the docs from local.yml and build the service in CI  -->

Checklist:

- [x] I've split the docs service from the `local.yml` file to the `docs.yml` file
- [x] I've updated the documentation
- [x] I've made sure that we build the docs service in every CI so that we know everything is working

## Rationale
To be more intentional about which services are being started. Also, we can run the docs service in
production environment if we want.

Fix #4867
