### PR TITLE
Add type hint for UserFactory

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -8,7 +8,7 @@ from factory.django import DjangoModelFactory
 from {{ cookiecutter.project_slug }}.users.models import User
 
 
-class UserFactory(DjangoModelFactory):
+class UserFactory(DjangoModelFactory[User]):
     {%- if cookiecutter.username_type == "username" %}
     username = Faker("user_name")
     {%- endif %}


### PR DESCRIPTION

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Since factory-boy 3.3.1, we can type annotate factories:

https://github.com/FactoryBoy/factory_boy/pull/1059

Setting that up for the only factory of the project

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option): rely on existing mypy test
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Demonstrate best practice as part of the project
