### PR TITLE
Celery tasks logs into Django logs configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/config/celery_app.py
+++ b/{{cookiecutter.project_slug}}/config/celery_app.py
@@ -1,6 +1,7 @@
 import os
 
 from celery import Celery
+from celery.signals import setup_logging
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
@@ -12,6 +13,15 @@ app = Celery("{{cookiecutter.project_slug}}")
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
 app.config_from_object("django.conf:settings", namespace="CELERY")
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwargs):
+    from logging.config import dictConfig
+    from django.conf import settings
+
+    dictConfig(settings.LOGGING)
+
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -327,6 +327,8 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_WORKER_SEND_TASK_EVENTS = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_send_sent_event
 CELERY_TASK_SEND_SENT_EVENT = True
+# https://cheat.readthedocs.io/en/latest/django/celery.html
+CELERYD_HIJACK_ROOT_LOGGER = False
 
 {%- endif %}
 # django-allauth


### PR DESCRIPTION
## Description

The goal is to have logs used in the class of the application when the class is used in a Celery Task. 
The logs were not available on production using supervisor and stdout.

And because logs are so important.

See #5559 

Checklist:

- [ x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5559 