### PR TITLE
Add options to reload django when file changes in windows docker

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -83,15 +83,15 @@ if env("USE_DOCKER") == "yes":
         # The node container isn't started (yet?)
         pass
     {%- endif %}
-{% if cookiecutter.windows == 'y' %}
-# RunServerPlus
-# ------------------------------------------------------------------------------
-# After how many seconds auto-reload should scan for updates in poller-mode
-RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 5
-
-# Werkzeug reloader type [auto, watchdog, or stat]
-RUNSERVERPLUS_POLLER_RELOADER_TYPE = 'stat'
-{% endif %}
+    {%- if cookiecutter.windows == 'y' %}
+    # RunServerPlus
+    # ------------------------------------------------------------------------------
+    # This is a custom setting for RunServerPlus to fix reloader issue in Windows docker environment
+    # Werkzeug reloader type [auto, watchdog, or stat]
+    RUNSERVERPLUS_POLLER_RELOADER_TYPE = 'stat'
+    # If you have CPU and IO load issues, you can increase this poller interval e.g) 5
+    RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 1
+    {%- endif %}
 {%- endif %}
 
 # django-extensions

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -83,6 +83,15 @@ if env("USE_DOCKER") == "yes":
         # The node container isn't started (yet?)
         pass
     {%- endif %}
+{% if cookiecutter.windows == 'y' %}
+# RunServerPlus
+# ------------------------------------------------------------------------------
+# After how many seconds auto-reload should scan for updates in poller-mode
+RUNSERVERPLUS_POLLER_RELOADER_INTERVAL = 5
+
+# Werkzeug reloader type [auto, watchdog, or stat]
+RUNSERVERPLUS_POLLER_RELOADER_TYPE = 'stat'
+{% endif %}
 {%- endif %}
 
 # django-extensions


### PR DESCRIPTION
## Description
Supporting django auto reload in windows docker.

## Rationale
Now it doesn't reload when django code is changed in windows docker env.
The problem is related to wsl2 and Werkzeug's built-in reloading system.
So it can be fixed with stat polling options.

FIX #4970 