### PR TITLE
return 403 when viewing other user's profile

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -103,7 +103,7 @@ class TestUserDetailView:
         response = user_detail_view(request, username=user.username)
         {%- endif %}
 
-        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.status_code == HTTPStatus.OK
 
     def test_not_authenticated(self, user: User, rf: RequestFactory):
         request = rf.get("/fake-url/")

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -103,7 +103,7 @@ class TestUserDetailView:
         response = user_detail_view(request, username=user.username)
         {%- endif %}
 
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.FORBIDDEN
 
     def test_not_authenticated(self, user: User, rf: RequestFactory):
         request = rf.get("/fake-url/")

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -22,7 +22,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 
     def get_object(self, queryset=None):
         obj = super().get_object(queryset)
-        if obj.id != self.request.user.id:
+        if obj.username != self.request.user.username:
             raise PermissionDenied
         return obj
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView
 from django.views.generic import RedirectView
 from django.views.generic import UpdateView
+from django.core.exceptions import PermissionDenied
 
 from {{ cookiecutter.project_slug }}.users.models import User
 
@@ -19,6 +20,11 @@ class UserDetailView(LoginRequiredMixin, DetailView):
     slug_url_kwarg = "username"
     {%- endif %}
 
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset)
+        if obj.id != self.request.user.id:
+            raise PermissionDenied
+        return obj
 
 user_detail_view = UserDetailView.as_view()
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -22,7 +22,11 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 
     def get_object(self, queryset=None):
         obj = super().get_object(queryset)
+        {%- if cookiecutter.username_type == "email" %}
+        if obj.id != self.request.user.id:
+        {%- else %}
         if obj.username != self.request.user.username:
+        {%- endif %}
             raise PermissionDenied
         return obj
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -1,11 +1,11 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView
 from django.views.generic import RedirectView
 from django.views.generic import UpdateView
-from django.core.exceptions import PermissionDenied
 
 from {{ cookiecutter.project_slug }}.users.models import User
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

This change addresses [#5253](https://github.com/cookiecutter/cookiecutter-django/issues/5253), by returning a `PermissionDenied` error page when a user attempts to visit the profile page of a different user.

I've made this change since these profile pages will generally have private information such as email address.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5253
