### PR TITLE
Pin node to version 22.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,6 @@ jobs:
         run: uv sync
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "22.11"
       - name: Bare Metal ${{ matrix.script.name }}
         run: sh tests/test_bare.sh ${{ matrix.script.args }}

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -18,19 +18,19 @@ cd my_awesome_project
 docker compose -f docker-compose.local.yml build
 
 # run the project's type checks
-docker compose -f docker-compose.local.yml run django mypy my_awesome_project
+docker compose -f docker-compose.local.yml run --rm django mypy my_awesome_project
 
 # run the project's tests
-docker compose -f docker-compose.local.yml run django pytest
+docker compose -f docker-compose.local.yml run --rm django pytest
 
 # return non-zero status code if there are migrations that have not been created
-docker compose -f docker-compose.local.yml run django python manage.py makemigrations --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
+docker compose -f docker-compose.local.yml run --rm django python manage.py makemigrations --check || { echo "ERROR: there were changes in the models, but migration listed above have not been created and are not saved in version control"; exit 1; }
 
 # Test support for translations
-docker compose -f docker-compose.local.yml run django python manage.py makemessages --all
+docker compose -f docker-compose.local.yml run --rm django python manage.py makemessages --all
 
 # Make sure the check doesn't raise any warnings
-docker compose -f docker-compose.local.yml run \
+docker compose -f docker-compose.local.yml run --rm \
   -e DJANGO_SECRET_KEY="$(openssl rand -base64 64)" \
   -e REDIS_URL=redis://redis:6379/0 \
   -e DJANGO_AWS_ACCESS_KEY_ID=x \
@@ -42,10 +42,10 @@ docker compose -f docker-compose.local.yml run \
   django python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
 
 # Generate the HTML for the documentation
-docker compose -f docker-compose.docs.yml run docs make html
+docker compose -f docker-compose.docs.yml run --rm docs make html
 
 # Run npm build script if package.json is present
 if [ -f "package.json" ]
 then
-    docker compose -f docker-compose.local.yml run node npm run build
+    docker compose -f docker-compose.local.yml run --rm node npm run build
 fi

--- a/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:22-bookworm-slim
+FROM docker.io/node:22.11-bookworm-slim
 
 WORKDIR /app
 

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -35,7 +35,7 @@
     "webpack-merge": "^6.0.1"
   },
   "engines": {
-    "node": "22"
+    "node": "22.11"
   },
   "browserslist": [
     "last 2 versions"


### PR DESCRIPTION
## Description

We specify the node version to the major only, but the latest [v22.12](https://nodejs.org/en/blog/release/v22.12.0) introduced a change which is impacting us, or at least one of our dependency:

> With this feature enabled, Node.js will no longer throw `ERR_REQUIRE_ESM` if `require()` is used to load a ES module. It can, however, throw `ERR_REQUIRE_ASYNC_MODULE` if the ES module being loaded or its dependencies contain top-level await. When the ES module is loaded successfully by `require()`, the returned object will either be a ES module namespace object similar to what's returned by `import()`, or what gets exported as "module.exports" in the ES module.

The root cause is from `gulp-imagemin` which is doing a top-level await:

- https://github.com/sindresorhus/gulp-imagemin/issues/389

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Pinning the version to fix our CI until the dependency is fixed or we figure out a better way to fix it.
