### PR TITLE
Fix PyCharm Run Configurations After local.yml Rename

### DIFF
--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_django.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_django.xml
@@ -15,7 +15,7 @@
             {%- endif %}
           </list>
         </option>
-        <option name="sourceFilePath" value="local.yml"/>
+        <option name="sourceFilePath" value="docker-compose.local.yml"/>
       </settings>
     </deployment>
     <method v="2"/>

--- a/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
+++ b/{{cookiecutter.project_slug}}/.idea/runConfigurations/docker_compose_up_docs.xml
@@ -8,7 +8,7 @@
             <option value="docs"/>
           </list>
         </option>
-        <option name="sourceFilePath" value="local.yml"/>
+        <option name="sourceFilePath" value="docker-compose.local.yml"/>
       </settings>
     </deployment>
     <method v="2"/>


### PR DESCRIPTION
## Description

This pull request addresses a compatibility issue in PyCharm run configurations caused by the renaming of local.yml to docker-compose.local.yml in commit [10c85ce](https://github.com/cookiecutter/cookiecutter-django/commit/10c85ce3d644ff7190b3d1bf1309386feee90b02)

This change is purely a fix for a compatibility issue and should not introduce any new functionality or breaking changes.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

- Maintains consistency across the project's configuration files.
- Ensures a smooth onboarding experience for new users who might encounter errors due to the file reference

