### PR TITLE
Fixed various broken URLs and typos in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,6 @@ $ tests/test_bare.sh use_celery=y
 
 ## Submitting a pull request
 
-Once you're happy with your changes and they look ok locally, push and send send [a pull request][submit-a-pr] to the main repo, which will trigger the tests on GitHub actions. If they fail, try to fix them. A maintainer should take a look at your change and give you feedback or merge it.
+Once you're happy with your changes and they look ok locally, push and send [a pull request][submit-a-pr] to the main repo, which will trigger the tests on GitHub actions. If they fail, try to fix them. A maintainer should take a look at your change and give you feedback or merge it.
 
 [submit-a-pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -149,7 +149,7 @@ debug:
 .. _MIT: https://opensource.org/licenses/MIT
 .. _BSD: https://opensource.org/licenses/BSD-3-Clause
 .. _GPLv3: https://www.gnu.org/licenses/gpl.html
-.. _Apache Software License 2.0: http://www.apache.org/licenses/LICENSE-2.0
+.. _Apache Software License 2.0: https://www.apache.org/licenses/LICENSE-2.0
 
 .. _PyCharm: https://www.jetbrains.com/pycharm/
 .. _VS Code: https://github.com/microsoft/vscode

--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -18,7 +18,7 @@ Prerequisites
 * Pre-commit; refer to the official documentation for the `pre-commit`_.
 * Cookiecutter; refer to the official GitHub repository of `Cookiecutter`_
 
-.. _`installation instructions`: https://docs.docker.com/install/#supported-platforms
+.. _`installation instructions`: https://docs.docker.com/install/
 .. _`installation guide`: https://docs.docker.com/compose/install/
 .. _`pre-commit`: https://pre-commit.com/#install
 .. _`Cookiecutter`: https://github.com/cookiecutter/cookiecutter

--- a/docs/2-local-development/developing-locally.rst
+++ b/docs/2-local-development/developing-locally.rst
@@ -206,7 +206,7 @@ The project comes with a simple task for manual testing purposes, inside `<proje
 
 You can also use Django admin to queue up tasks, thanks to the `django-celerybeat`_ package.
 
-.. _Getting started with Redis: https://redis.io/docs/getting-started/
+.. _Getting started with Redis: https://redis.io/docs/latest/get-started/
 .. _Celery Workers Guide: https://docs.celeryq.dev/en/stable/userguide/workers.html
 .. _django-celerybeat: https://django-celery-beat.readthedocs.io/en/latest/
 

--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -121,4 +121,4 @@ which run the SASS compilation & JS bundling.
 
 If things don't work, please refer to the Heroku docs.
 
-.. _multiple buildpacks: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app
+.. _multiple buildpacks: https://devcenter.heroku.com/articles/managing-buildpacks

--- a/docs/4-guides/document.rst
+++ b/docs/4-guides/document.rst
@@ -38,7 +38,7 @@ Additionally, you can auto-build Pull Request previews, but `you must enable it`
 
 .. _localhost: http://localhost:9000/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/index.html
-.. _develop locally: ./developing-locally.html
-.. _develop locally with docker: ./developing-locally-docker.html
+.. _develop locally: ../2-local-development/developing-locally.html
+.. _develop locally with docker: ../2-local-development/developing-locally-docker.html
 .. _ReadTheDocs: https://readthedocs.org/
-.. _you must enable it: https://docs.readthedocs.io/en/latest/guides/autobuild-docs-for-pull-requests.html#autobuild-documentation-for-pull-requests
+.. _you must enable it: https://docs.readthedocs.com/platform/latest/pull-requests.html#features

--- a/docs/5-help/faq.rst
+++ b/docs/5-help/faq.rst
@@ -24,4 +24,4 @@ Why doesn't this follow the layout from Two Scoops of Django?
 
 You may notice that some elements of this project do not exactly match what we describe in chapter 3 of `Two Scoops of Django 3.x`_. The reason for that is this project, amongst other things, serves as a test bed for trying out new ideas and concepts. Sometimes they work, sometimes they don't, but the end result is that it won't necessarily match precisely what is described in the book I co-authored.
 
-.. _Two Scoops of Django 3.x: https://www.feldroy.com/two-scoops-press#two-scoops-of-django
+.. _Two Scoops of Django 3.x: https://www.feldroy.com/two-scoops-of-django

--- a/docs/includes/mailgun.rst
+++ b/docs/includes/mailgun.rst
@@ -10,4 +10,4 @@ sandbox subdomain by default. Either add your email to the list of authorized re
 or verify your domain.
 
 
-.. _have emails verifications mandatory: https://django-allauth.readthedocs.io/en/latest/configuration.html?highlight=ACCOUNT_EMAIL_VERIFICATION
+.. _have emails verifications mandatory: https://docs.allauth.org/en/latest/account/configuration.html#email-verification


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description
- Updated Apache License URL to HTTPS
- Fixed Docker installation link  
- Updated Redis getting started URL
- Fixed Heroku buildpacks documentation link
- Corrected internal documentation links
- Updated allauth configuration URL
- Updated Two Scoops of Django book URL
- Fix duplicate word in CONTRIBUTING.md
<!-- What's it you're proposing? -->



Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Testing
- Ran `make linkcheck` in `docs/` directory to identify broken URLs
- All links verified to be working
- Documentation builds successfully with `make livehtml` in `docs/` directory
- 

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
