### PR TITLE
Remove double RUN cmd in ci.yml

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
 
       - name: Build the Stack
         run: docker compose -f local.yml build django
-        run: docker compose -f local.yml build docs
 
       - name: Run DB Migrations
         run: docker compose -f local.yml run --rm django python manage.py migrate


### PR DESCRIPTION
Remove double RUN cmd

## Description

Remove `run: docker compose -f local.yml build docs`

## Rationale

Not fixing this throws the following error during pre-commit: `found duplicate key "run" with value "docker compose -f local.yml build docs" (original value: "docker compose -f local.yml build django")`
