### PR TITLE
Downgrade watchfiles

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -8,7 +8,7 @@ psycopg[c]==3.2.1  # https://github.com/psycopg/psycopg
 psycopg[binary]==3.2.1  # https://github.com/psycopg/psycopg
 {%- endif %}
 {%- if cookiecutter.use_async == 'y' or cookiecutter.use_celery == 'y' %}
-watchfiles==0.22.0  # https://github.com/samuelcolvin/watchfiles
+watchfiles==0.21.0  # https://github.com/samuelcolvin/watchfiles
 {%- endif %}
 
 # Testing


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

When starting a new cookiecutter project with celery, it show the following error messages:

```
Error: No nodes replied within time constraint
Celery workers not available.
```
And also:
```
_rust_notify.WatchfilesRustInternalError: error in underlying watcher: IO error for operation on <path>: No such file or directory (os error 2)
```


Options used:
```
python_version = "3.12"
cloud_provider = 4
use_async = n
use_celery = y
```

It can be fixed by downgrading watchfiles again to 21.0
I followed this discussion https://github.com/encode/uvicorn/discussions/2361

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Fix for https://github.com/cookiecutter/cookiecutter-django/issues/5242