### PR TITLE
Run uv lock when updating template version

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "action@github.com"
-      - name: Update list
+      - name: Update changelog
         run: uv run --frozen scripts/update_changelog.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import os
 import re
+import subprocess
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -50,6 +51,9 @@ def main() -> None:
     setup_py_path = ROOT / "pyproject.toml"
     update_version(setup_py_path, release)
     print(f"Updated version in {setup_py_path}")
+
+    # Run uv lock
+    subprocess.run(["uv", "lock"], cwd=ROOT)
 
     # Commit changes, create tag and push
     update_git_repo([changelog_path, setup_py_path], release)


### PR DESCRIPTION
## Description

Run `uv lock` after updating the project version.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Updating the changelog bumps the version of the template in pyproject.toml, but leaves the `uv.lock` out of date. This change keeps it in line.