### PR TITLE
Fix howto docker command

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/howto.rst
+++ b/{{cookiecutter.project_slug}}/docs/howto.rst
@@ -15,7 +15,7 @@ from inside the `{{cookiecutter.project_slug}}/docs` directory.
 {% else %}
 To build and serve docs, use the commands::
 
-    docker compose -f docker-compose.local.yml up docs
+    docker compose -f docker-compose.docs.yml up
 
 {% endif %}
 


### PR DESCRIPTION
## Description

Fix the howto docker command that is pointing to a non existing file

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Be able to run docs without having to check if files exists or not