### PR TITLE
Add `django-ninja` as REST API option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,6 @@ jobs:
             args: "ci_tool=Gitlab"
           - name: Celery & DRF
             args: "use_celery=y rest_api=DRF"
-          - name: Classic username & DRF
-            args: "username_type=username rest_api=DRF"
-          - name: Email username & DRF
-            args: "username_type=email rest_api=DRF"
-          - name: Classic username & Django-Ninja
-            args: "use_async=y username_type=username rest_api='Django Ninja'"
-          - name: Email username & Django-Ninja
-            args: "use_async=y username_type=email rest_api='Django Ninja'"
           - name: Gulp
             args: "frontend_pipeline=Gulp"
           - name: Webpack
@@ -80,6 +72,12 @@ jobs:
             args: "frontend_pipeline=Webpack use_heroku=y"
           - name: Email Username
             args: "username_type=email ci_tool=Github project_name='Something superduper long - the great amazing project' project_slug=my_awesome_project"
+          - name: Email username & DRF
+            args: "username_type=email rest_api=DRF ci_tool=Gitlab"
+          - name: Async & Django-Ninja
+            args: "use_async=y rest_api='Django Ninja'"
+          - name: Async, email username & Django-Ninja
+            args: "use_async=y username_type=email rest_api='Django Ninja'"
 
     name: "Bare metal ${{ matrix.script.name }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,15 @@ jobs:
           - name: Basic
             args: "ci_tool=Gitlab"
           - name: Celery & DRF
-            args: "use_celery=y use_drf=y"
+            args: "use_celery=y rest_api=DRF"
+          - name: Classic username & DRF
+            args: "username_type=username rest_api=DRF"
+          - name: Email username & DRF
+            args: "username_type=email rest_api=DRF"
+          - name: Classic username & Django-Ninja
+            args: "use_async=y username_type=username rest_api='Django Ninja'"
+          - name: Email username & Django-Ninja
+            args: "use_async=y username_type=email rest_api='Django Ninja'"
           - name: Gulp
             args: "frontend_pipeline=Gulp"
           - name: Webpack

--- a/README.md
+++ b/README.md
@@ -150,8 +150,12 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     8 - SparkPost
     9 - Other SMTP
     Choose from 1, 2, 3, 4, 5, 6, 7, 8, 9 [1]: 1
+    Select rest_api [n]:
+    1 - None
+    2 - DRF
+    3 - Django Ninja
+    Choose from 1, 2, 3 [1]: 1
     use_async [n]: n
-    use_drf [n]: y
     Select frontend_pipeline:
     1 - None
     2 - Django Compressor

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -31,8 +31,8 @@
     "SparkPost",
     "Other SMTP"
   ],
+  "rest_api": ["None", "DRF", "Django Ninja"],
   "use_async": "n",
-  "use_drf": "n",
   "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack"],
   "use_celery": "n",
   "use_mailpit": "n",

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -94,11 +94,15 @@ mail_service:
     8. SparkPost_
     9. `Other SMTP`_
 
+rest_api:
+    Select a REST API framework to use. The choices are:
+
+    1. None
+    2. `Django Rest Framework`_
+    3. `Django Ninja`_
+
 use_async:
     Indicates whether the project should use web sockets with Uvicorn + Gunicorn.
-
-use_drf:
-    Indicates whether the project should be configured to use `Django Rest Framework`_.
 
 frontend_pipeline:
     Select a pipeline to compile and optimise frontend assets (JS, CSS, ...):
@@ -178,6 +182,7 @@ debug:
 .. _Other SMTP: https://anymail.readthedocs.io/en/stable/
 
 .. _Django Rest Framework: https://github.com/encode/django-rest-framework/
+.. _`Django Ninja`: https://github.com/vitalik/django-ninja
 
 .. _Django Compressor: https://github.com/django-compressor/django-compressor
 

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -182,7 +182,7 @@ debug:
 .. _Other SMTP: https://anymail.readthedocs.io/en/stable/
 
 .. _Django Rest Framework: https://github.com/encode/django-rest-framework/
-.. _`Django Ninja`: https://github.com/vitalik/django-ninja
+.. _Django Ninja: https://github.com/vitalik/django-ninja
 
 .. _Django Compressor: https://github.com/django-compressor/django-compressor
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -408,6 +408,15 @@ def remove_aws_dockerfile():
 
 def remove_drf_starter_files():
     Path("config", "api_router.py").unlink()
