### PR TITLE
Add docker buildkit flag

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,11 +1,11 @@
 # ruff: noqa: PLR0133
 import json
+import os
 import random
 import shutil
 import string
 import subprocess
 import sys
-import os
 from pathlib import Path
 
 try:


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Improving docker build error message when `docker-buildx` is missing by enabling `DOCKER_BUILDKIT` flag:

- Before the change
```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

unknown flag: --load

Usage:  docker build [OPTIONS] PATH | URL | -

Run 'docker build --help' for more information
Error building Docker image: Command '['docker', 'build', '--load', '-t', 'cookiecutter-django-
```

- After the change
```
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
Error building Docker image: Command '['docker', 'build', '--load', '-t', 'cookiecutter-django-
```

<!-- What's it you're proposing? -->

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

The pre-change error message doesn't explicitly point to the cause (`docker-buildx` not installed) 

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->

Thanks for the awesome template!
