### PR TITLE
Add missing extra_body block in allauth entrance.html

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/entrance.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/entrance.html
@@ -24,6 +24,8 @@
       {% endif %}
       {% block content %}
       {% endblock content %}
+      {% block extra_body %}
+      {% endblock extra_body %}
     </div>
   </div>
 {% endblock body %}{% endraw %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Adding `extra_block` block into `/templates/allauth/layouts/entrance.html`

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
`django-allauth`'s WebAuthn MFA option is not working because `extra_body` block is missing. The block has JavaScript required.
