### PR TITLE
Fix redirect error when forcing allauth login in admin site

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -1,7 +1,7 @@
+from allauth.account.decorators import secure_admin_login
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
-from django.contrib.auth.decorators import login_required
 from django.utils.translation import gettext_lazy as _
 
 from .forms import UserAdminChangeForm
@@ -11,7 +11,8 @@ from .models import User
 if settings.DJANGO_ADMIN_FORCE_ALLAUTH:
     # Force the `admin` sign in process to go through the `django-allauth` workflow:
     # https://docs.allauth.org/en/latest/common/admin.html#admin
-    admin.site.login = login_required(admin.site.login)  # type: ignore[method-assign]
+    admin.autodiscover()
+    admin.site.login = secure_admin_login(admin.site.login)  # type: ignore[method-assign]
 
 
 @admin.register(User)


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

I brought up the issue described in #4766 directly in django-allauth.
Since the release 0.63.1 this issue is fixed and the documentation is updated.
Allauth 0.63.1 is already merged into cookiecutter.
This PR implements the new workaround documented in the [allauth docs](https://docs.allauth.org/en/latest/common/admin.html#admin).

This fixes #4766.
<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
