### PR TITLE
Update GH actions to resolve deprecation warnings

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -34,7 +34,7 @@ jobs:
       # Consider using pre-commit.ci for open source project
       {%- endif %}
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   # With no caching at all the entire ci process takes 3m to complete!
   pytest:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

Update actions' version in Github Actions CI Workflow to remove the following deprecation warning:
`linter
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
`
