### PR TITLE
Remove hardcoded Python versions from GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -22,19 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Autoupdate template
-        run: pre-commit autoupdate
+        run: uv tool run pre-commit autoupdate
 
       - name: Autoupdate generated projects
         working-directory: "{{cookiecutter.project_slug}}"
-        run: pre-commit autoupdate
+        run: uv tool run pre-commit autoupdate
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Description

I noticed that they were changed in https://github.com/cookiecutter/cookiecutter-django/pull/6412 

Replacing `actions/setup-python` by `astral-sh/setup-uv` which derives them from `pyproject.toml`

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
