### PR TITLE
Update Two scoops of Django book link & image

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,15 @@ This project is an open source project run by volunteers. You can sponsor us via
 
 Projects that provide financial support to the maintainers:
 
----
+### Two Scoops of Django
 
-<p align="center">
-  <a href="https://www.feldroy.com/products//two-scoops-of-django-3-x"><img src="https://cdn.shopify.com/s/files/1/0304/6901/products/Two-Scoops-of-Django-3-Alpha-Cover_540x_26507b15-e489-470b-8a97-02773dd498d1_1080x.jpg"></a>
-</p>
+[![Cover of the book "Two Scoops of Django 3.x"](https://www.feldroy.com/static/book-TSD3-800.jpg)](https://www.feldroy.com/two-scoops-press#two-scoops-of-django)
 
 Two Scoops of Django 3.x is the best ice cream-themed Django reference in the universe!
 
 ### PyUp
 
-<p align="center">
-  <a href="https://pyup.io/"><img src="https://pyup.io/static/images/logo.png"></a>
-</p>
+[![PyUp Logo](https://pyup.io/static/images/logo.png)](https://pyup.io)
 
 PyUp brings you automated security and dependency updates used by Google and other organizations. Free for open source projects!
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -24,4 +24,4 @@ Why doesn't this follow the layout from Two Scoops of Django?
 
 You may notice that some elements of this project do not exactly match what we describe in chapter 3 of `Two Scoops of Django 3.x`_. The reason for that is this project, amongst other things, serves as a test bed for trying out new ideas and concepts. Sometimes they work, sometimes they don't, but the end result is that it won't necessarily match precisely what is described in the book I co-authored.
 
-.. _Two Scoops of Django 3.x: https://www.feldroy.com/books/two-scoops-of-django-3-x
+.. _Two Scoops of Django 3.x: https://www.feldroy.com/two-scoops-press#two-scoops-of-django


### PR DESCRIPTION
## Description

The book link for "Two Scoops of Django 3.x" was a 404; updated to the current page & pointed to a current cover image. Changed the HTML `<img>` tags to use markdown instead, removed `<p>` center tags

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
  - (Not relevant for documentation)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Just small updates to direct folks correctly to be able to support the relevant author.