### PR TITLE
Change pytest import mode to importlib

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,7 +1,7 @@
 # ==== pytest ====
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ds=config.settings.test --reuse-db"
+addopts = "--ds=config.settings.test --reuse-db --import-mode=importlib"
 python_files = [
     "tests.py",
     "test_*.py",


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Change pytest import mode to importlib

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Based on https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#choosing-an-import-mode :

"For historical reasons, pytest defaults to the prepend import mode instead of the importlib import mode we recommend for new projects. The reason lies in the way the prepend mode works:

Since there are no packages to derive a full package name from, pytest will import your test files as top-level modules. The test files in the first example (src layout) would be imported as test_app and test_view top-level modules by adding tests/ to sys.path.

This results in a drawback compared to the import mode importlib: your test files must have unique names. (...)
The importlib import mode does not have any of the drawbacks above, because sys.path is not changed when importing test modules.
"

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
