### PR TITLE
Remove hardcoded node versions from GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,6 @@ jobs:
         run: uv sync --locked
       - uses: actions/setup-node@v6
         with:
-          node-version: "24.14"
+          node-version-file: "{{cookiecutter.project_slug}}/package.json"
       - name: Bare Metal ${{ matrix.script.name }}
         run: sh tests/test_bare.sh ${{ matrix.script.args }}

--- a/scripts/node_version.py
+++ b/scripts/node_version.py
@@ -8,7 +8,6 @@ TEMPLATED_ROOT = ROOT / "{{cookiecutter.project_slug}}"
 DOCKERFILE = TEMPLATED_ROOT / "compose" / "local" / "node" / "Dockerfile"
 PROD_DOCKERFILE = TEMPLATED_ROOT / "compose" / "production" / "django" / "Dockerfile"
 PACKAGE_JSON = TEMPLATED_ROOT / "package.json"
-CI_YML = ROOT / ".github" / "workflows" / "ci.yml"
 
 
 def main() -> None:
@@ -16,7 +15,6 @@ def main() -> None:
     old_version = get_version_from_package_json()
     if old_version != new_version:
         update_package_json_version(old_version, new_version)
-        update_ci_node_version(old_version, new_version)
         update_production_node_version(old_version, new_version)
 
 
@@ -45,15 +43,6 @@ def update_package_json_version(old_version: str, new_version: str) -> None:
         f'"node": "{new_version}"',
     )
     PACKAGE_JSON.write_text(package_json_text)
-
-
-def update_ci_node_version(old_version: str, new_version: str) -> None:
-    yml_content = CI_YML.read_text()
-    yml_content = yml_content.replace(
-        f'node-version: "{old_version}"',
-        f'node-version: "{new_version}"',
-    )
-    CI_YML.write_text(yml_content)
 
 
 def update_production_node_version(old_version: str, new_version: str) -> None:


### PR DESCRIPTION
## Description

Similar to https://github.com/cookiecutter/cookiecutter-django/pull/6429 but for node version

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Less duplication and align version script will now work. It had issues to push changes to workflow files, GitHub doesn't allow it for the default `GITHUB_TOKEN`