### PR TITLE
Add requirements for ubuntu 24.04

### DIFF
--- a/{{cookiecutter.project_slug}}/utility/requirements-noble.apt
+++ b/{{cookiecutter.project_slug}}/utility/requirements-noble.apt
@@ -1,0 +1,23 @@
+##basic build dependencies of various Django apps for Debian Bookworm 12.x
+#build-essential metapackage install: make, gcc, g++,
+build-essential
+#required to translate
+gettext
+python3-dev
+
+##shared dependencies of:
+##Pillow, pylibmc
+zlib1g-dev
+
+##Postgresql and psycopg dependencies
+libpq-dev
+
+##Pillow dependencies
+libtiff5-dev
+libjpeg62-turbo-dev
+libfreetype6-dev
+liblcms2-dev
+libwebp-dev
+
+##django-extensions
+libgraphviz-dev


### PR DESCRIPTION
Github actions now uses 24.04 as latest tag, as reported in #5465

Fix #5465