### PR TITLE
Change aws-cli docker image to use official amazon image

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/garland/aws-cli-docker:1.16.140
+FROM docker.io/amazon/aws-cli:2.15.58
 
 COPY ./compose/production/aws/maintenance /usr/local/bin/maintenance
 COPY ./compose/production/postgres/maintenance/_sourced /usr/local/bin/maintenance/_sourced


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->
Updated the docker image for AWS CLI to official Amazon docker image. 

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
I have updated the docker image for AWS CLI to official Amazon docker image. The old version does not work on arm based compute machines (raspberry pi). This new update works on raspberry pi too and has been tested. 