### PR TITLE
Fix imagemin corruption with Gulp

### DIFF
--- a/{{cookiecutter.project_slug}}/gulpfile.mjs
+++ b/{{cookiecutter.project_slug}}/gulpfile.mjs
@@ -101,7 +101,7 @@ function vendorScripts() {
 // Image compression
 async function imgCompression() {
   const imagemin = (await import("gulp-imagemin")).default;
-  return src(`${paths.images}/*`)
+  return src(`${paths.images}/*`, { encoding: false })
     .pipe(imagemin()) // Compresses PNG, JPEG, GIF and SVG images
     .pipe(dest(paths.images));
 }


### PR DESCRIPTION
Gulp v5 uses utf8 encoding for source files by default. It's [recommended](https://github.com/gulpjs/gulp/issues/2777#issuecomment-2041178480) to use `{ encoding: false }` for binary files like images.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

I'm proposing to update the src encoding in Gulp for images. Images are binary files but Gulp v5 treats them as text by default, causing corruption in the output.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

https://github.com/gulpjs/gulp/issues/2777#issuecomment-2041178480