+    Path("{{cookiecutter.project_slug}}", "users", "api", "serializers.py").unlink()
+
+
+def remove_ninja_starter_files():
+    Path("config", "api.py").unlink()
+    Path("{{cookiecutter.project_slug}}", "users", "api", "schema.py").unlink()
+
+
+def remove_rest_api_files():
     shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "api"))
     shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "tests", "api"))
 
@@ -499,8 +508,12 @@ def main():  # noqa: C901, PLR0912, PLR0915
     if "{{ cookiecutter.ci_tool }}" != "Drone":
         remove_dotdrone_file()
 
-    if "{{ cookiecutter.use_drf }}".lower() == "n":
+    if "{{ cookiecutter.rest_api }}".lower() != "drf":
         remove_drf_starter_files()
+    elif "{{ cookiecutter.rest_api }}".lower() != "django ninja":
+        remove_ninja_starter_files()
+    else:
+        remove_rest_api_files()
 
     if "{{ cookiecutter.use_async }}".lower() == "n":
         remove_async_files()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -417,6 +417,8 @@ def remove_ninja_starter_files():
 
 
 def remove_rest_api_files():
+    remove_drf_starter_files()
+    remove_ninja_starter_files()
     shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "api"))
     shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "tests", "api"))
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -508,10 +508,10 @@ def main():  # noqa: C901, PLR0912, PLR0915
     if "{{ cookiecutter.ci_tool }}" != "Drone":
         remove_dotdrone_file()
 
-    if "{{ cookiecutter.rest_api }}".lower() != "drf":
-        remove_drf_starter_files()
-    elif "{{ cookiecutter.rest_api }}".lower() != "django ninja":
+    if "{{ cookiecutter.rest_api }}" == "DRF":
         remove_ninja_starter_files()
