### PR TITLE
Typo fix in url link for sphinx-doc

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/howto.rst
+++ b/{{cookiecutter.project_slug}}/docs/howto.rst
@@ -26,7 +26,7 @@ Changes to files in `docs/_source` will be picked up and reloaded automatically.
 Docstrings to Documentation
 ----------------------------------------------------------------------
 
-The sphinx extension `apidoc <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html/>`_ is used to automatically document code using signatures and docstrings.
+The sphinx extension `apidoc <https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html>`_ is used to automatically document code using signatures and docstrings.
 
 Numpy or Google style docstrings will be picked up from project files and available for documentation. See the `Napoleon <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/>`_ extension for details.
 


### PR DESCRIPTION
## Description

Fixed typo on url for sphinx-doc that had an extra forward slash at the end. A 404 page not found response is returned when navigating to the current url if the forward slash is present.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

With the extra forward slash at the end of the url the read-the-docs page returns a 404 response and could confuse users.
