### PR TITLE
Fix keywords case warning in Dockerfile

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -1,8 +1,8 @@
 # define an alias for the specific python version used in this file.
-FROM docker.io/python:3.12.4-slim-bookworm as python
+FROM docker.io/python:3.12.4-slim-bookworm AS python
 
 # Python build stage
-FROM python as python-build-stage
+FROM python AS python-build-stage
 
 ARG BUILD_ENVIRONMENT=local
 
@@ -22,7 +22,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM python AS python-run-stage
 
 ARG BUILD_ENVIRONMENT=local
 ARG APP_HOME=/app

--- a/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/docs/Dockerfile
@@ -1,9 +1,9 @@
 # define an alias for the specific python version used in this file.
-FROM docker.io/python:3.12.4-slim-bookworm as python
+FROM docker.io/python:3.12.4-slim-bookworm AS python
 
 
 # Python build stage
-FROM python as python-build-stage
+FROM python AS python-build-stage
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
@@ -26,7 +26,7 @@ RUN pip wheel --no-cache-dir --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM python AS python-run-stage
 
 ARG BUILD_ENVIRONMENT
 ENV PYTHONUNBUFFERED 1

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -1,5 +1,5 @@
 {% if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] -%}
-FROM docker.io/node:20-bookworm-slim as client-builder
+FROM docker.io/node:20-bookworm-slim AS client-builder
 
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
@@ -25,10 +25,10 @@ RUN npm run build
 
 {%- endif %}
 # define an alias for the specific python version used in this file.
-FROM docker.io/python:3.12.4-slim-bookworm as python
+FROM docker.io/python:3.12.4-slim-bookworm AS python
 
 # Python build stage
-FROM python as python-build-stage
+FROM python AS python-build-stage
 
 ARG BUILD_ENVIRONMENT=production
 
@@ -48,7 +48,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM python AS python-run-stage
 
 ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Recently noticed the following warning in my Docker builds (using https://github.com/docker/build-push-action):

> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match

I don't think it's causing any harm, apart perhaps some small noise in the logs... Seems like a good thing to do for consistency of keywords.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

- Fix noisy warning
- More consistent usage of keywords in Dockerfile
- https://docs.docker.com/reference/build-checks/from-as-casing/