### PR TITLE
Update postgres plan in Heroku deployment docs

### DIFF
--- a/docs/deployment-on-heroku.rst
+++ b/docs/deployment-on-heroku.rst
@@ -12,7 +12,8 @@ Run these commands to deploy the project to Heroku:
 
     heroku create --buildpack heroku/python
 
-    heroku addons:create heroku-postgresql:mini
+    # Note: this is not a free plan
+    heroku addons:create heroku-postgresql:essential-0
     # On Windows use double quotes for the time zone, e.g.
     # heroku pg:backups schedule --at "02:00 America/Los_Angeles" DATABASE_URL
     heroku pg:backups schedule --at '02:00 America/Los_Angeles' DATABASE_URL


### PR DESCRIPTION
## Description
Changes the command to create a heroku postgres addon


```
$ heroku addons:create heroku-postgresql:mini

 ›   Warning: heroku update available from 8.11.5 to 9.2.1.
Creating heroku-postgresql:mini on ⬢ location-tracker... !
 ▸    We tried to create heroku-postgresql:mini, but received an error from the add-on provider. Try the request again, or log a support ticket and include
 ▸    this message: The mini plan has reached end-of-life. You can try again with a valid plan. See the available plans with: heroku addons:plans
 ▸    heroku-postgresql.
```

The next cheapest heroku option is "essentials-0"

documentation: https://elements.heroku.com/addons/heroku-postgresql


```
$ heroku addons:create heroku-postgresql:essential-0

 ›   Warning: heroku update available from 8.11.5 to 9.2.1.
Creating heroku-postgresql:essential-0 on ⬢ location-tracker... ~$0.007/hour (max $5/month)
Database should be available soon
postgresql-silhouetted-14783 is being created in the background. The app will restart when complete...
Use heroku addons:info postgresql-silhouetted-14783 to check creation progress
Use heroku addons:docs heroku-postgresql to view documentation
```


Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This option (mini) is now longer valid
