### PR TITLE
Update post_gen_project.py to remove project.css when a bundler is used

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -105,6 +105,10 @@ def remove_vendors_js():
     if vendors_js_path.exists():
         vendors_js_path.unlink()
 
+def remove_project_css():
+    project_css_path = Path("{{ cookiecutter.project_slug }}", "static", "css", "project.css")
+    if project_css_path.exists():
+        project_css_path.unlink()
 
 def remove_packagejson_file():
     file_names = ["package.json"]
@@ -462,6 +466,7 @@ def main():
         if "{{ cookiecutter.use_docker }}".lower() == "y":
             remove_node_dockerfile()
     else:
+        remove_project_css()
         handle_js_runner(
             "{{ cookiecutter.frontend_pipeline }}",
             use_docker=("{{ cookiecutter.use_docker }}".lower() == "y"),


### PR DESCRIPTION
Add `remove_project_css` function to remove `static/css/project.css `in case a bundler is used.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->
Proposing to remove `static/css/project.css` whenever Webpack or Gulp are used.

Note: I've tested this with Webpack only. I'm not familiar enough with Gulp to know if it's to going to function similarly to Webpack in this respect -- I'm assuming so. I'm hoping someone can confirm this.

If Gulp needs the `project.css` file, then we should move the call `remove_project_css()` to here, in `handle_js_runner(...)` : https://github.com/cookiecutter/cookiecutter-django/blob/98bcde07e7521efdbb1bbd7129fd3c51914bf187/hooks/post_gen_project.py#L156

to only remove it if Webpack is used.

Checklist:

- [NA] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
Fix #5862

When a bundler is used, the `project.css` file is not used. It's sufficient to keep only `static/sass/project.scss`.