### PR TITLE
Pin Python version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:

--- a/.github/workflows/dependabot-uv-lock.yml
+++ b/.github/workflows/dependabot-uv-lock.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   lock:
+    if: github.repository_owner == 'cookiecutter'
     runs-on: ubuntu-latest
     env:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/dependabot-uv-lock.yml
+++ b/.github/workflows/dependabot-uv-lock.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lock:
-    if: github.repository_owner == 'cookiecutter'
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     env:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { text = "BSD" }
 authors = [
   { name = "Daniel Roy Greenfeld", email = "pydanny@gmail.com" },
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.13"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
@@ -25,7 +25,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development",
 ]

--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -18,13 +18,13 @@ cd my_awesome_project
 sudo utility/install_os_dependencies.sh install
 
 # Install Python deps
-uv pip install -r requirements/local.txt
+pip install -r requirements/local.txt
 
 # run the project's tests
-uv run pytest
+pytest
 
 # Make sure the check doesn't raise any warnings
-uv run python manage.py check --fail-level WARNING
+python manage.py check --fail-level WARNING
 
 # Run npm build script if package.json is present
 if [ -f "package.json" ]

--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -18,13 +18,13 @@ cd my_awesome_project
 sudo utility/install_os_dependencies.sh install
 
 # Install Python deps
-pip install -r requirements/local.txt
+uv pip install -r requirements/local.txt
 
 # run the project's tests
-pytest
+uv run pytest
 
 # Make sure the check doesn't raise any warnings
-python manage.py check --fail-level WARNING
+uv run python manage.py check --fail-level WARNING
 
 # Run npm build script if package.json is present
 if [ -f "package.json" ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.12"
+requires-python = "==3.12.*"
 
 [[package]]
 name = "alabaster"


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Looking at https://github.com/cookiecutter/cookiecutter-django/pull/5450 I noticed that Python 3.13 classifier was added, which promopted me to look at which version of Python was used to run the tests, and it turns out they run using Python 3.13: 

- https://github.com/cookiecutter/cookiecutter-django/actions/runs/11285345637/job/31387993157?pr=5450#step:5:8
- https://github.com/cookiecutter/cookiecutter-django/actions/runs/11285345637/job/31387992848?pr=5450#step:5:9

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Run tests on the same Python version as we officially support