### PR TITLE
Add PostgreSQL 16, remove Postgres 10 and 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _These features can be enabled during initial project setup._
 ## Constraints
 
 - Only maintained 3rd party libraries are used.
-- Uses PostgreSQL everywhere: 10 - 16 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
+- Uses PostgreSQL everywhere: 12 - 16 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
 - Environment variables for configuration (This won't work with Apache/mod_wsgi).
 
 ## Support this Project!
@@ -138,8 +138,6 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     3 - 14
     4 - 13
     5 - 12
-    6 - 11
-    7 - 10
     Choose from 1, 2, 3, 4, 5 [1]: 1
     Select cloud_provider:
     1 - AWS

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ _These features can be enabled during initial project setup._
 ## Constraints
 
 - Only maintained 3rd party libraries are used.
-- Uses PostgreSQL everywhere: 10 - 15 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
+- Uses PostgreSQL everywhere: 10 - 16 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
 - Environment variables for configuration (This won't work with Apache/mod_wsgi).
 
 ## Support this Project!
@@ -133,12 +133,13 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     Choose from 1, 2, 3 [1]: 1
     use_docker [n]: n
     Select postgresql_version:
-    1 - 15
-    2 - 14
-    3 - 13
-    4 - 12
-    5 - 11
-    6 - 10
+    1 - 16
+    2 - 15
+    3 - 14
+    4 - 13
+    5 - 12
+    6 - 11
+    7 - 10
     Choose from 1, 2, 3, 4, 5 [1]: 1
     Select cloud_provider:
     1 - AWS

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
   "windows": "n",
   "editor": ["None", "PyCharm", "VS Code"],
   "use_docker": "n",
-  "postgresql_version": ["15", "14", "13", "12", "11", "10"],
+  "postgresql_version": ["16", "15", "14", "13", "12", "11", "10"],
   "cloud_provider": ["AWS", "GCP", "Azure", "None"],
   "mail_service": [
     "Mailgun",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
   "windows": "n",
   "editor": ["None", "PyCharm", "VS Code"],
   "use_docker": "n",
-  "postgresql_version": ["16", "15", "14", "13", "12", "11", "10"],
+  "postgresql_version": ["16", "15", "14", "13", "12"],
   "cloud_provider": ["AWS", "GCP", "Azure", "None"],
   "mail_service": [
     "Mailgun",

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -71,8 +71,6 @@ postgresql_version:
     3. 14
     4. 13
     5. 12
-    6. 11
-    7. 10
 
 cloud_provider:
     Select a cloud provider for static & media files. The choices are:

--- a/docs/project-generation-options.rst
+++ b/docs/project-generation-options.rst
@@ -66,12 +66,13 @@ use_docker:
 postgresql_version:
     Select a PostgreSQL_ version to use. The choices are:
 
-    1. 15
-    2. 14
-    3. 13
-    4. 12
-    5. 11
-    6. 10
+    1. 16
+    2. 15
+    3. 14
+    4. 13
+    5. 12
+    6. 11
+    7. 10
 
 cloud_provider:
     Select a cloud provider for static & media files. The choices are:

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -62,8 +62,6 @@ SUPPORTED_COMBINATIONS = [
     {"postgresql_version": "14"},
     {"postgresql_version": "13"},
     {"postgresql_version": "12"},
-    {"postgresql_version": "11"},
-    {"postgresql_version": "10"},
     {"cloud_provider": "AWS", "use_whitenoise": "y"},
     {"cloud_provider": "AWS", "use_whitenoise": "n"},
     {"cloud_provider": "GCP", "use_whitenoise": "y"},

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -57,6 +57,7 @@ SUPPORTED_COMBINATIONS = [
     {"editor": "VS Code"},
     {"use_docker": "y"},
     {"use_docker": "n"},
+    {"postgresql_version": "16"},
     {"postgresql_version": "15"},
     {"postgresql_version": "14"},
     {"postgresql_version": "13"},


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Add PostgreSQL 16 to the versions of choice.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Psycopg 3 supports PostgreSQL from version 10 to 16. Fix #4920
