### PR TITLE
Create Intended Audience Section for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ production-ready Django projects quickly.
 - If you have problems with Cookiecutter Django, please open [issues](https://github.com/cookiecutter/cookiecutter-django/issues/new) don't send
   emails to the maintainers.
 
-  
 ## Table of Contents
+
 - [IntendedAudience](#IntendedAudience)
 - [Features](#Features)
 - [Constraints](#Constraints)
@@ -44,16 +44,16 @@ To use this application most effectively, users should have the scope of their a
 a new project.
 
 Example's of defined scope include:
+
 - docker usage
 - cloud provider
 - postgresql version
-See the [Usage](#Usage) section for a clear guide to the project creation process.
+  See the [Usage](#Usage) section for a clear guide to the project creation process.
 
 For more information about these specific requirements, see the documentation provided:
 (docker)[https://www.docker.com/]
 (PostgreSQL)[https://www.postgresql.org/]
 (AWS)[https://aws.amazon.com/]
-
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,44 @@ production-ready Django projects quickly.
 - If you have problems with Cookiecutter Django, please open [issues](https://github.com/cookiecutter/cookiecutter-django/issues/new) don't send
   emails to the maintainers.
 
+  
+## Table of Contents
+- [IntendedAudience](#IntendedAudience)
+- [Features](#Features)
+- [Constraints](#Constraints)
+- [Contributing](#contributing)
+- [License](#license)
+- [Usage](#Usage)
+- [Community](#Community)
+- [Releases](#Releases)
+- [Articles](#Articles)
+
+## IntendedAudience
+
+The purpose of this section is to outline the prerequisite knowledge that potential users need to effectively create projects
+with this application. Links will be provided to supplemental resources to help users get up to speed.
+
+This application's main purpose is to increase the efficiency of django applications by defining project specifications
+beforehand, thus preventing missing dependencies later on in the development process.
+
+Users of this software should have working proficiency in building django applications. For new users to Django, please
+refer to the official documentation: [here](https://docs.djangoproject.com/en/5.1/)
+
+To use this application most effectively, users should have the scope of their application defined before beginning to create
+a new project.
+
+Example's of defined scope include:
+- docker usage
+- cloud provider
+- postgresql version
+See the [Usage](#Usage) section for a clear guide to the project creation process.
+
+For more information about these specific requirements, see the documentation provided:
+(docker)[https://www.docker.com/]
+(PostgreSQL)[https://www.postgresql.org/]
+(AWS)[https://aws.amazon.com/]
+
+
 ## Features
 
 - For Django 5.0


### PR DESCRIPTION
## Description

I am proposing the addition of an intended audience section for the official README of this application.

## Rationale

The purpose of the intended audience section is to allow potential users to quickly scan to see if this application is well suited for their needs/experience level. When going through the official documentation for this project, I struggled to understand the use cases for some of the prompts requested when initializing the template. If users want the most out of using this application, it would make sense that they need prerequisite knowledge of what each prompted user input allows the project to accomplish, as this would save them time when configuring their project - which aligns nicely with the goal of the application as a whole. 