### PR TITLE
Add optional args to "just build"

### DIFF
--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -1,7 +1,7 @@
 export COMPOSE_FILE := "docker-compose.local.yml"
 
 ## Just does not yet manage signals for subprocesses reliably, which can lead to unexpected behavior.
-## Exercise caution before expanding its usage in production environments. 
+## Exercise caution before expanding its usage in production environments.
 ## For more information, see https://github.com/casey/just/issues/2473 .
 
 
@@ -10,9 +10,9 @@ default:
     @just --list
 
 # build: Build python image.
-build:
+build *args:
     @echo "Building python image..."
-    @docker compose build
+    @docker compose build {{ "{{args}}" }}
 
 # up: Start up containers.
 up:


### PR DESCRIPTION
## Description

Added optional arguments to `just build` making it possible to run `just build --no-cache`, i.e. calling `docker compose build` with any possible options.
