### PR TITLE
Add a prefix setting so that swagger tags are generated in a readable way

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -372,6 +372,7 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Documentation of API endpoints of {{ cookiecutter.project_name }}",
     "VERSION": "1.0.0",
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
+    "SCHEMA_PATH_PREFIX": "/api/",
 }
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -43,7 +43,7 @@ urlpatterns += [
     # API base url
     path("api/", include("config.api_router")),
     # DRF auth token
-    path("auth-token/", obtain_auth_token),
+    path("api/auth-token/", obtain_auth_token),
     path("api/schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
         "api/docs/",


### PR DESCRIPTION
## Description

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

>   
```python
    # A regex specifying the common denominator for all operation paths. If
    # SCHEMA_PATH_PREFIX is set to None, drf-spectacular will attempt to estimate
    # a common prefix. Use '' to disable.
    # Mainly used for tag extraction, where paths like '/api/v1/albums' with
    # a SCHEMA_PATH_PREFIX regex '/api/v[0-9]' would yield the tag 'albums'.
    'SCHEMA_PATH_PREFIX': None,
```

In drf-spectacular, [there is an option "SCHEMA_PATH_PREFIX"](https://drf-spectacular.readthedocs.io/en/latest/settings.html), which drf-spectacular uses to create new Swagger tags based on this value.

I think this will be a good change, as it will allow us to create unambiguous tags (tags=....) based on the prefix at document creation time without any additional work.

The api-auth URL also belongs to the API, so I've updated the path.


Without this change, API documentation is generated as follows by default:
<img width="2032" alt="스크린샷 2024-04-08 오전 12 14 59" src="https://github.com/cookiecutter/cookiecutter-django/assets/88619089/c66bccf6-f019-4068-9860-23a715eb0c1f">

If you apply this change, your API documentation will be generated with clear tags as shown below:
<img width="1552" alt="스크린샷 2024-04-07 오후 6 49 15" src="https://github.com/cookiecutter/cookiecutter-django/assets/88619089/44eea5b8-4201-465b-be36-8c7209cfd6c9">

If a user defines a new endpoint, such as /api/books/, a new tag will be generated appropriately.

Thanks!