### PR TITLE
Gitlab-ci tags docker & python are removed from runner

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -28,8 +28,6 @@ pytest:
   stage: test
   {%- if cookiecutter.use_docker == 'y' %}
   image: docker:25.0
-  tags:
-    - docker
   services:
     - docker:dind
   before_script:
@@ -42,8 +40,6 @@ pytest:
     - docker compose -f docker-compose.local.yml run django pytest
   {%- else %}
   image: python:3.12
-  tags:
-    - python
   services:
     - postgres:{{ cookiecutter.postgresql_version }}
   variables:


### PR DESCRIPTION
Gitlab has remove the `docker` and `python` tags from their runner configuration. The default runner remains unchanged and suitable for this project. 

> NOTE: The small SaaS runner on Linux is configured to run untagged jobs, this remains unchanged. So if you're using the small Linux runner but haven't specified a tag, the behavior of your job will not change.

https://gitlab.com/gitlab-org/gitlab-runner/-/issues/30829

Fixes https://github.com/cookiecutter/cookiecutter-django/issues/5148