### PR TITLE
Introducing Cookiecutter Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Updates](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/shield.svg)](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/)
 [![Join our Discord](https://img.shields.io/badge/Discord-cookiecutter-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/rAWFUP47d2)
 [![Code Helpers Badge](https://www.codetriage.com/cookiecutter/cookiecutter-django/badges/users.svg)](https://www.codetriage.com/cookiecutter/cookiecutter-django)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Cookiecutter%20Guru-006BFF)](https://gurubase.io/g/cookiecutter)
 
 Powered by [Cookiecutter](https://github.com/cookiecutter/cookiecutter), Cookiecutter Django is a framework for jumpstarting
 production-ready Django projects quickly.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Cookiecutter Guru](https://gurubase.io/g/cookiecutter) to Gurubase. Cookiecutter Guru uses the data from this repo and data from the [docs](https://cookiecutter-django.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Cookiecutter Guru", which highlights that Cookiecutter now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Cookiecutter Guru in Gurubase, just let me know that's totally fine.
