### PR TITLE
Update docs for `test_bare.sh`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,13 @@ $ source venv/bin/activate
 
 These tests are slower and can be run with or without Docker:
 
-- Without Docker: `scripts/test_bare.sh` (for bare metal)
-- With Docker: `scripts/test_docker.sh`
+- Without Docker: `tests/test_bare.sh` (for bare metal)
+- With Docker: `tests/test_docker.sh`
 
 All arguments to these scripts will be passed to the `cookiecutter` CLI, letting you set options, for example:
 
 ```bash
-$ scripts/test_bare.sh use_celery=y
+$ tests/test_bare.sh use_celery=y
 ```
 
 ## Submitting a pull request


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Fixed `CONTRIBUTING.md` to point to the right location for `test_docker.sh` and `test_bare.sh`

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

It seems these files were moved from `scripts/` to `tests/`, and configs referencing them were updated but docs weren't.