### PR TITLE
Fix Docker error volume name is too short during project generation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -535,8 +535,9 @@ def setup_dependencies():
             print(f"Error building Docker image: {e}", file=sys.stderr)
             sys.exit(1)
 
+        current_path = Path.cwd().absolute()
         # Use Docker to run the uv command
-        uv_cmd = ["docker", "run", "--rm", "-v", "./:/app", uv_image_tag, "uv"]
+        uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]
     else:
         # Use uv command directly
         uv_cmd = ["uv"]


### PR DESCRIPTION
## Description

Add forward slash to volume mount used to run the uv Docker image as it seems like some versions of Docker require at least 2 characters

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #6085 
