### PR TITLE
Fix Celery CPendingDeprecationWarning

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -329,6 +329,8 @@ CELERY_WORKER_SEND_TASK_EVENTS = True
 CELERY_TASK_SEND_SENT_EVENT = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-hijack-root-logger
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-connection-retry-on-startup
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
 {%- endif %}
 # django-allauth


### PR DESCRIPTION
## Description
Added the following setting with comment to base.py

```python
https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-connection-retry-on-startup
CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
```

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
This is the default value for this setting anyway and stops the deprecation warning per the example below.

```
2025-03-05 08:56:48 WARNING 2025-03-05 08:56:48,021 warnings 22 280781127086112 /usr/local/lib/python3.12/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
2025-03-05 08:56:48 whether broker connection retries are made during startup in Celery 6.0 and above.
2025-03-05 08:56:48 If you wish to retain the existing behavior for retrying connections on startup,
2025-03-05 08:56:48 you should set broker_connection_retry_on_startup to True.
```

Fix #5085 