### PR TITLE
Update Heroku deployment guide

### DIFF
--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -25,10 +25,6 @@ Run these commands to deploy the project to Heroku:
     # Assuming you chose Mailgun as mail service (see below for others)
     heroku addons:create mailgun:starter
 
-    heroku config:set PYTHONHASHSEED=random
-
-    heroku config:set WEB_CONCURRENCY=4
-
     heroku config:set DJANGO_DEBUG=False
     heroku config:set DJANGO_SETTINGS_MODULE=config.settings.production
     heroku config:set DJANGO_SECRET_KEY="$(openssl rand -base64 64)"


### PR DESCRIPTION
Hi! I'm the Heroku Python owner :-)

This:
* Removes setting of `PYTHONHASHSEED` env var, since it's defaulted to `random` since Python 3.3. See:
  https://docs.python.org/3.13/whatsnew/3.3.html#builtin-functions-and-types
* Removes setting of `WEB_CONCURRENCY` env var to a hardcoded value, since on Heroku the Python buildpack dynamically sets the value at container boot based on the available CPUs, so it's best to not override the default with a value that might not match the size of the dyno. See:
  https://devcenter.heroku.com/articles/python-concurrency#default-settings-and-behavior