### PR TITLE
Fix typos in translation instructions in README

### DIFF
--- a/{{cookiecutter.project_slug}}/locale/README.md
+++ b/{{cookiecutter.project_slug}}/locale/README.md
@@ -1,6 +1,6 @@
 # Translations
 
-Start by configuring the `LANGUAGES` settings in `base.py`, by uncommenting languages you are willing to support. Then, translations strings will be placed in this folder when running:
+Start by configuring the `LANGUAGES` settings in `base.py`, by uncommenting languages you are willing to support. Then, translation strings will be placed in this folder when running:
 
 ```bash
 {% if cookiecutter.use_docker == 'y' %}docker compose -f docker-compose.local.yml run --rm django {% endif %}python manage.py makemessages --all --no-location
@@ -19,7 +19,7 @@ Once all translations are done, they need to be compiled into `.mo` files (stand
 {% if cookiecutter.use_docker == 'y' %}docker compose -f docker-compose.local.yml run --rm django {% endif %}python manage.py compilemessages
 ```
 
-Note that the `.po` files are NOT used by the application directly, so if the `.mo` files are out of dates, the content won't appear as translated even if the `.po` files are up-to-date.
+Note that the `.po` files are NOT used by the application directly, so if the `.mo` files are out of date, the content won't appear as translated even if the `.po` files are up-to-date.
 
 ## Production
 


### PR DESCRIPTION
## Description

Just a minor fix to the README file.

Checklist:

- [ x ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ x ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

To better guide contributors