### PR TITLE
Upgrade to Django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: postgres:13
+        image: postgres:14
         ports:
           - 5432:5432
         env:

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     2 - 16
     3 - 15
     4 - 14
-    5 - 13
-    Choose from 1, 2, 3, 4, 5 [1]: 1
+    Choose from 1, 2, 3, 4 [1]: 1
     Select cloud_provider:
     1 - AWS
     2 - GCP

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ production-ready Django projects quickly.
 
 ## Features
 
-- For Django 5.1
+- For Django 5.2
 - Works with Python 3.12
 - Renders Django projects with 100% starting test coverage
 - Twitter [Bootstrap](https://github.com/twbs/bootstrap) v5
@@ -51,7 +51,7 @@ _These features can be enabled during initial project setup._
 ## Constraints
 
 - Only maintained 3rd party libraries are used.
-- Uses PostgreSQL everywhere: 13 - 17 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
+- Uses PostgreSQL everywhere: 14 - 17 ([MySQL fork](https://github.com/mabdullahadeel/cookiecutter-django-mysql) also available).
 - Environment variables for configuration (This won't work with Apache/mod_wsgi).
 
 ## Support this Project!

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
   "windows": "n",
   "editor": ["None", "PyCharm", "VS Code"],
   "use_docker": "n",
-  "postgresql_version": ["17", "16", "15", "14", "13"],
+  "postgresql_version": ["17", "16", "15", "14"],
   "cloud_provider": ["AWS", "GCP", "Azure", "None"],
   "mail_service": [
     "Mailgun",

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -70,7 +70,6 @@ postgresql_version:
     2. 16
     3. 15
     4. 14
-    5. 13
 
 cloud_provider:
     Select a cloud provider for static & media files. The choices are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.12,<3.13"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
-  "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.2",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -64,7 +64,6 @@ SUPPORTED_COMBINATIONS = [
     {"postgresql_version": "16"},
     {"postgresql_version": "15"},
     {"postgresql_version": "14"},
-    {"postgresql_version": "13"},
     {"cloud_provider": "AWS", "use_whitenoise": "y"},
     {"cloud_provider": "AWS", "use_whitenoise": "n"},
     {"cloud_provider": "GCP", "use_whitenoise": "y"},

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: '1.28.0'
     hooks:
       - id: django-upgrade
-        args: ['--target-version', '5.0']
+        args: ['--target-version', '5.2']
 
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -29,7 +29,7 @@ uvicorn-worker==0.3.0  # https://github.com/Kludex/uvicorn-worker
 
 # Django
 # ------------------------------------------------------------------------------
-django==5.1.12  # pyup: < 5.2 # https://www.djangoproject.com/
+django==5.2.6  # pyup: < 6.0 # https://www.djangoproject.com/
 django-environ==0.12.0  # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 django-allauth[mfa]==65.11.2  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
## Description

Upgrade to Django 5.2, drop support for PostgreSQL 13

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5759