### PR TITLE
Replace deprecated `uvicorn.workers` with `uvicorn-worker`

### DIFF
--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -1,6 +1,6 @@
 release: python manage.py migrate
 {%- if cookiecutter.use_async == "y" %}
-web: gunicorn config.asgi:application -k uvicorn-worker.UvicornWorker
+web: gunicorn config.asgi:application -k uvicorn_worker.UvicornWorker
 {%- else %}
 web: gunicorn config.wsgi:application
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -1,6 +1,6 @@
 release: python manage.py migrate
 {%- if cookiecutter.use_async == "y" %}
-web: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker
+web: gunicorn config.asgi:application -k uvicorn-worker.UvicornWorker
 {%- else %}
 web: gunicorn config.wsgi:application
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -28,7 +28,7 @@ if compress_enabled; then
 fi
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
-exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
+exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn-worker.UvicornWorker
 {%- else %}
 exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -28,7 +28,7 @@ if compress_enabled; then
 fi
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
-exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn-worker.UvicornWorker
+exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn_worker.UvicornWorker
 {%- else %}
 exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -106,7 +106,7 @@ function imgCompression() {
 function asyncRunServer() {
   const cmd = spawn(
     'gunicorn',
-    ['config.asgi', '-k', 'uvicorn-worker.UvicornWorker', '--reload'],
+    ['config.asgi', '-k', 'uvicorn_worker.UvicornWorker', '--reload'],
     {stdio: 'inherit'},
   );
   cmd.on('close', function (code) {

--- a/{{cookiecutter.project_slug}}/gulpfile.js
+++ b/{{cookiecutter.project_slug}}/gulpfile.js
@@ -106,7 +106,7 @@ function imgCompression() {
 function asyncRunServer() {
   const cmd = spawn(
     'gunicorn',
-    ['config.asgi', '-k', 'uvicorn.workers.UvicornWorker', '--reload'],
+    ['config.asgi', '-k', 'uvicorn-worker.UvicornWorker', '--reload'],
     {stdio: 'inherit'},
   );
   cmd.on('close', function (code) {

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -24,6 +24,7 @@ flower==2.0.1  # https://github.com/mher/flower
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
 uvicorn[standard]==0.30.0  # https://github.com/encode/uvicorn
+uvicorn-worker==0.2.0 # https://github.com/Kludex/uvicorn-worker
 {%- endif %}
 
 # Django


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description
This PR replaces all references to the deprecated `uvicorn.workers` module in favor of `uvicorn-worker`. 

Closes #5109 
<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
