### PR TITLE
Use `--locked` instead of `--frozen` when running `uv sync`

### DIFF
--- a/{{cookiecutter.project_slug}}/.drone.yml
+++ b/{{cookiecutter.project_slug}}/.drone.yml
@@ -39,7 +39,7 @@ steps:
   {%- else %}
   image: ghcr.io/astral-sh/uv:python3.12
   commands:
-  - uv sync --frozen
+  - uv sync --locked
   - uv run pytest
   {%- endif%}
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Check DB Migrations
         run: uv run python manage.py makemigrations --check

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-        python-version-file: ".python-version"
+          python-version-file: ".python-version"
 
       - name: Install dependencies
         run: uv sync

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -45,7 +45,7 @@ pytest:
   variables:
     DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
   before_script:
-    - uv sync --frozen
+    - uv sync --locked
   script:
     - uv run pytest
   {%- endif %}

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev
+    uv sync --locked --no-install-project --no-dev
 {%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] %}
 COPY --from=client-builder ${APP_HOME} ${APP_HOME}
 {% else %}
@@ -54,7 +54,7 @@ COPY . ${APP_HOME}
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-dev
+    uv sync --locked --no-dev
 
 # Python 'run' stage
 FROM python:3.12-slim-bookworm AS python-run-stage


### PR DESCRIPTION
## Description

As per latest recommendations: https://github.com/astral-sh/uv-docker-example/pull/53

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The main difference is that `--locked` assert that the `uv.lock` will remain unchanged. Production and CI systems should expect that to be the case.
