### PR TITLE
Add justfile for use with docker

### DIFF
--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -254,7 +254,7 @@ We have included a ``justfile`` to simplify the use of frequent Docker commands 
     "Just" itself rather than its subprocesses.
     For more information, see `this GitHub issue <https://github.com/casey/just/issues/2473>`_.
 
-First, install Just using one of the methods described in the `official documentation <https://just.systems/man/en/packages.html>_.
+First, install Just using one of the methods described in the `official documentation <https://just.systems/man/en/packages.html>`_.
 
 Here are the available commands:
 

--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -246,7 +246,17 @@ The stack comes with a dedicated node service to build the static assets, watch 
 Using Just for Docker Commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We have included a ``justfile`` to simplify the use of frequent Docker commands for local development. Here are the available commands:
+We have included a ``justfile`` to simplify the use of frequent Docker commands for local development. 
+
+.. warning::
+    Currently, "Just" does not reliably handle signals or forward them to its subprocesses. As a result, 
+    pressing CTRL+C (or sending other signals like SIGTERM, SIGINT, or SIGHUP) may only interrupt 
+    "Just" itself rather than its subprocesses. 
+    For more information, see `this GitHub issue <https://github.com/casey/just/issues/2473>`_.
+
+First, install Just using one of the methods described in the `official documentation <https://just.systems/man/en/packages.html>_.
+
+Here are the available commands:
 
 - ``just build``
   Builds the Python image using the local Docker Compose file.

--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -246,12 +246,12 @@ The stack comes with a dedicated node service to build the static assets, watch 
 Using Just for Docker Commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We have included a ``justfile`` to simplify the use of frequent Docker commands for local development. 
+We have included a ``justfile`` to simplify the use of frequent Docker commands for local development.
 
 .. warning::
-    Currently, "Just" does not reliably handle signals or forward them to its subprocesses. As a result, 
-    pressing CTRL+C (or sending other signals like SIGTERM, SIGINT, or SIGHUP) may only interrupt 
-    "Just" itself rather than its subprocesses. 
+    Currently, "Just" does not reliably handle signals or forward them to its subprocesses. As a result,
+    pressing CTRL+C (or sending other signals like SIGTERM, SIGINT, or SIGHUP) may only interrupt
+    "Just" itself rather than its subprocesses.
     For more information, see `this GitHub issue <https://github.com/casey/just/issues/2473>`_.
 
 First, install Just using one of the methods described in the `official documentation <https://just.systems/man/en/packages.html>_.

--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -242,6 +242,31 @@ The stack comes with a dedicated node service to build the static assets, watch 
 .. _Sass: https://sass-lang.com/
 .. _live reloading: https://browsersync.io
 
+
+Using Just for Docker Commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We have included a ``justfile`` to simplify the use of frequent Docker commands for local development. Here are the available commands:
+
+- ``just build``
+  Builds the Python image using the local Docker Compose file.
+
+- ``just up``
+  Starts the containers in detached mode and removes orphaned containers.
+
+- ``just down``
+  Stops the running containers.
+
+- ``just prune``
+  Stops and removes containers along with their volumes. You can optionally pass an argument with the service name to prune a single container.
+
+- ``just logs``
+  Shows container logs. You can optionally pass an argument with the service name to view logs for a specific service.
+
+- ``just manage <command>``
+  Runs Django management commands within the container. Replace ``<command>`` with any valid Django management command, such as ``migrate``, ``createsuperuser``, or ``shell``.
+
+
 (Optionally) Developing locally with HTTPS
 ------------------------------------------
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -82,6 +82,7 @@ def remove_docker_files():
         "docker-compose.local.yml",
         "docker-compose.production.yml",
         ".dockerignore",
+        "justfile",
     ]
     for file_name in file_names:
         os.remove(file_name)

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -1,5 +1,10 @@
 export COMPOSE_FILE := "docker-compose.local.yml"
 
+## Just does not yet manage signals for subprocesses reliably, which can lead to unexpected behavior.
+## Exercise caution before expanding its usage in production environments. 
+## For more information, see https://github.com/casey/just/issues/2473 .
+
+
 # Default command to list all available commands.
 default:
     @just --list

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -7,27 +7,27 @@ default:
 # build: Build python image.
 build:
     @echo "Building python image..."
-    @docker-compose build
+    @docker compose build
 
 # up: Start up containers.
 up:
     @echo "Starting up containers..."
-    @docker-compose up -d --remove-orphans
+    @docker compose up -d --remove-orphans
 
 # down: Stop containers.
 down:
     @echo "Stopping containers..."
-    @docker-compose down
+    @docker compose down
 
 # prune: Remove containers and their volumes.
 prune *args:
     @echo "Killing containers and removing volumes..."
-    @docker-compose down -v {{ "{{args}}" }}
+    @docker compose down -v {{ "{{args}}" }}
 
 # logs: View container logs
 logs *args:
-    @docker-compose logs -f {{ "{{args}}" }}
+    @docker compose logs -f {{ "{{args}}" }}
 
 # manage: Executes `manage.py` command.
 manage +args:
-    @docker-compose run --rm django python ./manage.py {{ "{{args}}" }}
+    @docker compose run --rm django python ./manage.py {{ "{{args}}" }}

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -1,0 +1,33 @@
+export COMPOSE_FILE := "docker-compose.local.yml"
+
+# Default command to list all available commands.
+default:
+    @just --list
+
+# build: Build python image.
+build:
+    @echo "Building python image..."
+    @docker-compose build
+
+# up: Start up containers.
+up:
+    @echo "Starting up containers..."
+    @docker-compose up -d --remove-orphans
+
+# down: Stop containers.
+down:
+    @echo "Stopping containers..."
+    @docker-compose down
+
+# prune: Remove containers and their volumes.
+prune *args:
+    @echo "Killing containers and removing volumes..."
+    @docker-compose down -v {{ "{{args}}" }}
+
+# logs: View container logs
+logs *args:
+    @docker-compose logs -f {{ "{{args}}" }}
+
+# manage: Executes `manage.py` command.
+manage +args:
+    @docker-compose run --rm django python ./manage.py {{ "{{args}}" }}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Set up [just](https://github.com/casey/just) to simplify calling docker commands.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

It helps to run frequent commands quicker. This [PR](https://github.com/cookiecutter/cookiecutter-django/pull/1879) attempted to do this via MakeFile. However, using `just` seems like a better approach, especially since it is a cross-platform tool (can be installed via pip), as mentioned in this [comment](https://github.com/cookiecutter/cookiecutter-django/pull/1879#issuecomment-2454038873) as well.

Closes #1879 
Fix #3318 