### PR TITLE
Update dependabot.yml to remove Django 6.0 ignore rule

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -69,11 +69,6 @@ updates:
     # Every weekday
     schedule:
       interval: 'daily'
-    ignore:
-      # Django 6.0 not yet supported by django-celery-beat
-      # Remove after https://github.com/cookiecutter/cookiecutter-django/pull/6233
-      - dependency-name: 'django'
-        versions: [ '6' ]
     groups:
       python:
         update-types:


### PR DESCRIPTION
## Description

`django-celery-beat` now supports Django 6, see https://github.com/celery/django-celery-beat/releases/tag/v2.9.0.

Checklist:

- [X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [X] I've updated the documentation or confirm that my change doesn't require any updates
