### PR TITLE
Add PostgreSQL 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     Choose from 1, 2, 3 [1]: 1
     use_docker [n]: n
     Select postgresql_version:
-    1 - 17
-    2 - 16
-    3 - 15
-    4 - 14
+    1 - 18
+    2 - 17
+    3 - 16
+    4 - 15
+    5 - 14
     Choose from 1, 2, 3, 4 [1]: 1
     Select cloud_provider:
     1 - AWS

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,7 +18,7 @@
   "windows": "n",
   "editor": ["None", "PyCharm", "VS Code"],
   "use_docker": "n",
-  "postgresql_version": ["17", "16", "15", "14"],
+  "postgresql_version": ["18", "17", "16", "15", "14"],
   "cloud_provider": ["AWS", "GCP", "Azure", "None"],
   "mail_service": [
     "Mailgun",

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -66,10 +66,11 @@ use_docker:
 postgresql_version:
     Select a PostgreSQL_ version to use. The choices are:
 
-    1. 17
-    2. 16
-    3. 15
-    4. 14
+    1. 18
+    2. 17
+    3. 16
+    4. 15
+    5. 14
 
 cloud_provider:
     Select a cloud provider for static & media files. The choices are:

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -60,6 +60,7 @@ SUPPORTED_COMBINATIONS = [
     {"editor": "VS Code"},
     {"use_docker": "y"},
     {"use_docker": "n"},
+    {"postgresql_version": "18"},
     {"postgresql_version": "17"},
     {"postgresql_version": "16"},
     {"postgresql_version": "15"},

--- a/{{cookiecutter.project_slug}}/docker-compose.local.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.local.yml
@@ -35,7 +35,11 @@ services:
     image: {{ cookiecutter.project_slug }}_production_postgres
     container_name: {{ cookiecutter.project_slug }}_local_postgres
     volumes:
+      {%- if cookiecutter.postgresql_version|int >= 18 %}
+      - {{ cookiecutter.project_slug }}_local_postgres_data:/var/lib/postgresql/{{ cookiecutter.postgresql_version }}/docker
+      {%- else %}
       - {{ cookiecutter.project_slug }}_local_postgres_data:/var/lib/postgresql/data
+      {%- endif %}
       - {{ cookiecutter.project_slug }}_local_postgres_data_backups:/backups
     env_file:
       - ./.envs/.local/.postgres

--- a/{{cookiecutter.project_slug}}/docker-compose.production.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.production.yml
@@ -47,7 +47,11 @@ services:
       dockerfile: ./compose/production/postgres/Dockerfile
     image: {{ cookiecutter.project_slug }}_production_postgres
     volumes:
+      {%- if cookiecutter.postgresql_version|int >= 18 %}
+      - production_postgres_data:/var/lib/postgresql/{{ cookiecutter.postgresql_version }}/docker
+      {%- else %}
       - production_postgres_data:/var/lib/postgresql/data
+      {%- endif %}
       - production_postgres_data_backups:/backups
     env_file:
       - ./.envs/.production/.postgres


### PR DESCRIPTION
## Description

Adds PostgreSQL 18.

**Note:** `PGDATA` was changed to `/var/lib/postgresql/MAJOR/docker`, see https://github.com/docker-library/postgres/pull/1259.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

I added support for [PostgreSQL 18](https://www.postgresql.org/about/news/postgresql-18-released-3142/) to leverage its major performance improvements and operational enhancements. The new asynchronous I/O subsystem and faster major-version upgrades reduce maintenance overhead, while features like virtual generated columns, native `uuidv7()` support, improved indexing and expanded observability focus on performance, maintainability and long-term platform stability.

## Verification

**Docker Compose:**

```
$ cat docker-compose.production.yml
# Skipped for brevity

  postgres:
    build:
      context: .
      dockerfile: ./compose/production/postgres/Dockerfile
    image: my_awesome_project_production_postgres
    volumes:
      - production_postgres_data:/var/lib/postgresql/18/docker
      - production_postgres_data_backups:/backups
    env_file:
      - ./.envs/.production/.postgres
```

```
$ cat docker-compose.local.yml
# Skipped for brevity

  postgres:
    build:
      context: .
      dockerfile: ./compose/production/postgres/Dockerfile
    image: my_awesome_project_production_postgres
    container_name: my_awesome_project_local_postgres
    volumes:
      - my_awesome_project_local_postgres_data:/var/lib/postgresql/18/docker
      - my_awesome_project_local_postgres_data_backups:/backups
    env_file:
      - ./.envs/.local/.postgres
```

**Docker Compose output:**

```
my_awesome_project_local_postgres      | The files belonging to this database system will be owned by user "postgres".
my_awesome_project_local_postgres      | This user must also own the server process.
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | The database cluster will be initialized with locale "en_US.utf8".
my_awesome_project_local_postgres      | The default database encoding has accordingly been set to "UTF8".
my_awesome_project_local_postgres      | The default text search configuration will be set to "english".
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | Data page checksums are enabled.
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | fixing permissions on existing directory /var/lib/postgresql/18/docker ... ok
my_awesome_project_local_postgres      | creating subdirectories ... ok
my_awesome_project_local_postgres      | selecting dynamic shared memory implementation ... posix
my_awesome_project_local_postgres      | selecting default "max_connections" ... 100
my_awesome_project_local_postgres      | selecting default "shared_buffers" ... 128MB
my_awesome_project_local_postgres      | selecting default time zone ... Etc/UTC
my_awesome_project_local_postgres      | creating configuration files ... ok
my_awesome_project_local_postgres      | running bootstrap script ... ok
my_awesome_project_local_postgres      | performing post-bootstrap initialization ... ok
my_awesome_project_local_postgres      | syncing data to disk ... ok
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | Success. You can now start the database server using:
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      |     pg_ctl -D /var/lib/postgresql/18/docker -l logfile start
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | initdb: warning: enabling "trust" authentication for local connections
my_awesome_project_local_postgres      | initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
my_awesome_project_local_postgres      | waiting for server to start....2025-10-26 10:10:03.226 UTC [51] LOG:  starting PostgreSQL 18.0 (Debian 18.0-1.pgdg13+3) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.227 UTC [51] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.231 UTC [57] LOG:  database system was shut down at 2025-10-26 10:10:03 UTC
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.232 UTC [51] LOG:  database system is ready to accept connections
my_awesome_project_local_postgres      |  done
my_awesome_project_local_postgres      | server started
my_awesome_project_local_postgres      | CREATE DATABASE
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | waiting for server to shut down....2025-10-26 10:10:03.426 UTC [51] LOG:  received fast shutdown request
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.436 UTC [51] LOG:  aborting any active transactions
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.438 UTC [51] LOG:  background worker "logical replication launcher" (PID 60) exited with exit code 1
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.438 UTC [55] LOG:  shutting down
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.439 UTC [55] LOG:  checkpoint starting: shutdown immediate
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.471 UTC [55] LOG:  checkpoint complete: wrote 943 buffers (5.8%), wrote 3 SLRU buffers; 0 WAL file(s) added, 0 removed, 0 recycled; write=0.008 s, sync=0.023 s, total=0.034 s; sync files=303, longest=0.006 s, average=0.001 s; distance=4352 kB, estimate=4352 kB; lsn=0/1B9FBD8, redo lsn=0/1B9FBD8
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.476 UTC [51] LOG:  database system is shut down
my_awesome_project_local_postgres      |  done
my_awesome_project_local_postgres      | server stopped
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | PostgreSQL init process complete; ready for start up.
my_awesome_project_local_postgres      |
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.542 UTC [1] LOG:  starting PostgreSQL 18.0 (Debian 18.0-1.pgdg13+3) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.542 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.542 UTC [1] LOG:  listening on IPv6 address "::", port 5432
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.543 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.546 UTC [73] LOG:  database system was shut down at 2025-10-26 10:10:03 UTC
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.547 UTC [1] LOG:  database system is ready to accept connections
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.646 UTC [77] LOG:  incomplete startup packet
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.646 UTC [78] LOG:  incomplete startup packet
my_awesome_project_local_celerybeat    | wait-for-it: postgres:5432 is available after 1 seconds
my_awesome_project_local_celerybeat    | PostgreSQL is available
my_awesome_project_local_celeryworker  | wait-for-it: postgres:5432 is available after 1 seconds
my_awesome_project_local_django        | wait-for-it: postgres:5432 is available after 1 seconds
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.650 UTC [79] LOG:  incomplete startup packet
my_awesome_project_local_celeryworker  | PostgreSQL is available
my_awesome_project_local_django        | PostgreSQL is available
my_awesome_project_local_postgres      | 2025-10-26 10:10:03.666 UTC [80] LOG:  incomplete startup packet
my_awesome_project_local_flower        | wait-for-it: postgres:5432 is available after 1 seconds
my_awesome_project_local_flower        | PostgreSQL is available
```

**Tests:**
```
$ docker compose -f docker-compose.local.yml run --rm django pytest
[+] Creating 4/4
 ✔ Network my_awesome_project_default           Created                                                                                                                                   0.0s
 ✔ Container my_awesome_project_local_mailpit   Created                                                                                                                                   0.1s
 ✔ Container my_awesome_project_local_redis     Created                                                                                                                                   0.0s
 ✔ Container my_awesome_project_local_postgres  Created                                                                                                                                   0.1s
[+] Running 3/3
 ✔ Container my_awesome_project_local_redis     Started                                                                                                                                   0.2s
 ✔ Container my_awesome_project_local_mailpit   Started                                                                                                                                   0.2s
 ✔ Container my_awesome_project_local_postgres  Started                                                                                                                                   0.2s
wait-for-it: waiting 30 seconds for postgres:5432
wait-for-it: postgres:5432 is available after 0 seconds
PostgreSQL is available
Test session starts (platform: linux, Python 3.13.9, pytest 8.4.2, pytest-sugar 1.1.1)
django: version: 5.2.7, settings: config.settings.test (from option)
rootdir: /app
configfile: pyproject.toml
plugins: sugar-1.1.1, anyio-4.11.0, Faker-37.12.0, django-4.11.1
collected 27 items

 my_awesome_project/users/tests/test_admin.py ✓✓✓✓✓                                                                                                                              19% █▉
 my_awesome_project/users/tests/test_forms.py ✓                                                                                                                                  22% ██▎
 my_awesome_project/users/tests/test_managers.py ✓✓✓✓                                                                                                                            37% ███▊
 my_awesome_project/users/tests/test_models.py ✓                                                                                                                                 41% ████▏
 my_awesome_project/users/tests/test_tasks.py ✓                                                                                                                                  44% ████▌
 my_awesome_project/users/tests/test_urls.py ✓✓✓                                                                                                                                 78% ███████▊
 my_awesome_project/users/tests/test_views.py ✓✓✓✓✓✓                                                                                                                             70% ███████▏
 tests/test_merge_production_dotenvs_in_dotenv.py ✓✓✓✓✓✓                                                                                                                        100% ██████████

Results (0.96s):
      27 passed
```