### PR TITLE
update CELERYD_HIJACK_ROOT_LOGGER to CELERY_WORKER_HIJACK_ROOT_LOGGER

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -327,8 +327,8 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_WORKER_SEND_TASK_EVENTS = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_send_sent_event
 CELERY_TASK_SEND_SENT_EVENT = True
-# https://cheat.readthedocs.io/en/latest/django/celery.html
-CELERYD_HIJACK_ROOT_LOGGER = False
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-hijack-root-logger
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 {%- endif %}
 # django-allauth


### PR DESCRIPTION


<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description
Updated `CELERYD_HIJACK_ROOT_LOGGER` to `CELERY_WORKER_HIJACK_ROOT_LOGGER`. [Link to the setting in celery docs](https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-hijack-root-logger)

`CELERYD_HIJACK_ROOT_LOGGER` was the name of the setting in celery v3 but that changed in v4

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

