### PR TITLE
change obsolete docker image "docker/compose:1.29.2" to "docker:25.0"

### DIFF
--- a/{{cookiecutter.project_slug}}/.drone.yml
+++ b/{{cookiecutter.project_slug}}/.drone.yml
@@ -27,7 +27,7 @@ steps:
 - name: test
   pull: if-not-exists
   {%- if cookiecutter.use_docker == 'y' %}
-  image: docker/compose:1.29.2
+  image: docker:25.0
   environment:
     DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
   commands:

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -27,7 +27,7 @@ precommit:
 pytest:
   stage: test
   {%- if cookiecutter.use_docker == 'y' %}
-  image: docker/compose:1.29.2
+  image: docker:25.0
   tags:
     - docker
   services:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description
There was a commit #4463 where "docker-compose" was [changed](https://github.com/cookiecutter/cookiecutter-django/blob/f567b5f685c0225c2402a3e90758d8cdd66d8ed1/%7B%7Bcookiecutter.project_slug%7D%7D/.gitlab-ci.yml#L36) to "docker compose" but the build image for [.gitlab.yml](https://github.com/cookiecutter/cookiecutter-django/blob/f567b5f685c0225c2402a3e90758d8cdd66d8ed1/%7B%7Bcookiecutter.project_slug%7D%7D/.gitlab-ci.yml#L30) was unchanged and as [docker/compose](https://hub.docker.com/r/docker/compose) image reached EOL so there is no support for "docker compose" command. Docker compose is now included as part of Docker official image. 
Also the same obsolete image is used for [.drone.yml ](https://github.com/cookiecutter/cookiecutter-django/blob/35f21ba6973b5b3e7151657af5f1b2ce432f3b9c/%7B%7Bcookiecutter.project_slug%7D%7D/.drone.yml#L30) pipeline config.
