### PR TITLE
Update linter error code from TCH to TC

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -106,7 +106,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "INT",
   # "ARG", # Unused function argument
   "PTH",


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Update the error code from TCH to TC since ruff has done that in v0.8, here's an extract from the blog post (and [link for reference](https://astral.sh/blog/ruff-v0.8.0#new-error-codes-for-flake8-type-checking-rules))

> This release changes the error codes for the rules in our [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) category from TCH to TC. This matches changes that were made in the original flake8-type-checking plugin from which these rules were originally adapted.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

