### PR TITLE
Pin fido2<2

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -33,6 +33,7 @@ django==5.1.9  # pyup: < 5.2 # https://www.djangoproject.com/
 django-environ==0.12.0  # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 django-allauth[mfa]==65.8.0  # https://github.com/pennersr/django-allauth
+fido2<2  # https://github.com/Yubico/python-fido2 - dependency of django-allauth[mfa]
 django-crispy-forms==2.4  # https://github.com/django-crispy-forms/django-crispy-forms
 crispy-bootstrap5==2025.4  # https://github.com/django-crispy-forms/crispy-bootstrap5
 {%- if cookiecutter.frontend_pipeline == 'Django Compressor' %}


### PR DESCRIPTION
## Description

Looks like version [2.0.0](https://pypi.org/project/fido2/#history) was released today and django-allauth doesn't [yet](https://codeberg.org/allauth/django-allauth/commit/cae122759be28047727787e1eb4955c56553ede1) support it, [breaking our CI](https://github.com/cookiecutter/cookiecutter-django/actions/runs/15139236371)

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix CI and our users who want to generate a project
