### PR TITLE
Remove unnecessary --dry-run flag

### DIFF
--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -24,7 +24,7 @@ docker compose -f docker-compose.local.yml run django mypy my_awesome_project
 docker compose -f docker-compose.local.yml run django pytest
 
 # return non-zero status code if there are migrations that have not been created
-docker compose -f docker-compose.local.yml run django python manage.py makemigrations --dry-run --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
+docker compose -f docker-compose.local.yml run django python manage.py makemigrations --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
 
 # Test support for translations
 docker compose -f docker-compose.local.yml run django python manage.py makemessages --all


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Remove the `--dry-run` flag from `python manage.py makemigrations --check` because it's no longer needed.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Before Django 4.2.9, you also need to add the --dry-run option, to prevent the command from writing migrations to disk, see [blog post](https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/). But looks like this project is on Django 5.x so it's no longer needed.
