### PR TITLE
Fix nginx image name in production.yml

### DIFF
--- a/{{cookiecutter.project_slug}}/production.yml
+++ b/{{cookiecutter.project_slug}}/production.yml
@@ -102,7 +102,7 @@ services:
     build:
       context: .
       dockerfile: ./compose/production/nginx/Dockerfile
-    image: {{ cookiecutter.project_slug }}_local_nginx
+    image: {{ cookiecutter.project_slug }}_production_nginx
     depends_on:
       - django
     volumes:


### PR DESCRIPTION
## Description

`_local_` is used in local.yml, in the production file we want the image name to be `_production_`