+    elif "{{ cookiecutter.rest_api }}" == "Django Ninja":
+        remove_drf_starter_files()
     else:
         remove_rest_api_files()
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -106,10 +106,11 @@ SUPPORTED_COMBINATIONS = [
     {"cloud_provider": "Azure", "mail_service": "Other SMTP"},
     # Note: cloud_providers GCP, Azure, and None
     # with mail_service Amazon SES is not supported
+    {"rest_api": "None"},
+    {"rest_api": "DRF"},
+    {"rest_api": "Django Ninja"},
     {"use_async": "y"},
     {"use_async": "n"},
-    {"use_drf": "y"},
-    {"use_drf": "n"},
     {"frontend_pipeline": "None"},
     {"frontend_pipeline": "Django Compressor"},
     {"frontend_pipeline": "Gulp"},

--- a/{{cookiecutter.project_slug}}/config/api.py
+++ b/{{cookiecutter.project_slug}}/config/api.py
@@ -1,6 +1,11 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from ninja import NinjaAPI
+from ninja.security import SessionAuth
 
-api = NinjaAPI(urls_namespace="api", docs_decorator=staff_member_required)
+api = NinjaAPI(
+    urls_namespace="api",
+    auth=SessionAuth(),
+    docs_decorator=staff_member_required,
+)
 
 api.add_router("/users/", "{{ cookiecutter.project_slug }}.users.api.views.router")

--- a/{{cookiecutter.project_slug}}/config/api.py
+++ b/{{cookiecutter.project_slug}}/config/api.py
@@ -1,0 +1,6 @@
+from django.contrib.admin.views.decorators import staff_member_required
+from ninja import NinjaAPI
+
+api = NinjaAPI(urls_namespace="api", docs_decorator=staff_member_required)
+
+api.add_router("/users/", "{{ cookiecutter.project_slug }}.users.api.views.router")

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -3,7 +3,7 @@
 
 {% if cookiecutter.use_celery == 'y' -%}
 import ssl
-{%- endif %}
+{%- endif -%}
 from pathlib import Path
 
 import environ

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -1,9 +1,8 @@
 # ruff: noqa: ERA001, E501
 """Base settings to build other settings files upon."""
-
-{% if cookiecutter.use_celery == 'y' -%}
+{% if cookiecutter.use_celery == 'y' %}
 import ssl
-{%- endif -%}
+{%- endif %}
 from pathlib import Path
 
 import environ

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -92,7 +92,7 @@ THIRD_PARTY_APPS = [
 {%- if cookiecutter.use_celery == 'y' %}
     "django_celery_beat",
 {%- endif %}
-{%- if cookiecutter.use_drf == "y" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
@@ -154,7 +154,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-{%- if cookiecutter.use_drf == 'y' %}
+{%- if cookiecutter.rest_api != 'None' %}
     "corsheaders.middleware.CorsMiddleware",
 {%- endif %}
 {%- if cookiecutter.use_whitenoise == 'y' %}
@@ -361,7 +361,7 @@ SOCIALACCOUNT_FORMS = {"signup": "{{cookiecutter.project_slug}}.users.forms.User
 INSTALLED_APPS += ["compressor"]
 STATICFILES_FINDERS += ["compressor.finders.CompressorFinder"]
 {%- endif %}
-{% if cookiecutter.use_drf == "y" -%}
+{% if cookiecutter.rest_api == 'DRF' -%}
 # django-rest-framework
 # -------------------------------------------------------------------------------
 # django-rest-framework - https://www.django-rest-framework.org/api-guide/settings/

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -97,6 +97,8 @@ THIRD_PARTY_APPS = [
     "rest_framework.authtoken",
     "corsheaders",
     "drf_spectacular",
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+    "corsheaders",
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
     "webpack_loader",

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -43,7 +43,8 @@ EMAIL_PORT = 1025
 {%- else -%}
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = env(
-    "DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend",
+    "DJANGO_EMAIL_BACKEND",
+    default="django.core.mail.backends.console.EmailBackend",
 )
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -17,7 +17,7 @@ from .base import *  # noqa: F403
 from .base import DATABASES
 from .base import INSTALLED_APPS
 from .base import REDIS_URL
-{%- if cookiecutter.use_drf == "y" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 from .base import SPECTACULAR_SETTINGS
 {%- endif %}
 from .base import env
@@ -436,7 +436,7 @@ sentry_sdk.init(
     traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
 )
 {% endif %}
-{% if cookiecutter.use_drf == "y" -%}
+{% if cookiecutter.rest_api == 'DRF' -%}
 
 # django-rest-framework
 # -------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -8,7 +8,7 @@ from django.urls import include
 from django.urls import path
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
-{%- if cookiecutter.use_drf == 'y' %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
@@ -36,7 +36,7 @@ if settings.DEBUG:
     # Static file serving when using Gunicorn + Uvicorn for local web socket development
     urlpatterns += staticfiles_urlpatterns()
 {%- endif %}
-{% if cookiecutter.use_drf == 'y' %}
+{% if cookiecutter.rest_api == 'DRF' %}
 # API URLS
 urlpatterns += [
     # API base url
@@ -49,6 +49,13 @@ urlpatterns += [
         SpectacularSwaggerView.as_view(url_name="api-schema"),
         name="api-docs",
     ),
+]
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+
+# API URLS
+urlpatterns += [
+    # API base url
+    path("api/", api.urls),
 ]
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -12,6 +12,9 @@ from django.views.generic import TemplateView
 from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+
+from .api import api
 {%- endif %}
 
 urlpatterns = [

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 from pathlib import Path

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -26,7 +26,7 @@ warn_redundant_casts = true
 warn_unused_configs = true
 plugins = [
     "mypy_django_plugin.main",
-    {%- if cookiecutter.use_drf == "y" %}
+    {%- if cookiecutter.rest_api == 'DRF' %}
     "mypy_drf_plugin.main",
     {%- endif %}
 ]

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -46,7 +46,9 @@ django-cors-headers==4.9.0  # https://github.com/adamchainz/django-cors-headers
 # DRF-spectacular for api documentation
 drf-spectacular==0.28.0  # https://github.com/tfranzel/drf-spectacular
 {%- elif cookiecutter.rest_api == 'Django Ninja' %}
+# Django Ninja
 django-ninja==1.4.3 # https://github.com/vitalik/django-ninja
+django-cors-headers==4.9.0  # https://github.com/adamchainz/django-cors-headers
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
 django-webpack-loader==3.2.1  # https://github.com/django-webpack/django-webpack-loader

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -39,12 +39,14 @@ crispy-bootstrap5==2025.6  # https://github.com/django-crispy-forms/crispy-boots
 django-compressor==4.5.1  # https://github.com/django-compressor/django-compressor
 {%- endif %}
 django-redis==6.0.0  # https://github.com/jazzband/django-redis
-{%- if cookiecutter.use_drf == 'y' %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 # Django REST Framework
 djangorestframework==3.16.1  # https://github.com/encode/django-rest-framework
 django-cors-headers==4.9.0  # https://github.com/adamchainz/django-cors-headers
 # DRF-spectacular for api documentation
 drf-spectacular==0.28.0  # https://github.com/tfranzel/drf-spectacular
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+django-ninja==1.4.3 # https://github.com/vitalik/django-ninja
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
 django-webpack-loader==3.2.1  # https://github.com/django-webpack/django-webpack-loader

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -15,7 +15,7 @@ mypy==1.18.2  # https://github.com/python/mypy
 django-stubs[compatible-mypy]==5.2.5  # https://github.com/typeddjango/django-stubs
 pytest==8.4.2  # https://github.com/pytest-dev/pytest
 pytest-sugar==1.1.1  # https://github.com/Teemu/pytest-sugar
-{%- if cookiecutter.use_drf == "y" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 djangorestframework-stubs==3.16.4  # https://github.com/typeddjango/djangorestframework-stubs
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/schema.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/schema.py
@@ -1,0 +1,34 @@
+from django.urls.base import reverse
+from ninja import ModelSchema
+
+from {{ cookiecutter.project_slug }}.users.models import User
+
+
+class UpdateUserSchema(ModelSchema):
+    class Meta:
+        model = User
+        {%- if cookiecutter.username_type == "email" %}
+        fields = ["name"]
+        {%- else %}
+        fields = ["username", "name"]
+        {%- endif %}
+
+
+class UserSchema(ModelSchema):
+    url: str
+
+    class Meta:
+        model = User
+        {%- if cookiecutter.username_type == "email" %}
+        fields = ["email", "name"]
+        {%- else %}
+        fields = ["username", "email", "name"]
+        {%- endif %}
+
+    @staticmethod
+    def resolve_url(obj: User):
+        {%- if cookiecutter.username_type == "email" %}
+        return reverse("api:retrieve_user", kwargs={"pk": obj.pk})
+        {%- else %}
+        return reverse("api:retrieve_user", kwargs={"username": obj.username})
+        {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -34,7 +34,8 @@ from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from ninja import Router
 
-from {{ cookiecutter.project_slug }}.users.api.schema import UserSchema, UpdateUserSchema
+from {{ cookiecutter.project_slug }}.users.api.schema import UpdateUserSchema
+from {{ cookiecutter.project_slug }}.users.api.schema import UserSchema
 from {{ cookiecutter.project_slug }}.users.models import User
 
 router = Router(tags=["users"])
@@ -54,9 +55,8 @@ def list_users(request):
 def retrieve_user(request, pk: str):
     if pk == "me":
         return request.user
-    else:
-        users_qs = _get_users_queryset(request)
-        return get_object_or_404(users_qs, pk=pk)
+    users_qs = _get_users_queryset(request)
+    return get_object_or_404(users_qs, pk=pk)
 {%- else %}
 
 
@@ -64,9 +64,8 @@ def retrieve_user(request, pk: str):
 def retrieve_user(request, username: str):
     if username == "me":
         return request.user
-    else:
-        users_qs = _get_users_queryset(request)
-        return get_object_or_404(users_qs, username=username)
+    users_qs = _get_users_queryset(request)
+    return get_object_or_404(users_qs, username=username)
 {%- endif %}
 {%- if cookiecutter.username_type == "email" %}
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -1,4 +1,4 @@
-{%- if cookiecutter.rest_api == "DRF" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
@@ -29,7 +29,7 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
     def me(self, request):
         serializer = UserSerializer(request.user, context={"request": request})
         return Response(status=status.HTTP_200_OK, data=serializer.data)
-{%- elif cookiecutter.rest_api == "django ninja" %}
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from ninja import Router

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -1,4 +1,4 @@
-{%- if cookiecutter.rest_api == 'DRF' %}
+{% if cookiecutter.rest_api == 'DRF' -%}
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
@@ -29,7 +29,7 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
     def me(self, request):
         serializer = UserSerializer(request.user, context={"request": request})
         return Response(status=status.HTTP_200_OK, data=serializer.data)
-{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+{%- elif cookiecutter.rest_api == 'Django Ninja' -%}
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
 from ninja import Router

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/api/views.py
@@ -1,3 +1,4 @@
+{%- if cookiecutter.rest_api == "DRF" %}
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
@@ -28,3 +29,64 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
     def me(self, request):
         serializer = UserSerializer(request.user, context={"request": request})
         return Response(status=status.HTTP_200_OK, data=serializer.data)
+{%- elif cookiecutter.rest_api == "django ninja" %}
+from django.db.models import QuerySet
+from django.shortcuts import get_object_or_404
+from ninja import Router
+
+from {{ cookiecutter.project_slug }}.users.api.schema import UserSchema, UpdateUserSchema
+from {{ cookiecutter.project_slug }}.users.models import User
+
+router = Router(tags=["users"])
+
+
+def _get_users_queryset(request) -> QuerySet[User]:
+    return User.objects.filter(pk=request.user.pk)
+
+
+@router.get("/", response=list[UserSchema])
+def list_users(request):
+    return _get_users_queryset(request)
+{%- if cookiecutter.username_type == "email" %}
+
+
+@router.get("/{pk}/", response=UserSchema)
+def retrieve_user(request, pk: str):
+    if pk == "me":
+        return request.user
+    else:
+        users_qs = _get_users_queryset(request)
+        return get_object_or_404(users_qs, pk=pk)
+{%- else %}
+
+
+@router.get("/{username}/", response=UserSchema)
+def retrieve_user(request, username: str):
+    if username == "me":
+        return request.user
+    else:
+        users_qs = _get_users_queryset(request)
+        return get_object_or_404(users_qs, username=username)
+{%- endif %}
+{%- if cookiecutter.username_type == "email" %}
+
+
+@router.patch("/{pk}/", response=UserSchema)
+def update_user(request, pk: str, data: UpdateUserSchema):
+    users_qs = _get_users_queryset(request)
+    user = get_object_or_404(users_qs, pk=pk)
+    user.name = data.name
+    user.save()
+    return user
+{%- else %}
+
+
+@router.patch("/{username}/", response=UserSchema)
+def update_user(request, username: str, data: UpdateUserSchema):
+    users_qs = _get_users_queryset(request)
+    user = get_object_or_404(users_qs, username=username)
+    user.name = data.name
+    user.save()
+    return user
+{%- endif %}
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_openapi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_openapi.py
@@ -5,19 +5,34 @@ from django.urls import reverse
 
 
 def test_api_docs_accessible_by_admin(admin_client):
+    {%- if cookiecutter.rest_api == "DRF" %}
     url = reverse("api-docs")
+    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    url = reverse("api:openapi-view")
+    {%- endif %}
     response = admin_client.get(url)
     assert response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.django_db
 def test_api_docs_not_accessible_by_anonymous_users(client):
+    {%- if cookiecutter.rest_api == "DRF" %}
     url = reverse("api-docs")
     response = client.get(url)
     assert response.status_code == HTTPStatus.FORBIDDEN
+    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    url = reverse("api:openapi-view")
+    response = client.get(url)
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.url == "/admin/login/?next=/api/docs"
+    {%- endif %}
 
 
 def test_api_schema_generated_successfully(admin_client):
+    {%- if cookiecutter.rest_api == "DRF" %}
     url = reverse("api-schema")
+    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    url = reverse("api:openapi-json")
+    {%- endif %}
     response = admin_client.get(url)
     assert response.status_code == HTTPStatus.OK

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_openapi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_openapi.py
@@ -5,9 +5,9 @@ from django.urls import reverse
 
 
 def test_api_docs_accessible_by_admin(admin_client):
-    {%- if cookiecutter.rest_api == "DRF" %}
+    {%- if cookiecutter.rest_api == 'DRF' %}
     url = reverse("api-docs")
-    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    {%- elif cookiecutter.rest_api == 'Django Ninja' %}
     url = reverse("api:openapi-view")
     {%- endif %}
     response = admin_client.get(url)
@@ -16,11 +16,11 @@ def test_api_docs_accessible_by_admin(admin_client):
 
 @pytest.mark.django_db
 def test_api_docs_not_accessible_by_anonymous_users(client):
-    {%- if cookiecutter.rest_api == "DRF" %}
+    {%- if cookiecutter.rest_api == 'DRF' %}
     url = reverse("api-docs")
     response = client.get(url)
     assert response.status_code == HTTPStatus.FORBIDDEN
-    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    {%- elif cookiecutter.rest_api == 'Django Ninja' %}
     url = reverse("api:openapi-view")
     response = client.get(url)
     assert response.status_code == HTTPStatus.FOUND
@@ -29,9 +29,9 @@ def test_api_docs_not_accessible_by_anonymous_users(client):
 
 
 def test_api_schema_generated_successfully(admin_client):
-    {%- if cookiecutter.rest_api == "DRF" %}
+    {%- if cookiecutter.rest_api == 'DRF' %}
     url = reverse("api-schema")
-    {%- elif cookiecutter.rest_api == "Django Ninja" %}
+    {%- elif cookiecutter.rest_api == 'Django Ninja' %}
     url = reverse("api:openapi-json")
     {%- endif %}
     response = admin_client.get(url)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
@@ -34,15 +34,15 @@ def test_user_me():
 def test_user_detail(user: User):
     {%- if cookiecutter.username_type == "email" %}
     assert (
+        reverse("api:retrieve_user", kwargs={"pk": user.pk}) == f"/api/users/{user.pk}/"
+    )
+    assert resolve(f"/api/users/{user.pk}/").view_name == "api:retrieve_user"
+    {%- else %}
+    assert (
         reverse("api:retrieve_user", kwargs={"username": user.username})
         == f"/api/users/{user.username}/"
     )
     assert resolve(f"/api/users/{user.username}/").view_name == "api:retrieve_user"
-    {%- else %}
-    assert (
-        reverse("api:retrieve_user", kwargs={"pk": user.pk}) == f"/api/users/{user.pk}/"
-    )
-    assert resolve(f"/api/users/{user.pk}/").view_name == "api:retrieve_user"
     {%- endif %}
 
 
@@ -64,7 +64,7 @@ def test_user_me():
 def test_update_user():
     {%- if cookiecutter.username_type == "email" %}
     assert reverse("api:update_user", kwargs={"pk": "me"}) == "/api/users/me/"
-    assert resolve("/api/users/me/").view_name == "api:update_user"
+    assert resolve("/api/users/me/").view_name == "api:retrieve_user"
     {%- else %}
     assert reverse("api:update_user", kwargs={"username": "me"}) == "/api/users/me/"
     assert resolve("/api/users/me/").view_name == "api:retrieve_user"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
@@ -1,7 +1,7 @@
-from django.urls import resolve
-from django.urls import reverse
+from django.urls import reverse, resolve
 
 from {{ cookiecutter.project_slug }}.users.models import User
+{%- if cookiecutter.rest_api == "DRF" %}
 
 
 def test_user_detail(user: User):
@@ -27,3 +27,46 @@ def test_user_list():
 def test_user_me():
     assert reverse("api:user-me") == "/api/users/me/"
     assert resolve("/api/users/me/").view_name == "api:user-me"
+{%- elif cookiecutter.rest_api == "Django Ninja" %}
+
+
+def test_user_detail(user: User):
+    {%- if cookiecutter.username_type == "email" %}
+    assert (
+        reverse("api:retrieve_user", kwargs={"username": user.username})
+        == f"/api/users/{user.username}/"
+    )
+    assert resolve(f"/api/users/{user.username}/").view_name == "api:retrieve_user"
+    {%- else %}
+    assert (
+        reverse("api:retrieve_user", kwargs={"pk": user.pk})
+        == f"/api/users/{user.pk}/"
+    )
+    assert resolve(f"/api/users/{user.pk}/").view_name == "api:retrieve_user"
+    {%- endif %}
+
+
+def test_user_list():
+    assert reverse("api:list_users") == "/api/users/"
+    assert resolve("/api/users/").view_name == "api:list_users"
+
+
+def test_user_me():
+    {%- if cookiecutter.username_type == "email" %}
+    assert reverse("api:retrieve_user", kwargs={"pk": "me"}) == "/api/users/me/"
+    assert resolve("/api/users/me/").view_name == "api:retrieve_user"
+    {%- else %}
+    assert reverse("api:retrieve_user", kwargs={"username": "me"}) == "/api/users/me/"
+    assert resolve("/api/users/me/").view_name == "api:retrieve_user"
+    {%- endif %}
+
+
+def test_update_user():
+    {%- if cookiecutter.username_type == "email" %}
+    assert reverse("api:update_user", kwargs={"pk": "me"}) == "/api/users/me/"
+    assert resolve("/api/users/me/").view_name == "api:update_user"
+    {%- else %}
+    assert reverse("api:update_user", kwargs={"username": "me"}) == "/api/users/me/"
+    assert resolve("/api/users/me/").view_name == "api:retrieve_user"
+    {%- endif %}
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
@@ -40,8 +40,7 @@ def test_user_detail(user: User):
     assert resolve(f"/api/users/{user.username}/").view_name == "api:retrieve_user"
     {%- else %}
     assert (
-        reverse("api:retrieve_user", kwargs={"pk": user.pk})
-        == f"/api/users/{user.pk}/"
+        reverse("api:retrieve_user", kwargs={"pk": user.pk}) == f"/api/users/{user.pk}/"
     )
     assert resolve(f"/api/users/{user.pk}/").view_name == "api:retrieve_user"
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
@@ -2,7 +2,7 @@ from django.urls import resolve
 from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
-{%- if cookiecutter.rest_api == "DRF" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 
 
 def test_user_detail(user: User):
@@ -28,7 +28,7 @@ def test_user_list():
 def test_user_me():
     assert reverse("api:user-me") == "/api/users/me/"
     assert resolve("/api/users/me/").view_name == "api:user-me"
-{%- elif cookiecutter.rest_api == "Django Ninja" %}
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
 
 
 def test_user_detail(user: User):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_urls.py
@@ -1,4 +1,5 @@
-from django.urls import reverse, resolve
+from django.urls import resolve
+from django.urls import reverse
 
 from {{ cookiecutter.project_slug }}.users.models import User
 {%- if cookiecutter.rest_api == "DRF" %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -1,4 +1,4 @@
-{%- if cookiecutter.rest_api == 'DRF' %}
+{% if cookiecutter.rest_api == 'DRF' -%}
 import pytest
 from rest_framework.test import APIRequestFactory
 
@@ -38,7 +38,7 @@ class TestUserViewSet:
             {%- endif %}
             "name": user.name,
         }
-{%- elif cookiecutter.rest_api == 'Django Ninja' %}
+{%- elif cookiecutter.rest_api == 'Django Ninja' -%}
 from http import HTTPStatus
 
 import pytest

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -1,3 +1,4 @@
+{%- if cookiecutter.rest_api == "DRF" %}
 import pytest
 from rest_framework.test import APIRequestFactory
 
@@ -37,3 +38,6 @@ class TestUserViewSet:
             {%- endif %}
             "name": user.name,
         }
+{%- elif cookiecutter.rest_api == "Django Ninja" %}
+
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -39,5 +39,89 @@ class TestUserViewSet:
             "name": user.name,
         }
 {%- elif cookiecutter.rest_api == "Django Ninja" %}
+import pytest
+from django.test import Client
+from django.urls import reverse
 
+from {{ cookiecutter.project_slug }}.users.models import User
+from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def user():
+    return UserFactory()
+
+
+def test_list_users_as_anonymous_user(client: Client):
+    response = client.get(reverse("api:list_users"))
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_users_as_authenticated_user(client: Client, user: User):
+    client.force_login(user)
+    # Another user, excluded from the response
+    UserFactory()
+
+    response = client.get(reverse("api:list_users"))
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "name": user.name,
+            "url": f"/api/users/{user.username}/",
+            "username": user.username,
+        },
+    ]
+
+
+@pytest.mark.parametrize("username", [None, "me"])
+def test_retrieve_user(client: Client, user: User, username: str | None):
+    client.force_login(user)
+    username = username or user.username
+
+    response = client.get(
+        reverse("api:retrieve_user", kwargs={"username": username})
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "name": user.name,
+        "url": f"/api/users/{user.username}/",
+        "username": user.username,
+    }
+
+
+def test_retrieve_another_user(client: Client, user: User):
+    client.force_login(user)
+    user_2 = UserFactory()
+
+    response = client.get(
+        reverse("api:retrieve_user", kwargs={"username": user_2.username})
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
+
+
+def test_update_user(client: Client):
+    user = UserFactory(name="Old", username="old")
+    client.force_login(user)
+
+    response = client.patch(
+        reverse("api:update_user", kwargs={"username": "old"}),
+        data='{"name": "New Name"}',
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json() == {
+        "name": "New Name",
+        "url": "/api/users/old/",
+        "username": "old",
+    }
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -1,4 +1,4 @@
-{%- if cookiecutter.rest_api == "DRF" %}
+{%- if cookiecutter.rest_api == 'DRF' %}
 import pytest
 from rest_framework.test import APIRequestFactory
 
@@ -38,7 +38,7 @@ class TestUserViewSet:
             {%- endif %}
             "name": user.name,
         }
-{%- elif cookiecutter.rest_api == "Django Ninja" %}
+{%- elif cookiecutter.rest_api == 'Django Ninja' %}
 import pytest
 from django.test import Client
 from django.urls import reverse

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -59,8 +59,7 @@ def user():
 def test_list_users_as_anonymous_user(client: Client):
     response = client.get(reverse("api:list_users"))
 
-    assert response.status_code == HTTPStatus.OK
-    assert response.json() == []
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
 
 
 def test_list_users_as_authenticated_user(client: Client, user: User):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -39,6 +39,8 @@ class TestUserViewSet:
             "name": user.name,
         }
 {%- elif cookiecutter.rest_api == 'Django Ninja' %}
+from http import HTTPStatus
+
 import pytest
 from django.test import Client
 from django.urls import reverse
@@ -57,7 +59,7 @@ def user():
 def test_list_users_as_anonymous_user(client: Client):
     response = client.get(reverse("api:list_users"))
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == []
 
 
@@ -68,7 +70,7 @@ def test_list_users_as_authenticated_user(client: Client, user: User):
 
     response = client.get(reverse("api:list_users"))
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == [
         {
             "name": user.name,
@@ -87,7 +89,7 @@ def test_retrieve_user(client: Client, user: User, username: str | None):
         reverse("api:retrieve_user", kwargs={"username": username}),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == {
         "name": user.name,
         "url": f"/api/users/{user.username}/",
@@ -103,7 +105,7 @@ def test_retrieve_another_user(client: Client, user: User):
         reverse("api:retrieve_user", kwargs={"username": user_2.username}),
     )
 
-    assert response.status_code == 404
+    assert response.status_code == HTTPStatus.NOT_FOUND
     assert response.json() == {"detail": "Not Found"}
 
 
@@ -117,7 +119,7 @@ def test_update_user(client: Client):
         content_type="application/json",
     )
 
-    assert response.status_code == 200, response.json()
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert response.json() == {
         "name": "New Name",
         "url": "/api/users/old/",

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -46,11 +46,10 @@ from django.urls import reverse
 from {{ cookiecutter.project_slug }}.users.models import User
 from {{ cookiecutter.project_slug }}.users.tests.factories import UserFactory
 
-
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture()
+@pytest.fixture
 def user():
     return UserFactory()
 
@@ -85,7 +84,7 @@ def test_retrieve_user(client: Client, user: User, username: str | None):
     username = username or user.username
 
     response = client.get(
-        reverse("api:retrieve_user", kwargs={"username": username})
+        reverse("api:retrieve_user", kwargs={"username": username}),
     )
 
     assert response.status_code == 200
@@ -101,7 +100,7 @@ def test_retrieve_another_user(client: Client, user: User):
     user_2 = UserFactory()
 
     response = client.get(
-        reverse("api:retrieve_user", kwargs={"username": user_2.username})
+        reverse("api:retrieve_user", kwargs={"username": user_2.username}),
     )
 
     assert response.status_code == 404

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -73,9 +73,14 @@ def test_list_users_as_authenticated_user(client: Client, user: User):
     assert response.status_code == HTTPStatus.OK
     assert response.json() == [
         {
+            "email": user.email,
             "name": user.name,
+            {%- if cookiecutter.username_type == "email" %}
+            "url": f"/api/users/{user.pk}/",
+            {%- else %}
             "url": f"/api/users/{user.username}/",
             "username": user.username,
+            {%- endif %}
         },
     ]
 {%- if cookiecutter.username_type == "email" %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -166,7 +166,7 @@ def test_update_user(client: Client):
 
     response = client.patch(
         reverse("api:update_user", kwargs={"username": "old"}),
-        data='{"name": "New Name"}',
+        data='{"name": "New Name", "username": "old"}',
         content_type="application/json",
     )
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/views.py
@@ -33,7 +33,7 @@ class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         assert self.request.user.is_authenticated  # type guard
         return self.request.user.get_absolute_url()
 
-    def get_object(self, queryset: QuerySet | None=None) -> User:
+    def get_object(self, queryset: QuerySet | None = None) -> User:
         assert self.request.user.is_authenticated  # type guard
         return self.request.user
 


### PR DESCRIPTION
## Description

- Change `use_drf=y/n` option to `rest_api=None/DRF/Django Ninja`
- Update all existing mentions of DRFs to the new style
- Add a few jobs on CI to cover REST API + username field combinations
- Add a similar level of functionality and testing as DRF with Django Ninja

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

While DRF is a solid option, Django Ninja has gained popularity over the years and is the only other option listed in [the ecosystem page](https://www.djangoproject.com/community/ecosystem/).

Fix #4923 