### PR TITLE
Change "body" to "main" in entrance.html

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/entrance.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/entrance.html
@@ -8,7 +8,7 @@
     {% trans "Sign In" %}
   {% endblock head_title %}
 {% endblock title %}
-{% block body %}
+{% block main %}
   <div class="d-flex justify-content-center h-100 py-4">
     <div class="col-md-4 py-4 my-4 px-4">
       {% if messages %}
@@ -28,4 +28,4 @@
       {% endblock extra_body %}
     </div>
   </div>
-{% endblock body %}{% endraw %}
+{% endblock main %}{% endraw %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -161,18 +161,18 @@
     </nav>
   </div>
   <div class="container">
-    {% if messages %}
-      {% for message in messages %}
-        <div class="alert alert-dismissible {% if message.tags %}alert-{{ message.tags }}{% endif %}">
-          {{ message }}
-          <button type="button"
-                  class="btn-close"
-                  data-bs-dismiss="alert"
-                  aria-label="Close"></button>
-        </div>
-      {% endfor %}
-    {% endif %}
     {% block main %}
+      {% if messages %}
+        {% for message in messages %}
+          <div class="alert alert-dismissible {% if message.tags %}alert-{{ message.tags }}{% endif %}">
+            {{ message }}
+            <button type="button"
+                    class="btn-close"
+                    data-bs-dismiss="alert"
+                    aria-label="Close"></button>
+          </div>
+        {% endfor %}
+      {% endif %}
       {% block content %}
         <p>Use this document as a way to quick start any new project.</p>
       {% endblock content %}


### PR DESCRIPTION
## Description

The current setup for account sign up and signin loses the nav bar from the base.html 
I am proposing we utilize the block `main` to regain the nav bar.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)

The tests fail for me using main branch before this change, not sure its related

```
file /Users/patricktran/projamming/tmp/cookiecutter-django/tests/test_cookiecutter_generation.py, line 380
  @pytest.mark.parametrize(
      ["editor", "pycharm_docs_exist"],
      [
          ("None", False),
          ("PyCharm", True),
          ("VS Code", False),
      ],
  )
  def test_pycharm_docs_removed(cookies, context, editor, pycharm_docs_exist):
E       fixture 'cookies' not found
>       available fixtures: _dj_autoclear_mailbox, _django_clear_site_cache, _django_db_helper, _django_db_marker, _django_set_urlconf, _django_setup_unittest, _fail_for_invalid_template_variable, _live_server_helper, _session_faker, _template_string_if_invalid_marker, admin_client, admin_user, anyio_backend, anyio_backend_name, anyio_backend_options, async_client, async_rf, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, client, context, db, django_assert_max_num_queries, django_assert_num_queries, django_capture_on_commit_callbacks, django_db_blocker, django_db_createdb, django_db_keepdb, django_db_modify_db_settings, django_db_modify_db_settings_parallel_suffix, django_db_modify_db_settings_tox_suffix, django_db_modify_db_settings_xdist_suffix, django_db_reset_sequences, django_db_serialized_rollback, django_db_setup, django_db_use_migrations, django_mail_dnsname, django_mail_patch_dns, django_test_environment, django_user_model, django_username_field, doctest_namespace, faker, live_server, mailoutbox, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, rf, settings, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, transactional_db
>       use 'pytest --fixtures [testpath]' for help on them.
```

- [x] I've updated the documentation or confirm that my change doesn't require any updates (I do not see this in docs)

## Rationale

Seems like the original purpose of the main block was to allow this.

`entrance.html` already has a block `content` inside the html. Presumably to act as a base template for the allauth views.
<img width="632" alt="Screenshot 2024-09-29 at 11 39 37 AM" src="https://github.com/user-attachments/assets/94878474-7f51-46a9-a773-ce476b7654e4">

since our `base.html` relies on a block `content`, we now have duplicate names.
<img width="553" alt="Screenshot 2024-09-29 at 11 40 46 AM" src="https://github.com/user-attachments/assets/792e4307-797d-442a-9c13-08815bec6199">

In order to get around this issue of duplicate names, `base.html` block `content` is wrapped with block `main`. 
This way another template using a block `content` can still extend `base.html` and keep the functionality of the nav bar, css, javascript and other behavior.

Without this change (default), the sign up and sign in screens have no way to navigate back to the main page.

<img width="1135" alt="Screenshot 2024-09-29 at 11 43 43 AM" src="https://github.com/user-attachments/assets/01aec383-372a-457b-a231-f73d2be02ecb">


