### PR TITLE
Fix missing ACCOUNT_EMAIL_REQUIRED for email type

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -343,6 +343,8 @@ ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 # https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
+# https://docs.allauth.org/en/latest/account/configuration.html
+ACCOUNT_EMAIL_REQUIRED = True
 {%- endif %}
 # https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Add missing `ACCOUNT_EMAIL_REQUIRED = True` when `cookiecutter.username_type` is `email`. 
I think it got accidentally removed in #5723

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Without this, we get the following error:
```
Error occurred during checks: SystemCheckError("SystemCheckError: System check identified some issues:

CRITICALS:
?: ACCOUNT_LOGIN_METHODS = {'email'} requires ACCOUNT_EMAIL_REQUIRED = True

System check identified 1 issue (0 silenced).")
```

