### PR TITLE
Remove redundant `use_celery` condition in local compose file

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.local.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.local.yml
@@ -53,10 +53,8 @@ services:
   redis:
     image: docker.io/redis:6
     container_name: {{ cookiecutter.project_slug }}_local_redis
-    {% if cookiecutter.use_celery == 'y' %}
     volumes:
       - {{ cookiecutter.project_slug }}_local_redis_data:/data
-    {% endif %}
 
   celeryworker:
     <<: *django


### PR DESCRIPTION
## Description

Remove redundant conditional (same condition is being checked a few lines above)
Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Simplifies the code and improves readability

Fix #5843

