### PR TITLE
Set allauth email subject prefix

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -224,10 +224,11 @@ DEFAULT_FROM_EMAIL = env(
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
-ACCOUNT_EMAIL_SUBJECT_PREFIX = env(
-    "DJANGO_ACCOUNT_EMAIL_SUBJECT_PREFIX",
+EMAIL_SUBJECT_PREFIX = env(
+    "DJANGO_EMAIL_SUBJECT_PREFIX",
     default="[{{cookiecutter.project_name}}] ",
 )
+ACCOUNT_EMAIL_SUBJECT_PREFIX = EMAIL_SUBJECT_PREFIX
 
 # ADMIN
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -224,8 +224,8 @@ DEFAULT_FROM_EMAIL = env(
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-subject-prefix
-EMAIL_SUBJECT_PREFIX = env(
-    "DJANGO_EMAIL_SUBJECT_PREFIX",
+ACCOUNT_EMAIL_SUBJECT_PREFIX = env(
+    "DJANGO_ACCOUNT_EMAIL_SUBJECT_PREFIX",
     default="[{{cookiecutter.project_name}}] ",
 )
 


### PR DESCRIPTION
## Description

As I was working with cookiecutter django on a personal project I encountered an issue with one of the variables handling the email details.

- I've made a small change in `production.py` file regarding the name of `EMAIL_SUBJECT_PREFIX`.
- I've NOT updated the documentation, because I didn't want to mess up the srt file (new var name was a bit long).

You can read more on this stackoverflow [answer](https://stackoverflow.com/a/60416998/14615155).