### PR TITLE
Fix CI failure when Docker is enabled but keep_local_envs_in_vcs is disabled

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.docs.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.docs.yml
@@ -6,7 +6,8 @@ services:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile
     env_file:
-      - ./.envs/.local/.django
+      - path: ./.envs/.local/.django
+        required: false
     volumes:
       - /app/.venv
       - ./docs:/docs:z

--- a/{{cookiecutter.project_slug}}/docker-compose.local.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.local.yml
@@ -22,8 +22,10 @@ services:
       - /app/.venv
       - .:/app:z
     env_file:
-      - ./.envs/.local/.django
-      - ./.envs/.local/.postgres
+      - path: ./.envs/.local/.django
+        required: false
+      - path: ./.envs/.local/.postgres
+        required: false
     ports:
       - '8000:8000'
     command: /start
@@ -42,7 +44,8 @@ services:
       {%- endif %}
       - {{ cookiecutter.project_slug }}_local_postgres_data_backups:/backups
     env_file:
-      - ./.envs/.local/.postgres
+      - path: ./.envs/.local/.postgres
+        required: false
 
   {%- if cookiecutter.use_mailpit == 'y' %}
 


### PR DESCRIPTION
#Summary

Use Docker Compose 'required: false' option for env_file entries to make environment files optional. This allows CI to run successfully when env files are not committed to version control, while still using them when present for local development.

Fix #5319

## Description

Use Docker Compose `required: false` option for `env_file` entries to make environment files optional.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

When `keep_local_envs_in_vcs` is set to `n`, the `.envs/.local/` files are gitignored and not committed to version control. However, Docker Compose fails in CI when it cannot find the referenced env files.

This fix uses Docker Compose's `required: false` option (available since v2.24.0) to make the env files optional:

- ✅ Local development works (env files used when present)
- ✅ CI passes (missing files are ignored)
- ✅ No breaking changes to existing behavior
