### PR TITLE
Fix start command for docs

### DIFF
--- a/docs/document.rst
+++ b/docs/document.rst
@@ -11,7 +11,7 @@ After you have set up to `develop locally`_, run the following command from the 
 
 If you set up your project to `develop locally with docker`_, run the following command: ::
 
-    $ docker compose -f local.yml up docs
+    $ docker compose -f docs.yml up
 
 Navigate to port 9000 on your host to see the documentation. This will be opened automatically at `localhost`_ for local, non-docker development.
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
Because docs service moved to docs.yml from local.yml. change the command in documents.rst
<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
