### PR TITLE
Disable UP038 Ruff rule to avoid introducing slower code

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -150,11 +150,20 @@ select = [
 ignore = [
   "S101", # Use of assert detected https://docs.astral.sh/ruff/rules/assert/
   "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
-  "SIM102" # sometimes it's better to nest
+  "SIM102", # sometimes it's better to nest
+  "UP038" # Checks for uses of isinstance/issubclass that take a tuple 
+          # of types for comparison.
+          # Deactivated because it can make the code slow: 
+          # https://github.com/astral-sh/ruff/issues/7871
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []
+# The fixes in extend-unsafe-fixes will require 
+# provide the `--unsafe-fixes` flag when fixing.
+extend-unsafe-fixes = [
+    "UP038"
+]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 


### PR DESCRIPTION
## Description

Disable the [UP038](https://docs.astral.sh/ruff/rules/non-pep604-isinstance/) Ruff rule to avoid introducing valid code, which is slower due to the lack of optimization in the Python interpreter itself.

This rule also does not exist in `pyupgrade` for the same reason.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Although Python 3.10 starts to support the use of Union in `isinstance` and `issubclass`, there is a considerable performance loss compared to using `tuple`, which has not yet been fully resolved in the Python interpreter.

[Python 3.11 has improved performance but is still 4x slower than using tuples](https://github.com/python/cpython/issues/91603#issue-1206079854). Maybe it will be resolved in Python 3.13.
Check https://github.com/astral-sh/ruff/issues/7871

