### PR TITLE
Update Nginx  dependabot versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,7 @@ updates:
     directory: "{{cookiecutter.project_slug}}/compose/production/nginx/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase
     labels:
       - "update"
 


### PR DESCRIPTION
## Description

- Update Nginx  dependabot versioning-strategy as a way to fix #5345 and #5344

Related docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

For some reason, Dependabot is not telling us when there are updates to the Nginx container (and maybe some others). This pull-request is intended to try to do some fine-tuning to fix this issue.

- Helps prevent #5344 from happening again
