### PR TITLE
Drop support for Python 2 in template generation hooks

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,16 +1,3 @@
-"""
-NOTE:
-    the below code is to be maintained Python 2.x-compatible
-    as the whole Cookiecutter Django project initialization
-    can potentially be run in Python 2.x environment
-    (at least so we presume in `pre_gen_project.py`).
-
-TODO: restrict Cookiecutter Django project initialization to
-      Python 3.x environments only
-"""
-
-from __future__ import print_function
-
 import json
 import os
 import random

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,15 +1,3 @@
-"""
-NOTE:
-    the below code is to be maintained Python 2.x-compatible
-    as the whole Cookiecutter Django project initialization
-    can potentially be run in Python 2.x environment.
-
-TODO: restrict Cookiecutter Django project initialization
-      to Python 3.x environments only
-"""
-
-from __future__ import print_function
-
 import sys
 
 TERMINATOR = "\x1b[0m"
@@ -34,36 +22,10 @@ assert project_slug == project_slug.lower(), "'{}' project slug should be all lo
 
 assert "\\" not in "{{ cookiecutter.author_name }}", "Don't include backslashes in author name."
 
-if "{{ cookiecutter.use_docker }}".lower() == "n":
-    python_major_version = sys.version_info[0]
-    if python_major_version == 2:
-        print(
-            WARNING + "You're running cookiecutter under Python 2, but the generated "
-            "project requires Python 3.12+. Do you want to proceed (y/n)? " + TERMINATOR
-        )
-        yes_options, no_options = frozenset(["y"]), frozenset(["n"])
-        while True:
-            choice = raw_input().lower()  # noqa: F821
-            if choice in yes_options:
-                break
-
-            elif choice in no_options:
-                print(INFO + "Generation process stopped as requested." + TERMINATOR)
-                sys.exit(1)
-            else:
-                print(
-                    HINT
-                    + "Please respond with {} or {}: ".format(
-                        ", ".join(["'{}'".format(o) for o in yes_options if not o == ""]),
-                        ", ".join(["'{}'".format(o) for o in no_options if not o == ""]),
-                    )
-                    + TERMINATOR
-                )
-
 if "{{ cookiecutter.use_whitenoise }}".lower() == "n" and "{{ cookiecutter.cloud_provider }}" == "None":
-    print("You should either use Whitenoise or select a " "Cloud Provider to serve static files")
+    print("You should either use Whitenoise or select a Cloud Provider to serve static files")
     sys.exit(1)
 
 if "{{ cookiecutter.mail_service }}" == "Amazon SES" and "{{ cookiecutter.cloud_provider }}" != "AWS":
-    print("You should either use AWS or select a different " "Mail Service for sending emails.")
+    print("You should either use AWS or select a different Mail Service for sending emails.")
     sys.exit(1)


### PR DESCRIPTION
## Description

Python 2.7 has been EOL for 5 years, it's time. This PR is not fixing all the issues but remove the comment at the top of each file as well as the most obvious changes. The rest will be fixed either automatically in https://github.com/cookiecutter/cookiecutter-django/pull/5613 or manually as a follow up change.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Enable us to use modern syntax in prr/post-generation hooks
