### PR TITLE
Switch Dependabot to uv ecosystem

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -62,7 +62,7 @@ updates:
 
 {%- endif %}
 
-  # Enable version updates for Python/uv - Production
+  # Enable version updates for Python/uv
   - package-ecosystem: 'uv'
     # Look for a `pyproject.toml` in the `root` directory
     directory: '/'


### PR DESCRIPTION
## Description

Previously, Dependabot updated only the `pyproject.toml` file without updating the lockfile. This resulted in an outdated `uv.lock` and failed builds. Users then had to run `uv lock` or `docker compose -f docker-compose.local.yml run --rm django uv lock`.

More context:

- [Using uv with dependency bots](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependabot)

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates
