### PR TITLE
Pin dart-sass to 1.77.6 to avoid deprecation warnings

### DIFF
--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -26,7 +26,7 @@
     "postcss": "^8.3.11",
     "postcss-loader": "^8.0.0",
     "postcss-preset-env": "^10.0.3",
-    "sass": "^1.43.4",
+    "sass": "1.79.6",
     "sass-loader": "^16.0.1",
     "webpack": "^5.65.0",
     "webpack-bundle-tracker": "^3.0.1",

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -26,7 +26,7 @@
     "postcss": "^8.3.11",
     "postcss-loader": "^8.0.0",
     "postcss-preset-env": "^10.0.3",
-    "sass": "1.78.0",
+    "sass": "1.77.6",
     "sass-loader": "^16.0.1",
     "webpack": "^5.65.0",
     "webpack-bundle-tracker": "^3.0.1",

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -26,7 +26,7 @@
     "postcss": "^8.3.11",
     "postcss-loader": "^8.0.0",
     "postcss-preset-env": "^10.0.3",
-    "sass": "1.79.6",
+    "sass": "1.78.0",
     "sass-loader": "^16.0.1",
     "webpack": "^5.65.0",
     "webpack-bundle-tracker": "^3.0.1",


### PR DESCRIPTION
## Description

```
Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
```

Pin Dart SASS to lower version for now.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Version 1.80.0+ [throws a lot of warnings](https://github.com/cookiecutter/cookiecutter-django/actions/runs/12056382813/job/33618783318#step:8:673): https://github.com/twbs/bootstrap/issues/40962

Version 1.79 has deprecations too: https://github.com/twbs/bootstrap/issues/40849

Most are coming from Bootstrap so a bit outside of our control. 
