### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["master", "main"]
+    branches: ["main"]
   pull_request:
 
 concurrency:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -3,7 +3,7 @@ name: Update Contributors
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Always happy to get issues identified and pull requests!
 2. Clone your fork
 3. Create a branch for your changes
 
-This last step is very important, don't start developing from master, it'll cause pain if you need to send another change later.
+This last step is very important, don't start developing from main, it'll cause pain if you need to send another change later.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cookiecutter Django
 
-[![Build Status](https://img.shields.io/github/actions/workflow/status/cookiecutter/cookiecutter-django/ci.yml?branch=master)](https://github.com/cookiecutter/cookiecutter-django/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/cookiecutter/cookiecutter-django/ci.yml?branch=main)](https://github.com/cookiecutter/cookiecutter-django/actions/workflows/ci.yml?query=branch%3Amain)
 [![Documentation Status](https://readthedocs.org/projects/cookiecutter-django/badge/?version=latest)](https://cookiecutter-django.readthedocs.io/en/latest/?badge=latest)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/cookiecutter/cookiecutter-django/master.svg)](https://results.pre-commit.ci/latest/github/cookiecutter/cookiecutter-django/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/cookiecutter/cookiecutter-django/main.svg)](https://results.pre-commit.ci/latest/github/cookiecutter/cookiecutter-django/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 [![Updates](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/shield.svg)](https://pyup.io/repos/github/cookiecutter/cookiecutter-django/)
@@ -184,7 +184,7 @@ Create a git repo and push it there:
     git add .
     git commit -m "first awesome commit"
     git remote add origin git@github.com:pydanny/redditclone.git
-    git push -u origin master
+    git push -u origin main
 
 Now take a look at your repo. Don't forget to carefully look at the generated README. Awesome, right?
 

--- a/docs/5-help/faq.rst
+++ b/docs/5-help/faq.rst
@@ -10,7 +10,7 @@ It is there to add a migration so you don't have to manually change the ``sites.
 
 See `0003_set_site_domain_and_name.py`_.
 
-.. _`0003_set_site_domain_and_name.py`: https://github.com/cookiecutter/cookiecutter-django/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/%7B%7Bcookiecutter.project_slug%7D%7D/contrib/sites/migrations/0003_set_site_domain_and_name.py
+.. _`0003_set_site_domain_and_name.py`: https://github.com/cookiecutter/cookiecutter-django/blob/main/%7B%7Bcookiecutter.project_slug%7D%7D/%7B%7Bcookiecutter.project_slug%7D%7D/contrib/sites/migrations/0003_set_site_domain_and_name.py
 
 
 Why aren't you using just one configuration file (12-Factor App)

--- a/docs/6-about/maintainer-guide.md
+++ b/docs/6-about/maintainer-guide.md
@@ -96,9 +96,9 @@ With that in mind, when merging changes, it's a good idea to set the labels and 
 
 `update-contributors.yml`
 
-Runs on each push to master branch. List the 5 most recently merged pull requests and extract their author. If any of the authors is a new one, updates the `.github/contributors.json`, regenerate the `CONTRIBUTORS.md` from it, and push back the changes to master.
+Runs on each push to main branch. List the 5 most recently merged pull requests and extract their author. If any of the authors is a new one, updates the `.github/contributors.json`, regenerate the `CONTRIBUTORS.md` from it, and push back the changes to master.
 
 #### Limitations
 
-- If you merge a pull request from a new contributor, and merge another one right after, the push to master will fail as the remote will be out of date.
+- If you merge a pull request from a new contributor, and merge another one right after, the push to main will fail as the remote will be out of date.
 - If you merge more than 5 pull requests in a row like this, the new contributor might fail to be added.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 try:
     # Inspired by
-    # https://github.com/django/django/blob/master/django/utils/crypto.py
+    # https://github.com/django/django/blob/main/django/utils/crypto.py
     random = random.SystemRandom()
     using_sysrandom = True
 except NotImplementedError:

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ env:
 
 on:
   pull_request:
-    branches: ['master', 'main']
+    branches: ['main']
     paths-ignore: ['docs/**']
 
   push:
-    branches: ['master', 'main']
+    branches: ['main']
     paths-ignore: ['docs/**']
 
 concurrency:


### PR DESCRIPTION
## Description

I think it's time we make this change. Lot of prominent projects made the move and I believe GitHub has good tooling to do this change. This PR prepares all the various mention of master to main i nthe codebase.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Follow industry naming conventions
