### PR TITLE
Fix media folder permissions prod dockerfile

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -119,6 +119,8 @@ COPY --from=client-builder --chown=django:django ${APP_HOME} ${APP_HOME}
 COPY --chown=django:django . ${APP_HOME}
 {%- endif %}
 
+RUN mkdir -p ${APP_HOME}/{{ cookiecutter.project_slug }}/media
+
 # make django owner of the WORKDIR directory as well.
 RUN chown -R django:django ${APP_HOME}
 

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -119,6 +119,7 @@ COPY --from=client-builder --chown=django:django ${APP_HOME} ${APP_HOME}
 COPY --chown=django:django . ${APP_HOME}
 {%- endif %}
 
+# explicitly create the media folder before changing ownership below
 RUN mkdir -p ${APP_HOME}/{{ cookiecutter.project_slug }}/media
 
 # make django owner of the WORKDIR directory as well.


### PR DESCRIPTION
## Description

Update the production dockerfile to improve media folder permissions in production

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirmed that my change doesn't require any updates

## Rationale

Fix #5728
