### PR TITLE
Update mentions of psycopg in comments

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_ENVIRONMENT=local
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev
 
 # Requirements are installed here to ensure they will be cached.
@@ -47,7 +47,7 @@ RUN groupadd --gid 1000 dev-user \
 
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
   # Translations dependencies
   gettext \

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
@@ -35,7 +35,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # To run the Makefile
   make \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
   # Translations dependencies
   gettext \

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -36,7 +36,7 @@ ARG BUILD_ENVIRONMENT=production
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev
 
 # Requirements are installed here to ensure they will be cached.
@@ -65,7 +65,7 @@ RUN addgroup --system django \
 
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
   # Translations dependencies
   gettext \

--- a/{{cookiecutter.project_slug}}/utility/requirements-bionic.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-bionic.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-bookworm.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-bookworm.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-bullseye.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-bullseye.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-buster.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-buster.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-focal.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-focal.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-jammy.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-jammy.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-jessie.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-jessie.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-stretch.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-stretch.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-trusty.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-trusty.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies

--- a/{{cookiecutter.project_slug}}/utility/requirements-xenial.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-xenial.apt
@@ -9,7 +9,7 @@ python3-dev
 ##Pillow, pylibmc
 zlib1g-dev
 
-##Postgresql and psycopg2 dependencies
+##Postgresql and psycopg dependencies
 libpq-dev
 
 ##Pillow dependencies


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Removing the comments mentioning `psycopg2` as it has been upgraded in a previous commit: https://github.com/cookiecutter/cookiecutter-django/pull/4421/files

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

I also checked that the dependency mentioned is still needed with `psycopg3`.
Source: https://www.psycopg.org/psycopg3/docs/basic/install.html
```
PostgreSQL client development headers (e.g. the libpq-dev package).
```

## Rationale

Updated comments.