### PR TITLE
perf(ci/test-docker): cache test_docker.sh docker builds with gha cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: uv sync
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Docker ${{ matrix.script.name }}
         run: sh tests/test_docker.sh ${{ matrix.script.args }}
 

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -68,6 +68,11 @@ docker compose -f docker-compose.local.yml run --rm \
   django python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
 
 # Generate the HTML for the documentation
+docker buildx bake -f docker-compose.docs.yml --load docs \
+  --allow fs=* \
+  --set docs.cache-from=type=gha,scope=docs-cached \
+  --set docs.cache-to=type=gha,scope=docs-cached,mode=max \
+
 docker compose -f docker-compose.docs.yml run --rm docs make html
 
 # Run npm build script if package.json is present

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -16,7 +16,7 @@ cd my_awesome_project
 
 # Base command with required services
 BAKE_COMMAND="docker buildx bake -f docker-compose.local.yml --load django \
-  --allow fs=*
+  --allow fs=* \
   --set django.cache-from=type=gha,scope=django-cached-tests \
   --set django.cache-to=type=gha,scope=django-cached-tests,mode=max \
   --set postgres.cache-from=type=gha,scope=postgres-cached-tests \

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -71,7 +71,7 @@ docker compose -f docker-compose.local.yml run --rm \
 docker buildx bake -f docker-compose.docs.yml --load docs \
   --allow fs=* \
   --set docs.cache-from=type=gha,scope=docs-cached \
-  --set docs.cache-to=type=gha,scope=docs-cached,mode=max \
+  --set docs.cache-to=type=gha,scope=docs-cached,mode=max
 
 docker compose -f docker-compose.docs.yml run --rm docs make html
 

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -32,8 +32,6 @@ fi
 # Add redis and celery services cache if Celery is enabled
 if grep -q "redis" docker-compose.local.yml; then
   BAKE_COMMAND="$BAKE_COMMAND \
-    --set redis.cache-from=type=gha,scope=redis-cached-tests \
-    --set redis.cache-to=type=gha,scope=redis-cached-tests,mode=max \
     --set celeryworker.cache-from=type=gha,scope=celeryworker-cached-tests \
     --set celeryworker.cache-to=type=gha,scope=celeryworker-cached-tests,mode=max \
     --set celerybeat.cache-from=type=gha,scope=celerybeat-cached-tests \


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Implemented caching for docker builds in `test_docker.sh` using `docker buildx bake`.

Should considerably reduce docker build times for the following matrix of jobs: `Docker Basic`, `Docker Celery & DRF`, `Docker Gulp`, `Docker Webpack`

Right now builds aren't cached and take about **~4 minutes**