### PR TITLE
Update start-flower in flower to wait until all celery workers are online

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/local/django/celery/flower/start
@@ -3,6 +3,14 @@
 set -o errexit
 set -o nounset
 
+
+until timeout 10 celery -A config.celery_app inspect ping; do
+    >&2 echo "Celery workers not available"
+done
+
+echo 'Starting flower'
+
+
 exec watchfiles --filter python celery.__main__.main \
     --args \
     "-A config.celery_app -b \"${CELERY_BROKER_URL}\" flower --basic_auth=\"${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}\""

--- a/{{cookiecutter.project_slug}}/compose/production/django/celery/flower/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/celery/flower/start
@@ -4,6 +4,14 @@ set -o errexit
 set -o nounset
 
 
+
+until timeout 10 celery -A config.celery_app inspect ping; do
+    >&2 echo "Celery workers not available"
+done
+
+echo 'Starting flower'
+
+
 exec celery \
     -A config.celery_app \
     -b "${CELERY_BROKER_URL}" \


### PR DESCRIPTION
Flower needs to start only after the celery workers come online. otherwise one will see errors like `inspect method failed` etc

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
