### PR TITLE
keep_local_envs_in_vcs user preference

### DIFF
--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -136,10 +136,8 @@ ci_tool:
     5. `Drone CI`_
 
 keep_local_envs_in_vcs:
-    Indicates whether the project's ``.envs/.local/`` should be kept in VCS
-    (comes in handy when working in teams where local environment reproducibility
-    is strongly encouraged).
-    Note: .env(s) are only utilized when Docker Compose and/or Heroku support is enabled.
+
+Indicates whether the project’s .envs/.local/ should be kept in VCS (comes in handy when working in teams where local environment reproducibility is strongly encouraged).
 
 debug:
     Indicates whether the project should be configured for debugging.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -453,9 +453,6 @@ def main():  # noqa: C901, PLR0912, PLR0915
                 "Heroku support is enabled. Keeping them as requested, but they may not be useful "
                 "in your current setup." + TERMINATOR,
             )
-            append_to_gitignore_file(".env")
-            append_to_gitignore_file(".envs/*")
-            append_to_gitignore_file("!.envs/.local/")
         else:
             remove_envs_and_associated_files()
     else:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Fix bug in environment file cleanup that ignored user preferences. Previously, when users selected `keep_local_envs_in_vcs: "y"` but weren't using Docker or Heroku, the environment files would be deleted anyway despite the user's explicit choice to keep them.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

This fix ensures the cookiecutter template respects user consent by keeping environment files when keep_local_envs_in_vcs: "y" is set, preventing unintended deletion and the user can use the envoirnment files later.
