### PR TITLE
Pin watchdog to 4.0.2

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -1,5 +1,6 @@
 -r production.txt
 
+watchdog==4.0.2 # https://github.com/gorakhargosh/watchdog
 Werkzeug[watchdog]==3.0.4 # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
 {%- if cookiecutter.use_docker == 'y' %}


### PR DESCRIPTION
Watchdog 5.0.0 was recently released. This update causes Werkzeug to reload the Django server much more frequently than desired (causing the local docker development build to barely load).

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Without this change, playing around with the local docker development build consistently fails with ECONNRESET due to page loads triggering inotify events and therefore django server reboots

I've not tried to reproduce this issue on other environments, but this is the case on my M3 Mac.