### PR TITLE
Fix: clear ENTRYPOINT in derived image to allow script execution

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker.io/amazon/aws-cli:2.17.0
 
+# Clear entrypoint from the base image, otherwise it's always calling the aws CLI
 ENTRYPOINT []
 
 COPY ./compose/production/aws/maintenance /usr/local/bin/maintenance

--- a/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/amazon/aws-cli:2.17.0
 
+ENTRYPOINT []
+
 COPY ./compose/production/aws/maintenance /usr/local/bin/maintenance
 COPY ./compose/production/postgres/maintenance/_sourced /usr/local/bin/maintenance/_sourced
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Clear ENTRYPOINT in derived image from `docker.io/amazon/aws-cli:2.17.0` to allow upload and download script execution.

Since switching to official Amazon docker image (with ENTRYPOINT) in eec17f7c57a50bcf96deeedbb0fa1c208031de3f, the examples in documentation ([PostgreSQL Backups with Docker](https://cookiecutter-django.readthedocs.io/en/latest/docker-postgres-backups.html)) didn't work

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5217.