### PR TITLE
Use correct hostname for postgres in docker envs

### DIFF
--- a/{{cookiecutter.project_slug}}/.envs/.local/.postgres
+++ b/{{cookiecutter.project_slug}}/.envs/.local/.postgres
@@ -1,6 +1,6 @@
 # PostgreSQL
 # ------------------------------------------------------------------------------
-POSTGRES_HOST=postgres
+POSTGRES_HOST={{ cookiecutter.project_slug }}_local_postgres
 POSTGRES_PORT=5432
 POSTGRES_DB={{ cookiecutter.project_slug }}
 POSTGRES_USER=!!!SET POSTGRES_USER!!!


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

Closes #6234

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fresh Docker install uses the incorrect value on `POSTGRES_HOST`