### PR TITLE
Use main over master for branch name in deployment-on-heroku instruction

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -46,7 +46,7 @@ Run these commands to deploy the project to Heroku:
     # Assign with AWS_STORAGE_BUCKET_NAME
     heroku config:set DJANGO_AWS_STORAGE_BUCKET_NAME=
 
-    git push heroku master
+    git push heroku main
 
     heroku run python manage.py createsuperuser
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The newer convention(although it has been years) is to use `main` as the default branch over `master`. Newly created cookiecutter projects are more likely to have the default branch as `main` rather than `master`