### PR TITLE
add ZeptoMail support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,6 +29,7 @@
     "Sendgrid",
     "Brevo",
     "SparkPost",
+    "ZeptoMail",
     "Other SMTP"
   ],
   "use_async": "n",

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -93,7 +93,8 @@ mail_service:
     6. SendGrid_
     7. `Brevo (formerly SendinBlue)`_
     8. SparkPost_
-    9. `Other SMTP`_
+    9. ZeptoMail_
+    10. `Other SMTP`_
 
 use_async:
     Indicates whether the project should use web sockets with Uvicorn + Gunicorn.
@@ -176,6 +177,7 @@ debug:
 .. _SendGrid: https://sendgrid.com
 .. _Brevo (formerly SendinBlue): https://www.brevo.com
 .. _SparkPost: https://www.sparkpost.com
+.. _ZeptoMail: https://www.zoho.com/zeptomail/
 .. _Other SMTP: https://anymail.readthedocs.io/en/stable/
 
 .. _Django Rest Framework: https://github.com/encode/django-rest-framework/

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -77,6 +77,7 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Sendgrid"},
     {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Brevo"},
     {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "SparkPost"},
+    {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "ZeptoMail"},
     {"cloud_provider": "None", "use_whitenoise": "y", "mail_service": "Other SMTP"},
     # Note: cloud_provider=None AND use_whitenoise=n is not supported
     {"cloud_provider": "AWS", "mail_service": "Mailgun"},
@@ -95,6 +96,7 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "GCP", "mail_service": "Sendgrid"},
     {"cloud_provider": "GCP", "mail_service": "Brevo"},
     {"cloud_provider": "GCP", "mail_service": "SparkPost"},
+    {"cloud_provider": "GCP", "mail_service": "ZeptoMail"},
     {"cloud_provider": "GCP", "mail_service": "Other SMTP"},
     {"cloud_provider": "Azure", "mail_service": "Mailgun"},
     {"cloud_provider": "Azure", "mail_service": "Mailjet"},
@@ -103,6 +105,7 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "Azure", "mail_service": "Sendgrid"},
     {"cloud_provider": "Azure", "mail_service": "Brevo"},
     {"cloud_provider": "Azure", "mail_service": "SparkPost"},
+    {"cloud_provider": "Azure", "mail_service": "ZeptoMail"},
     {"cloud_provider": "Azure", "mail_service": "Other SMTP"},
     # Note: cloud_providers GCP, Azure, and None
     # with mail_service Amazon SES is not supported

--- a/{{cookiecutter.project_slug}}/.envs/.production/.django
+++ b/{{cookiecutter.project_slug}}/.envs/.production/.django
@@ -32,6 +32,9 @@ SENDGRID_MERGE_FIELD_FORMAT=None
 BREVO_API_KEY=
 {% elif cookiecutter.mail_service == 'SparkPost' %}
 SPARKPOST_API_KEY=
+{% elif cookiecutter.mail_service == 'ZeptoMail' %}
+ZOHO_ZEPTOMAIL_API_KEY_TOKEN=
+ZOHO_ZEPTOMAIL_HOSTED_REGION=zeptomail.zoho.com
 {% endif %}
 {% if cookiecutter.cloud_provider == 'AWS' %}
 # AWS

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -290,6 +290,12 @@ ANYMAIL = {
     "SPARKPOST_API_KEY": env("SPARKPOST_API_KEY"),
     "SPARKPOST_API_URL": env("SPARKPOST_API_URL", default="https://api.sparkpost.com/api/v1"),
 }
+{%- elif cookiecutter.mail_service == 'ZeptoMail' %}
+# https://www.zoho.com/zeptomail/django-integration.html
+EMAIL_BACKEND = "zoho_zeptomail.backend.zeptomail_backend.ZohoZeptoMailEmailBackend"
+ZOHO_ZEPTOMAIL_API_KEY_TOKEN = env("ZOHO_ZEPTOMAIL_API_KEY_TOKEN")
+ZOHO_ZEPTOMAIL_HOSTED_REGION = env("ZOHO_ZEPTOMAIL_HOSTED_REGION")
+ANYMAIL = {}
 {%- elif cookiecutter.mail_service == 'Other SMTP' %}
 # https://anymail.readthedocs.io/en/stable/esps
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -39,6 +39,8 @@ django-anymail[sendgrid]==12.0  # https://github.com/anymail/django-anymail
 django-anymail[brevo]==12.0  # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'SparkPost' %}
 django-anymail[sparkpost]==12.0  # https://github.com/anymail/django-anymail
+{%- elif cookiecutter.mail_service == 'ZeptoMail' %}
+django-zoho-zeptomail==0.0.3   # https://www.zoho.com/zeptomail/django-integration.html
 {%- elif cookiecutter.mail_service == 'Other SMTP' %}
 django-anymail==12.0  # https://github.com/anymail/django-anymail
 {%- endif %}


### PR DESCRIPTION

Description

Add support for Zoho ZeptoMail because of their DjangoSupport, free tier and somewhat relaxed admission policy.

Checklist:

    [ x ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
    [ x ] I've updated the documentation or confirm that my change doesn't require any updates

Rationale

I did the legwork to get this working and it was easy enough. I want to convenience others to have it even easier and make django cookiecutter even better!

ps. This is my first PR to a FOSS project and I hope I didn't miss anything or waste anyones time with this PR, just trying to help and learn.
