### PR TITLE
Remove silent `ImportError` suppression in `UsersConfig.ready()`

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/apps.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/apps.py
@@ -1,5 +1,3 @@
-import contextlib
-
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
@@ -9,5 +7,6 @@ class UsersConfig(AppConfig):
     verbose_name = _("Users")
 
     def ready(self):
-        with contextlib.suppress(ImportError):
-            import {{ cookiecutter.project_slug }}.users.signals  # noqa: F401, PLC0415
+        """
+        Override this method in subclasses to run code when Django starts.
+        """


### PR DESCRIPTION

## Description

This PR removes the use of contextlib.suppress(ImportError) around the signals import in UsersConfig.ready().
See issue: https://github.com/cookiecutter/cookiecutter-django/issues/6259

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

Fix #6259

