### PR TITLE
Set `minimum_pre_commit_version` in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: "{{cookiecutter.project_slug}}|.github/contributors.json|CHANGELOG.md|CONTRIBUTORS.md"
 default_stages: [pre-commit]
+minimum_pre_commit_version: '3.2.0'
 
 default_language_version:
   python: python3.12

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: '^docs/|/migrations/|devcontainer.json'
 default_stages: [pre-commit]
+minimum_pre_commit_version: '3.2.0'
 
 default_language_version:
   python: python3.12


### PR DESCRIPTION
## Description

Set it to 3.2 as we rely on the `pre-commit` stage which was introduced in that version and is not understood by earlier versions.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5618 
