### PR TITLE
Fix line endings for dotenv merge

### DIFF
--- a/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
+++ b/{{cookiecutter.project_slug}}/merge_production_dotenvs_in_dotenv.py
@@ -18,7 +18,7 @@ def merge(
     merged_content = ""
     for merge_file in files_to_merge:
         merged_content += merge_file.read_text()
-        merged_content += os.linesep
+        merged_content += "\n"
     output_file.write_text(merged_content)
 
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Replaced `os.linesep` with `\n` to fix line endings for dotenv merge.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

`read_text` converts all line ending into `\n` and `write_text` converts `\n` into system dependent line endings, any contents update in between needs to use only `\n`.
Whats currently happening on Windows is that `os.linesep` contains `\r\n` which gets converted by `write_text` into two new lines and out of the box tests are failing.
