### PR TITLE
Upgrade factory-boy to 3.3.3 and fix mypy compatibility

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -33,7 +33,7 @@ pre-commit==4.5.1  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==3.3.2  # https://github.com/FactoryBoy/factory_boy
+factory-boy==3.3.3  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==6.2.0  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==4.1  # https://github.com/django-extensions/django-extensions

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/conftest.py
@@ -11,4 +11,4 @@ def _media_storage(settings, tmpdir) -> None:
 
 @pytest.fixture
 def user(db) -> User:
-    return UserFactory()
+    return UserFactory.create()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/api/test_views.py
@@ -53,7 +53,7 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def user():
-    return UserFactory()
+    return UserFactory.create()
 
 
 def test_list_users_as_anonymous_user(client: Client):
@@ -65,7 +65,7 @@ def test_list_users_as_anonymous_user(client: Client):
 def test_list_users_as_authenticated_user(client: Client, user: User):
     client.force_login(user)
     # Another user, excluded from the response
-    UserFactory()
+    UserFactory.create()
 
     response = client.get(reverse("api:list_users"))
 
@@ -151,7 +151,7 @@ def test_retrieve_user(client: Client, user: User):
 
 def test_retrieve_another_user(client: Client, user: User):
     client.force_login(user)
-    user_2 = UserFactory()
+    user_2 = UserFactory.create()
 
     response = client.get(
         {%- if cookiecutter.username_type == "email" %}
@@ -166,7 +166,7 @@ def test_retrieve_another_user(client: Client, user: User):
 
 
 def test_update_current_user(client: Client):
-    user = UserFactory(name="Old")
+    user = UserFactory.create(name="Old")
     client.force_login(user)
 
     response = client.patch(
@@ -196,7 +196,7 @@ def test_update_current_user(client: Client):
 
 
 def test_update_user(client: Client):
-    user = UserFactory(name="Old")
+    user = UserFactory.create(name="Old")
     client.force_login(user)
 
     response = client.patch(
@@ -215,7 +215,7 @@ def test_update_user(client: Client):
 
 
 def test_update_user(client: Client):
-    user = UserFactory(name="Old", username="old")
+    user = UserFactory.create(name="Old", username="old")
     client.force_login(user)
 
     response = client.patch(

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/factories.py
@@ -1,5 +1,4 @@
-from collections.abc import Sequence
-from typing import Any
+from __future__ import annotations
 
 from factory import Faker
 from factory import post_generation
@@ -16,7 +15,7 @@ class UserFactory(DjangoModelFactory[User]):
     name = Faker("name")
 
     @post_generation
-    def password(self, create: bool, extracted: Sequence[Any], **kwargs):  # noqa: FBT001
+    def password(self: User, create: bool, extracted: str | None, **kwargs):  # noqa: FBT001
         password = (
             extracted
             if extracted
@@ -30,14 +29,10 @@ class UserFactory(DjangoModelFactory[User]):
             ).evaluate(None, None, extra={"locale": None})
         )
         self.set_password(password)
-
-    @classmethod
-    def _after_postgeneration(cls, instance, create, results=None):
-        """Save again the instance if creating and at least one hook ran."""
-        if create and results and not cls._meta.skip_postgeneration_save:
-            # Some post-generation hooks ran, and may have modified us.
-            instance.save()
+        if create:
+            self.save()
 
     class Meta:
         model = User
         django_get_or_create = ["{{cookiecutter.username_type}}"]
+        skip_postgeneration_save = True

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/tests/test_views.py
@@ -95,7 +95,7 @@ class TestUserRedirectView:
 class TestUserDetailView:
     def test_authenticated(self, user: User, rf: RequestFactory):
         request = rf.get("/fake-url/")
-        request.user = UserFactory()
+        request.user = UserFactory.create()
 
         {%- if cookiecutter.username_type == "email" %}
         response = user_detail_view(request, pk=user.pk)


### PR DESCRIPTION
## Description

Fix mypy compatibility with factory-boy 3.3.3 type stubs.

factory-boy 3.3.3 added a `py.typed` marker (PEP 561), causing mypy to start using its bundled type stubs. This broke `UserFactory` with errors like `"UserFactory" has no attribute "set_password"`.

- Bump factory-boy 3.3.2 -> 3.3.3
- Annotate `self: User` on `@post_generation` method so mypy resolves User attributes correctly
- Replace `_after_postgeneration` override with `skip_postgeneration_save = True` in Meta, saving explicitly in the password hook when creating
- Use `UserFactory.create()` instead of `UserFactory()` for proper return type inference (`-> T` instead of `Self`)

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

factory-boy 3.3.3 exports type annotations via PEP 561, which breaks mypy on the generated project's `UserFactory`. Verified locally:

- `uv run mypy .` passes on generated project (only pre-existing `ANYMAIL` annotation issue in `production.py`)
- `reveal_type(UserFactory.create())` returns `User`; `reveal_type(UserFactory())` returns `UserFactory` — confirms `.create()` is needed
- Upstream `test_ruff_check_passes` — 85/86 passed (1 failure is missing Docker in my environment, unrelated)

Ref: https://github.com/FactoryBoy/factory_boy/issues/1113