### PR TITLE
Honor env variable WEB_CONCURRENCY when running gunicorn

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -27,6 +27,10 @@ if compress_enabled; then
   python /app/manage.py compress
 fi
 {%- endif %}
+
+# The number of worker processes for handling requests. [default: 4]
+WEB_CONCURRENCY=${WEB_CONCURRENCY:-4}
+
 {%- if cookiecutter.use_async == 'y' %}
 exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 -w $WEB_CONCURRENCY --chdir=/app -k uvicorn.workers.UvicornWorker
 {%- else %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/start
+++ b/{{cookiecutter.project_slug}}/compose/production/django/start
@@ -28,7 +28,7 @@ if compress_enabled; then
 fi
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' %}
-exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
+exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 -w $WEB_CONCURRENCY --chdir=/app -k uvicorn.workers.UvicornWorker
 {%- else %}
-exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app
+exec /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 -w $WEB_CONCURRENCY --chdir=/app
 {%- endif %}


### PR DESCRIPTION
## Description

At the moment, `WEB_CONCURRENCY` env variable is only used on Heroku & PythonAnywhere.
We expect it to work when running with docker, this patch allow to configure the number of worker which by default is 4 on gunicorn.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates


