### PR TITLE
Use wait-for-it in favor of the custom python script when waiting for postgres

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -48,7 +48,8 @@ RUN groupadd --gid 1000 dev-user \
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # psycopg dependencies
-  libpq-dev \
+  libpq-dev  \
+  wait-for-it \
   # Translations dependencies
   gettext \
   # cleaning up unused files

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
   # psycopg dependencies
-  libpq-dev
+  libpq-dev \
+  wait-for-it
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements .

--- a/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
+++ b/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
@@ -16,33 +16,7 @@ if [ -z "${POSTGRES_USER}" ]; then
 fi
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
-python << END
-import sys
-import time
-
-import psycopg
-
-suggest_unrecoverable_after = 30
-start = time.time()
-
-while True:
-    try:
-        psycopg.connect(
-            dbname="${POSTGRES_DB}",
-            user="${POSTGRES_USER}",
-            password="${POSTGRES_PASSWORD}",
-            host="${POSTGRES_HOST}",
-            port="${POSTGRES_PORT}",
-        )
-        break
-    except psycopg.OperationalError as error:
-        sys.stderr.write("Waiting for PostgreSQL to become available...\n")
-
-        if time.time() - start > suggest_unrecoverable_after:
-            sys.stderr.write("  This is taking longer than expected. The following exception may be indicative of an unrecoverable error: '{}'\n".format(error))
-
-    time.sleep(1)
-END
+wait-for-it "${POSTGRES_HOST}:${POSTGRES_PORT}" -t 30
 
 >&2 echo 'PostgreSQL is available'
 


### PR DESCRIPTION
Proposing the usage of wait-for-it in favor of our own python script as raised in https://github.com/cookiecutter/cookiecutter-django/issues/4539

wait-for-it can also be used in the healthcheck command but that is out of scope for now. 