### PR TITLE
Add groups for dependabot updates

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -51,10 +51,6 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
-    groups:
-      docker:
-        patterns:
-          - '*'
 
 {%- endif %}
 
@@ -68,8 +64,9 @@ updates:
       interval: 'daily'
     groups:
       python:
-        patterns:
-          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
 {%- if cookiecutter.frontend_pipeline == 'Gulp' %}
 
@@ -82,7 +79,8 @@ updates:
       interval: 'daily'
     groups:
       javascript:
-        patterns:
-          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
 
 {%- if cookiecutter.use_docker == 'y' %}
 
@@ -28,10 +32,14 @@ updates:
         update-types:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
+    groups:
+      docker-python:
+        patterns:
+          - '*'
 
 
   - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `compose/local/node` directory
+    # Look for a `Dockerfile` in the listed directories
     directories:
       - 'compose/local/node/'
       - 'compose/production/aws/'
@@ -43,6 +51,10 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
+    groups:
+      docker:
+        patterns:
+          - '*'
 
 {%- endif %}
 
@@ -54,6 +66,11 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
 
 {%- if cookiecutter.frontend_pipeline == 'Gulp' %}
 
@@ -64,5 +81,9 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
+    groups:
+      npm:
+        patterns:
+          - '*'
 
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -67,10 +67,9 @@ updates:
     schedule:
       interval: 'daily'
     groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
+      python:
+        patterns:
+          - '*'
 
 {%- if cookiecutter.frontend_pipeline == 'Gulp' %}
 
@@ -82,7 +81,7 @@ updates:
     schedule:
       interval: 'daily'
     groups:
-      npm:
+      javascript:
         patterns:
           - '*'
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Dependabot doesn't have to create new pull requests for each update. Instead, it can group the updates for a particular ecosystem into one pull request.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Update groups makes it much easier to stay on top of dependabot updates and also prevents them from clogging up your commit history. 

Fixes #5699