### PR TITLE
Use uv sync & uv run in docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv sync --extra docs
-    - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,7 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv venv
-    - uv pip install .[docs]
+    - uv sync --extra docs
     - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv sync --extra docs
+    - uv sync --extra docs --no-dev --frozen
     - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
## Description

The offical RTD guide was written a few months ago and I realised after merging https://github.com/cookiecutter/cookiecutter-django/pull/5438 that we can in fact simplify a bit more.

Also upstreamed these changes to RTD: https://github.com/readthedocs/readthedocs.org/pull/11655

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Simpler build steps
