### PR TITLE
Fix Makefile and make.bat files used for automatic generation of documentation.

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/Makefile
+++ b/{{cookiecutter.project_slug}}/docs/Makefile
@@ -13,11 +13,11 @@ APP = /app
 APP = ../{{cookiecutter.project_slug}}
 {% endif %}
 
-.PHONY: help livehtml apidocs Makefile
+.PHONY: html livehtml apidocs Makefile
 
-# Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
+# Put it first so that "make" without argument is like "make html".
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
 
 # Build, watch and serve docs with live reload
 livehtml:

--- a/{{cookiecutter.project_slug}}/docs/make.bat
+++ b/{{cookiecutter.project_slug}}/docs/make.bat
@@ -12,7 +12,7 @@ set SOURCEDIR=_source
 set BUILDDIR=_build
 set APP=..\{{cookiecutter.project_slug}}
 
-if "%1" == "" goto help
+if "%1" == "" goto html
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -39,8 +39,8 @@ GOTO :EOF
 sphinx-apidoc -o %SOURCEDIR%/api %APP%
 GOTO :EOF
 
-:help
-%SPHINXBUILD% -b help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+:html
+%SPHINXBUILD% -b html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 :end
 popd


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->
Fixing this bug --> https://github.com/cookiecutter/cookiecutter-django/issues/5346
Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
I've used Tox to run the templates test suite.
- [x] I've updated the documentation or confirm that my change doesn't require any updates
This doesn't seem relevant for the fix.

## Rationale
<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Fix: #5346

Both the "Makefile" and "make.bat" files are passing a non-existent argument ("help") to the -M/-b option. These are the only valid arguments: https://www.sphinx-doc.org/en/master/usage/builders/index.html

From that list, the most logical Builder to use is "html" since that's the one that is used later with sphinx-autobuild.