### PR TITLE
docs: remove `$` from shell command examples for easier copy-pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ and then editing the results to include your name, email, and various configurat
 
 First, get Cookiecutter. Trust me, it's awesome:
 
-    $ pip install "cookiecutter>=1.7.0"
+    pip install "cookiecutter>=1.7.0"
 
 Now run it against this repo:
 
-    $ cookiecutter https://github.com/cookiecutter/cookiecutter-django
+    cookiecutter https://github.com/cookiecutter/cookiecutter-django
 
 You'll be prompted for some values. Provide them, then a Django project will be created for you.
 
@@ -175,16 +175,16 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
 
 Enter the project and take a look around:
 
-    $ cd reddit/
-    $ ls
+    cd reddit/
+    ls
 
 Create a git repo and push it there:
 
-    $ git init
-    $ git add .
-    $ git commit -m "first awesome commit"
-    $ git remote add origin git@github.com:pydanny/redditclone.git
-    $ git push -u origin master
+    git init
+    git add .
+    git commit -m "first awesome commit"
+    git remote add origin git@github.com:pydanny/redditclone.git
+    git push -u origin master
 
 Now take a look at your repo. Don't forget to carefully look at the generated README. Awesome, right?
 


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Removed the `$` character from shell command examples in the README file to improve copy-paste usability across different environments.

## Rationale

The `$` symbol, while commonly used to indicate shell commands, can cause issues when users try to copy-paste commands directly, especially on Windows or in scripts. Removing it makes the examples cleaner and easier to execute without modification.

Fixes #5913

Checklist:

- [ ] I've made sure that tests are updated accordingly (not applicable — documentation-only change)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
