### PR TITLE
Fix missing update from uv.lock during release process

### DIFF
--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -53,10 +53,11 @@ def main() -> None:
     print(f"Updated version in {setup_py_path}")
 
     # Run uv lock
-    subprocess.run(["uv", "lock"], cwd=ROOT)
+    uv_lock_path = ROOT / "uv.lock"
+    subprocess.run(["uv", "lock", "--no-upgrade"], cwd=ROOT)
 
     # Commit changes, create tag and push
-    update_git_repo([changelog_path, setup_py_path], release)
+    update_git_repo([changelog_path, setup_py_path, uv_lock_path], release)
 
     # Create GitHub release
     github_release = repo.create_git_release(


### PR DESCRIPTION
## Description

The `uv.lock` file contains the repo version. This version changes daily as we do a release, and while I tried to keep the lock file up to date in https://github.com/cookiecutter/cookiecutter-django/pull/5478, it doesn't actually work, because the file is not part of the commit due to a missing `git add`

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Keep version in lock file in line with template version
