### PR TITLE
Add Docker build caching on GitHub Actions

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -68,11 +68,31 @@ jobs:
         uses: actions/checkout@v4
       {%- if cookiecutter.use_docker == 'y' %}
 
-      - name: Build the Stack
-        run: docker compose -f docker-compose.local.yml build django
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build the docs
-        run: docker compose -f docker-compose.docs.yml build docs
+      - name: Build and cache local backend
+        uses: docker/bake-action@v6
+        with:
+          push: false
+          load: true
+          files: docker-compose.local.yml
+          targets: django
+          set: |
+            django.cache-from=type=gha,scope=django-cached-tests
+            django.cache-to=type=gha,scope=django-cached-tests,mode=max
+            postgres.cache-from=type=gha,scope=postgres-cached-tests
+            postgres.cache-to=type=gha,scope=postgres-cached-tests,mode=max
+
+      - name: Build and cache docs
+        uses: docker/bake-action@v6
+        with:
+          push: false
+          load: true
+          files: docker-compose.docs.yml
+          set: |
+            docs.cache-from=type=gha,scope=cached-docs
+            docs.cache-to=type=gha,scope=cached-docs,mode=max
 
       - name: Check DB Migrations
         run: docker compose -f docker-compose.local.yml run --rm django python manage.py makemigrations --check


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

First of all, appreciate the work you've put into this project! 🔥

Implemented caching for docker builds in github actions CI.

Helps tremendously reduce the waiting time for tests via taking advantage of github actions cache backend in docker builds.
Reduces the build times from **~3 minutes** to **~30 seconds**, because of cached steps like pip install requirements/*.txt, apt install/update etc

Fix #2588 