### PR TITLE
Group dependabot docker directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,11 @@ updates:
       - "update"
 
   # Enable version updates for Docker
-  # We need to specify each Dockerfile in a separate entry because Dependabot doesn't
-  # support wildcards or recursively checking subdirectories. Check this issue for updates:
-  # https://github.com/dependabot/dependabot-core/issues/2178
   - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/local/django/"
+    directories:
+      - "{{cookiecutter.project_slug}}/compose/local/django/"
+      - "{{cookiecutter.project_slug}}/compose/local/docs/"
+      - "{{cookiecutter.project_slug}}/compose/production/django/"
     schedule:
       interval: "daily"
     ignore:
@@ -52,60 +52,12 @@ updates:
       - "update"
 
   - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/local/docs/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/local/node/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/production/aws/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/production/django/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/production/postgres/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/production/nginx/"
-    schedule:
-      interval: "daily"
-    versioning-strategy: increase
-    labels:
-      - "update"
-
-  - package-ecosystem: "docker"
-    directory: "{{cookiecutter.project_slug}}/compose/production/traefik/"
+    directories:
+      - "{{cookiecutter.project_slug}}/compose/local/node/"
+      - "{{cookiecutter.project_slug}}/compose/production/aws/"
+      - "{{cookiecutter.project_slug}}/compose/production/postgres/"
+      - "{{cookiecutter.project_slug}}/compose/production/nginx/"
+      - "{{cookiecutter.project_slug}}/compose/production/traefik/"
     schedule:
       interval: "daily"
     labels:

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -13,12 +13,12 @@ updates:
 {%- if cookiecutter.use_docker == 'y' %}
 
   # Enable version updates for Docker
-  # We need to specify each Dockerfile in a separate entry because Dependabot doesn't
-  # support wildcards or recursively checking subdirectories. Check this issue for updates:
-  # https://github.com/dependabot/dependabot-core/issues/2178
   - package-ecosystem: 'docker'
     # Look for a `Dockerfile` in the `compose/local/django` directory
-    directory: 'compose/local/django/'
+    directories:
+      - 'compose/local/django/'
+      - 'compose/local/docs/'
+      - 'compose/production/django/'
     # Every weekday
     schedule:
       interval: 'daily'
@@ -29,69 +29,20 @@ updates:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
 
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/local/docs` directory
-    directory: 'compose/local/docs/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-    # Ignore minor version updates (3.10 -> 3.11) but update patch versions
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - 'version-update:semver-major'
-          - 'version-update:semver-minor'
 
   - package-ecosystem: 'docker'
     # Look for a `Dockerfile` in the `compose/local/node` directory
-    directory: 'compose/local/node/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/production/aws` directory
-    directory: 'compose/production/aws/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/production/django` directory
-    directory: 'compose/production/django/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-    # Ignore minor version updates (3.10 -> 3.11) but update patch versions
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - 'version-update:semver-major'
-          - 'version-update:semver-minor'
-
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/production/postgres` directory
-    directory: 'compose/production/postgres/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/production/traefik` directory
-    directory: 'compose/production/traefik/'
-    # Every weekday
-    schedule:
-      interval: 'daily'
-
+    directories:
+      - 'compose/local/node/'
+      - 'compose/production/aws/'
+      - 'compose/production/postgres/'
+      - 'compose/production/traefik/'
 {%- if cookiecutter.cloud_provider == 'None' %}
-
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/production/nginx` directory
-    directory: 'compose/production/nginx/'
+      - 'compose/production/nginx/'
+{%- endif %}
     # Every weekday
     schedule:
       interval: 'daily'
-{%- endif %}
 
 {%- endif %}
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Dependabot supports a "directories" keyword now so the docker dependencies can be grouped together now.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

It saves a lot of space. Also, the issue dependabot/dependabot-core#2178 has been fixed, so if you're ok pinning all the dependencies to their minor version they can all be captured by one glob.

Fix #5699 