### PR TITLE
这是一个 现代化 Django 项目生成器模板 ，基于 Cookiecutter 构建，可以一键生成生产级别的 Django 项目脚手架。

### DIFF
--- a/hooks/core.py
+++ b/hooks/core.py
@@ -6,12 +6,15 @@ import shutil
 import string
 import subprocess
 import sys
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from dataclasses import field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 try:
     random = random.SystemRandom()
@@ -58,10 +61,7 @@ class AuditLog:
         total = len(self.entries)
         successful = sum(1 for e in self.entries if e.success)
         failed = sum(1 for e in self.entries if not e.success)
-        by_type = {
-            op_type: sum(1 for e in self.entries if e.operation_type == op_type)
-            for op_type in OperationType
-        }
+        by_type = {op_type: sum(1 for e in self.entries if e.operation_type == op_type) for op_type in OperationType}
         return {
             "summary": {
                 "total_operations": total,

--- a/hooks/core.py
+++ b/hooks/core.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+import random
+import shutil
+import string
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    random = random.SystemRandom()
+    using_sysrandom = True
+except NotImplementedError:
+    using_sysrandom = False
+
+DEBUG_VALUE = "debug"
+
+
+class OperationType(Enum):
+    DELETE_FILE = "delete_file"
+    DELETE_DIR = "delete_dir"
+    MODIFY_FILE = "modify_file"
+    APPEND_FILE = "append_file"
+    RUN_COMMAND = "run_command"
+    SET_FLAG = "set_flag"
+
+
+class FailureStrategy(Enum):
+    ABORT = "abort"
+    CONTINUE = "continue"
+    ROLLBACK = "rollback"
+
+
+@dataclass
+class AuditEntry:
+    operation_type: OperationType
+    target: str
+    timestamp: datetime = field(default_factory=datetime.now)
+    success: bool = False
+    error: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class AuditLog:
+    def __init__(self) -> None:
+        self.entries: list[AuditEntry] = []
+
+    def record(self, entry: AuditEntry) -> None:
+        self.entries.append(entry)
+
+    def generate_report(self) -> dict[str, Any]:
+        total = len(self.entries)
+        successful = sum(1 for e in self.entries if e.success)
+        failed = sum(1 for e in self.entries if not e.success)
+        by_type = {
+            op_type: sum(1 for e in self.entries if e.operation_type == op_type)
+            for op_type in OperationType
+        }
+        return {
+            "summary": {
+                "total_operations": total,
+                "successful": successful,
+                "failed": failed,
+            },
+            "operations_by_type": {k.value: v for k, v in by_type.items() if v > 0},
+            "entries": [
+                {
+                    "type": e.operation_type.value,
+                    "target": e.target,
+                    "timestamp": e.timestamp.isoformat(),
+                    "success": e.success,
+                    "error": e.error,
+                    "details": e.details,
+                }
+                for e in self.entries
+            ],
+        }
+
+    def print_report(self) -> None:
+        report = self.generate_report()
+        print("\n" + "=" * 60)
+        print("GENERATION AUDIT REPORT")
+        print("=" * 60)
+        print(f"Total operations: {report['summary']['total_operations']}")
+        print(f"Successful: {report['summary']['successful']}")
+        print(f"Failed: {report['summary']['failed']}")
+        print("\nOperations by type:")
+        for op_type, count in report["operations_by_type"].items():
+            print(f"  - {op_type}: {count}")
+        print("=" * 60 + "\n")
+
+
+class Operation(ABC):
+    def __init__(self, operation_type: OperationType, target: str) -> None:
+        self.operation_type = operation_type
+        self.target = target
+        self.executed = False
+        self.backup_data: Any = None
+
+    @abstractmethod
+    def _execute(self) -> None: ...
+
+    @abstractmethod
+    def _rollback(self) -> None: ...
+
+    def execute(self, audit_log: AuditLog) -> None:
+        entry = AuditEntry(operation_type=self.operation_type, target=self.target)
+        try:
+            self._execute()
+            self.executed = True
+            entry.success = True
+        except Exception as e:
+            entry.success = False
+            entry.error = str(e)
+            raise
+        finally:
+            audit_log.record(entry)
+
+    def rollback(self, audit_log: AuditLog) -> None:
+        if not self.executed:
+            return
+        entry = AuditEntry(
+            operation_type=self.operation_type,
+            target=f"ROLLBACK: {self.target}",
+            details={"original_operation": self.target},
+        )
+        try:
+            self._rollback()
+            entry.success = True
+        except Exception as e:
+            entry.success = False
+            entry.error = str(e)
+            raise
+        finally:
+            audit_log.record(entry)
+
+
+class DeleteFileOperation(Operation):
+    def __init__(self, file_path: Path | str) -> None:
+        super().__init__(OperationType.DELETE_FILE, str(file_path))
+        self.file_path = Path(file_path)
+        self.backup_content: bytes | None = None
+
+    def _execute(self) -> None:
+        if self.file_path.exists():
+            self.backup_content = self.file_path.read_bytes()
+            self.file_path.unlink()
+
+    def _rollback(self) -> None:
+        if self.backup_content is not None:
+            self.file_path.parent.mkdir(parents=True, exist_ok=True)
+            self.file_path.write_bytes(self.backup_content)
+
+
+class DeleteDirOperation(Operation):
+    def __init__(self, dir_path: Path | str) -> None:
+        super().__init__(OperationType.DELETE_DIR, str(dir_path))
+        self.dir_path = Path(dir_path)
+        self.backup_archive: Path | None = None
+
+    def _execute(self) -> None:
+        if self.dir_path.exists():
+            backup_base = self.dir_path.parent / f".backup_{self.dir_path.name}"
+            self.backup_archive = Path(shutil.make_archive(str(backup_base), "zip", self.dir_path))
+            shutil.rmtree(self.dir_path)
+
+    def _rollback(self) -> None:
+        if self.backup_archive and self.backup_archive.exists():
+            self.dir_path.mkdir(parents=True, exist_ok=True)
+            shutil.unpack_archive(str(self.backup_archive), self.dir_path)
+            self.backup_archive.unlink()
+
+
+class ModifyFileOperation(Operation):
+    def __init__(
+        self,
+        file_path: Path | str,
+        modifier: Callable[[str], str],
+    ) -> None:
+        super().__init__(OperationType.MODIFY_FILE, str(file_path))
+        self.file_path = Path(file_path)
+        self.modifier = modifier
+        self.backup_content: bytes | None = None
+
+    def _execute(self) -> None:
+        self.backup_content = self.file_path.read_bytes()
+        content = self.file_path.read_text()
+        new_content = self.modifier(content)
+        self.file_path.write_text(new_content)
+
+    def _rollback(self) -> None:
+        if self.backup_content is not None:
+            self.file_path.write_bytes(self.backup_content)
+
+
+class AppendFileOperation(Operation):
+    def __init__(self, file_path: Path | str, content: str) -> None:
+        super().__init__(OperationType.APPEND_FILE, str(file_path))
+        self.file_path = Path(file_path)
+        self.content = content
+        self.original_size: int = 0
+
+    def _execute(self) -> None:
+        self.original_size = self.file_path.stat().st_size if self.file_path.exists() else 0
+        with self.file_path.open("a") as f:
+            f.write(self.content + "\n")
+
+    def _rollback(self) -> None:
+        if self.file_path.exists():
+            with self.file_path.open("r+b") as f:
+                f.truncate(self.original_size)
+
+
+class RunCommandOperation(Operation):
+    def __init__(self, cmd: list[str], **kwargs: Any) -> None:
+        super().__init__(OperationType.RUN_COMMAND, " ".join(cmd))
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.details: dict[str, Any] = {}
+
+    def _execute(self) -> None:
+        result = subprocess.run(
+            self.cmd,
+            capture_output=True,
+            check=True,
+            **self.kwargs,
+        )
+        self.details = {
+            "returncode": result.returncode,
+            "stdout": result.stdout.decode()[:500],
+            "stderr": result.stderr.decode()[:500],
+        }
+
+    def _rollback(self) -> None:
+        pass
+
+
+class SetFlagOperation(Operation):
+    def __init__(self, file_path: Path | str, flag: str, value: str) -> None:
+        super().__init__(OperationType.SET_FLAG, str(file_path))
+        self.file_path = Path(file_path)
+        self.flag = flag
+        self.value = value
+        self.backup_content: bytes | None = None
+
+    def _execute(self) -> None:
+        self.backup_content = self.file_path.read_bytes()
+        content = self.file_path.read_text()
+        content = content.replace(self.flag, self.value)
+        self.file_path.write_text(content)
+
+    def _rollback(self) -> None:
+        if self.backup_content is not None:
+            self.file_path.write_bytes(self.backup_content)
+
+
+class Executor(ABC):
+    @abstractmethod
+    def execute(self, operation: Operation, audit_log: AuditLog) -> None: ...
+
+
+class RealExecutor(Executor):
+    def execute(self, operation: Operation, audit_log: AuditLog) -> None:
+        operation.execute(audit_log)
+
+
+class DryRunExecutor(Executor):
+    def execute(self, operation: Operation, audit_log: AuditLog) -> None:
+        entry = AuditEntry(
+            operation_type=operation.operation_type,
+            target=operation.target,
+            details={"dry_run": True},
+        )
+        entry.success = True
+        audit_log.record(entry)
+        print(f"[DRY RUN] Would {operation.operation_type.value}: {operation.target}")
+
+
+class LogOnlyExecutor(Executor):
+    def execute(self, operation: Operation, audit_log: AuditLog) -> None:
+        entry = AuditEntry(
+            operation_type=operation.operation_type,
+            target=operation.target,
+            details={"log_only": True},
+        )
+        entry.success = True
+        audit_log.record(entry)
+
+
+class RollbackManager:
+    def __init__(self, audit_log: AuditLog) -> None:
+        self.audit_log = audit_log
+        self.executed_operations: list[Operation] = []
+
+    def register_executed(self, operation: Operation) -> None:
+        if operation.executed:
+            self.executed_operations.append(operation)
+
+    def rollback_all(self) -> None:
+        print("\n" + "!" * 60)
+        print("ROLLING BACK ALL OPERATIONS")
+        print("!" * 60)
+        for operation in reversed(self.executed_operations):
+            try:
+                operation.rollback(self.audit_log)
+                print(f"  Rolled back: {operation.target}")
+            except Exception as e:
+                print(f"  Failed to rollback {operation.target}: {e}")
+        print("Rollback complete\n")
+
+
+class ExecutionContext:
+    def __init__(
+        self,
+        executor: Executor | None = None,
+        failure_strategy: FailureStrategy = FailureStrategy.ROLLBACK,
+        dry_run: bool = False,
+    ) -> None:
+        self.audit_log = AuditLog()
+        self.rollback_manager = RollbackManager(self.audit_log)
+        self.executor = executor or (DryRunExecutor() if dry_run else RealExecutor())
+        self.failure_strategy = failure_strategy
+        self.operations: list[Operation] = []
+        self.checkpoint_index = 0
+
+    def add_operation(self, operation: Operation) -> None:
+        self.operations.append(operation)
+
+    def checkpoint(self) -> None:
+        self.checkpoint_index = len(self.operations)
+
+    def execute_all(self) -> None:
+        for i, operation in enumerate(self.operations):
+            try:
+                self.executor.execute(operation, self.audit_log)
+                self.rollback_manager.register_executed(operation)
+            except Exception as e:
+                print(f"Error executing operation {operation.target}: {e}", file=sys.stderr)
+                match self.failure_strategy:
+                    case FailureStrategy.ABORT:
+                        print("Aborting execution due to failure", file=sys.stderr)
+                        raise
+                    case FailureStrategy.CONTINUE:
+                        print("Continuing despite failure...", file=sys.stderr)
+                        continue
+                    case FailureStrategy.ROLLBACK:
+                        self.rollback_manager.rollback_all()
+                        raise
+        self.checkpoint()
+
+    def resume_from_checkpoint(self) -> None:
+        for operation in self.operations[self.checkpoint_index :]:
+            try:
+                self.executor.execute(operation, self.audit_log)
+                self.rollback_manager.register_executed(operation)
+            except Exception as e:
+                print(f"Error: {e}", file=sys.stderr)
+                match self.failure_strategy:
+                    case FailureStrategy.ROLLBACK:
+                        self.rollback_manager.rollback_all()
+                        raise
+                    case FailureStrategy.ABORT:
+                        raise
+                    case FailureStrategy.CONTINUE:
+                        continue
+
+    def get_report(self) -> dict[str, Any]:
+        return self.audit_log.generate_report()
+
+    def print_report(self) -> None:
+        self.audit_log.print_report()
+
+
+class Strategy(ABC):
+    @abstractmethod
+    def should_apply(self, context: dict[str, Any]) -> bool: ...
+
+    @abstractmethod
+    def collect_operations(self, context: dict[str, Any]) -> list[Operation]: ...
+
+
+def update_package_json_modifier(
+    remove_dev_deps: list[str] | None = None,
+    remove_keys: list[str] | None = None,
+    scripts: dict[str, str] | None = None,
+) -> Callable[[str], str]:
+    remove_dev_deps = remove_dev_deps or []
+    remove_keys = remove_keys or []
+    scripts = scripts or {}
+
+    def modifier(content: str) -> str:
+        data = json.loads(content)
+        for package_name in remove_dev_deps:
+            data["devDependencies"].pop(package_name, None)
+        for key in remove_keys:
+            data.pop(key, None)
+        data["scripts"].update(scripts)
+        return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+
+    return modifier
+
+
+def remove_repo_from_pre_commit_modifier(repo_to_remove: str) -> Callable[[str], str]:
+    def modifier(content: str) -> str:
+        lines = content.splitlines(keepends=True)
+        removing = False
+        new_lines = []
+        for line in lines:
+            if removing and "- repo:" in line:
+                removing = False
+            if repo_to_remove in line:
+                removing = True
+            if not removing:
+                new_lines.append(line)
+        return "".join(new_lines)
+
+    return modifier
+
+
+def generate_random_string(
+    length: int,
+    using_digits: bool = False,
+    using_ascii_letters: bool = False,
+    using_punctuation: bool = False,
+) -> str | None:
+    if not using_sysrandom:
+        return None
+
+    symbols = []
+    if using_digits:
+        symbols += string.digits
+    if using_ascii_letters:
+        symbols += string.ascii_letters
+    if using_punctuation:
+        all_punctuation = set(string.punctuation)
+        unsuitable = {"'", '"', "\\", "$"}
+        suitable = all_punctuation.difference(unsuitable)
+        symbols += "".join(suitable)
+    return "".join([random.choice(symbols) for _ in range(length)])
+
+
+def generate_random_user() -> str:
+    result = generate_random_string(length=32, using_ascii_letters=True)
+    assert result is not None
+    return result
+
+
+TERMINATOR = "\x1b[0m"
+WARNING = "\x1b[1;33m [WARNING]: "
+INFO = "\x1b[1;33m [INFO]: "
+SUCCESS = "\x1b[1;32m [SUCCESS]: "

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,17 +3,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from hooks.core import (
-    DEBUG_VALUE,
-    INFO,
-    SUCCESS,
-    TERMINATOR,
-    WARNING,
-    ExecutionContext,
-    FailureStrategy,
-    generate_random_string,
-    generate_random_user,
-)
+from hooks.core import SUCCESS
+from hooks.core import TERMINATOR
+from hooks.core import WARNING
+from hooks.core import ExecutionContext
+from hooks.core import FailureStrategy
 from hooks.strategies import ALL_STRATEGIES
 
 
@@ -39,10 +33,7 @@ def main() -> None:
     context = get_cookiecutter_context()
     debug = context["debug"].lower() == "y"
 
-    if (
-        context["cloud_provider"] == "None"
-        and context["use_docker"].lower() == "n"
-    ):
+    if context["cloud_provider"] == "None" and context["use_docker"].lower() == "n":
         print(
             WARNING + "You chose to not use any cloud providers nor Docker, "
             "media files won't be served in production." + TERMINATOR,

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,597 +1,88 @@
-# ruff: noqa: PLR0133
-import json
-import os
-import random
-import shutil
-import string
-import subprocess
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
-try:
-    # Inspired by
-    # https://github.com/django/django/blob/main/django/utils/crypto.py
-    random = random.SystemRandom()
-    using_sysrandom = True
-except NotImplementedError:
-    using_sysrandom = False
-
-TERMINATOR = "\x1b[0m"
-WARNING = "\x1b[1;33m [WARNING]: "
-INFO = "\x1b[1;33m [INFO]: "
-HINT = "\x1b[3;33m"
-SUCCESS = "\x1b[1;32m [SUCCESS]: "
-
-DEBUG_VALUE = "debug"
-
-
-def remove_open_source_files():
-    file_names = ["CONTRIBUTORS.txt", "LICENSE"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_gplv3_files():
-    file_names = ["COPYING"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_custom_user_manager_files():
-    users_path = Path("{{cookiecutter.project_slug}}", "users")
-    (users_path / "managers.py").unlink()
-    (users_path / "tests" / "test_managers.py").unlink()
-
-
-def remove_pycharm_files():
-    idea_dir_path = Path(".idea")
-    if idea_dir_path.exists():
-        shutil.rmtree(idea_dir_path)
-
-    docs_dir_path = Path("docs", "pycharm")
-    if docs_dir_path.exists():
-        shutil.rmtree(docs_dir_path)
-
-
-def remove_docker_files():
-    shutil.rmtree(".devcontainer")
-    shutil.rmtree("compose")
-
-    file_names = [
-        "docker-compose.local.yml",
-        "docker-compose.production.yml",
-        ".dockerignore",
-        "justfile",
-    ]
-    for file_name in file_names:
-        Path(file_name).unlink()
-    if "{{ cookiecutter.editor }}" == "PyCharm":
-        file_names = ["docker_compose_up_django.xml", "docker_compose_up_docs.xml"]
-        for file_name in file_names:
-            Path(".idea", "runConfigurations", file_name).unlink()
-
-
-def remove_nginx_docker_files():
-    shutil.rmtree(Path("compose", "production", "nginx"))
-
-
-def remove_utility_files():
-    shutil.rmtree("utility")
-
-
-def remove_heroku_files():
-    file_names = ["Procfile"]
-    for file_name in file_names:
-        if file_name == "requirements.txt" and "{{ cookiecutter.ci_tool }}".lower() == "travis":
-            # Don't remove the file if we are using Travis CI but not using Heroku
-            continue
-        Path(file_name).unlink()
-    shutil.rmtree("bin")
-
-
-def remove_sass_files():
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "static", "sass"))
-
-
-def remove_gulp_files():
-    file_names = ["gulpfile.mjs"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_webpack_files():
-    shutil.rmtree("webpack")
-    remove_vendors_js()
-
-
-def remove_vendors_js():
-    vendors_js_path = Path("{{ cookiecutter.project_slug }}", "static", "js", "vendors.js")
-    if vendors_js_path.exists():
-        vendors_js_path.unlink()
-
-
-def remove_project_css():
-    project_css_path = Path("{{ cookiecutter.project_slug }}", "static", "css", "project.css")
-    if project_css_path.exists():
-        project_css_path.unlink()
-
-
-def remove_packagejson_file():
-    file_names = ["package.json"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def update_package_json(remove_dev_deps=None, remove_keys=None, scripts=None):
-    remove_dev_deps = remove_dev_deps or []
-    remove_keys = remove_keys or []
-    scripts = scripts or {}
-    package_json = Path("package.json")
-    content = json.loads(package_json.read_text())
-    for package_name in remove_dev_deps:
-        content["devDependencies"].pop(package_name)
-    for key in remove_keys:
-        content.pop(key)
-    content["scripts"].update(scripts)
-    updated_content = json.dumps(content, ensure_ascii=False, indent=2) + "\n"
-    package_json.write_text(updated_content)
-
-
-def handle_js_runner(choice, use_docker, use_async):
-    if choice == "Gulp":
-        update_package_json(
-            remove_dev_deps=[
-                "@babel/core",
-                "@babel/preset-env",
-                "babel-loader",
-                "concurrently",
-                "css-loader",
-                "mini-css-extract-plugin",
-                "postcss-loader",
-                "postcss-preset-env",
-                "sass-loader",
-                "webpack",
-                "webpack-bundle-tracker",
-                "webpack-cli",
-                "webpack-dev-server",
-                "webpack-merge",
-            ],
-            remove_keys=["babel"],
-            scripts={
-                "dev": "gulp",
-                "build": "gulp build",
-            },
-        )
-        remove_webpack_files()
-    elif choice == "Webpack":
-        scripts = {
-            "dev": "webpack serve --config webpack/dev.config.js",
-            "build": "webpack --config webpack/prod.config.js",
-        }
-        remove_dev_deps = [
-            "browser-sync",
-            "cssnano",
-            "gulp",
-            "gulp-concat",
-            "gulp-imagemin",
-            "gulp-plumber",
-            "gulp-postcss",
-            "gulp-rename",
-            "gulp-sass",
-            "gulp-uglify-es",
-        ]
-        if not use_docker:
-            dev_django_cmd = (
-                "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
-            )
-            scripts.update(
-                {
-                    "dev": "concurrently npm:dev:*",
-                    "dev:webpack": "webpack serve --config webpack/dev.config.js",
-                    "dev:django": dev_django_cmd,
-                },
-            )
-        else:
-            remove_dev_deps.append("concurrently")
-        update_package_json(remove_dev_deps=remove_dev_deps, scripts=scripts)
-        remove_gulp_files()
-
-
-def remove_prettier_pre_commit():
-    remove_repo_from_pre_commit_config("mirrors-prettier")
-
-
-def remove_repo_from_pre_commit_config(repo_to_remove: str):
-    pre_commit_config = Path(".pre-commit-config.yaml")
-    content = pre_commit_config.read_text().splitlines(keepends=True)
-
-    removing = False
-    new_lines = []
-    for line in content:
-        if removing and "- repo:" in line:
-            removing = False
-        if repo_to_remove in line:
-            removing = True
-        if not removing:
-            new_lines.append(line)
-
-    pre_commit_config.write_text("".join(new_lines))
-
-
-def remove_celery_files():
-    file_paths = [
-        Path("config", "celery_app.py"),
-        Path("{{ cookiecutter.project_slug }}", "users", "tasks.py"),
-        Path("{{ cookiecutter.project_slug }}", "users", "tests", "test_tasks.py"),
-    ]
-    for file_path in file_paths:
-        file_path.unlink()
-
-
-def remove_async_files():
-    file_paths = [
-        Path("config", "asgi.py"),
-        Path("config", "websocket.py"),
-    ]
-    for file_path in file_paths:
-        file_path.unlink()
-
-
-def remove_dottravisyml_file():
-    Path(".travis.yml").unlink()
-
-
-def remove_dotgitlabciyml_file():
-    Path(".gitlab-ci.yml").unlink()
-
-
-def remove_dotgithub_folder():
-    shutil.rmtree(".github")
-
-
-def remove_dotdrone_file():
-    Path(".drone.yml").unlink()
-
-
-def generate_random_string(length, using_digits=False, using_ascii_letters=False, using_punctuation=False):  # noqa: FBT002
-    """
-    Example:
-        opting out for 50 symbol-long, [a-z][A-Z][0-9] string
-        would yield log_2((26+26+50)^50) ~= 334 bit strength.
-    """
-    if not using_sysrandom:
-        return None
-
-    symbols = []
-    if using_digits:
-        symbols += string.digits
-    if using_ascii_letters:
-        symbols += string.ascii_letters
-    if using_punctuation:
-        all_punctuation = set(string.punctuation)
-        # These symbols can cause issues in environment variables
-        unsuitable = {"'", '"', "\\", "$"}
-        suitable = all_punctuation.difference(unsuitable)
-        symbols += "".join(suitable)
-    return "".join([random.choice(symbols) for _ in range(length)])
-
-
-def set_flag(file_path: Path, flag, value=None, formatted=None, *args, **kwargs):
-    if value is None:
-        random_string = generate_random_string(*args, **kwargs)
-        if random_string is None:
-            print(
-                "We couldn't find a secure pseudo-random number generator on your "
-                f"system. Please, make sure to manually {flag} later.",
-            )
-            random_string = flag
-        if formatted is not None:
-            random_string = formatted.format(random_string)
-        value = random_string
-
-    with file_path.open("r+") as f:
-        file_contents = f.read().replace(flag, value)
-        f.seek(0)
-        f.write(file_contents)
-        f.truncate()
-
-    return value
-
-
-def set_django_secret_key(file_path: Path):
-    return set_flag(
-        file_path,
-        "!!!SET DJANGO_SECRET_KEY!!!",
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
-def set_django_admin_url(file_path: Path):
-    return set_flag(
-        file_path,
-        "!!!SET DJANGO_ADMIN_URL!!!",
-        formatted="{}/",
-        length=32,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
-def generate_random_user():
-    return generate_random_string(length=32, using_ascii_letters=True)
-
-
-def generate_postgres_user(debug=False):  # noqa: FBT002
-    return DEBUG_VALUE if debug else generate_random_user()
-
-
-def set_postgres_user(file_path, value):
-    return set_flag(file_path, "!!!SET POSTGRES_USER!!!", value=value)
-
-
-def set_postgres_password(file_path, value=None):
-    return set_flag(
-        file_path,
-        "!!!SET POSTGRES_PASSWORD!!!",
-        value=value,
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
-def set_celery_flower_user(file_path, value):
-    return set_flag(file_path, "!!!SET CELERY_FLOWER_USER!!!", value=value)
-
-
-def set_celery_flower_password(file_path, value=None):
-    return set_flag(
-        file_path,
-        "!!!SET CELERY_FLOWER_PASSWORD!!!",
-        value=value,
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
-def append_to_gitignore_file(ignored_line):
-    with Path(".gitignore").open("a") as gitignore_file:
-        gitignore_file.write(ignored_line)
-        gitignore_file.write("\n")
-
-
-def set_flags_in_envs(postgres_user, celery_flower_user, debug=False):  # noqa: FBT002
-    local_django_envs_path = Path(".envs", ".local", ".django")
-    production_django_envs_path = Path(".envs", ".production", ".django")
-    local_postgres_envs_path = Path(".envs", ".local", ".postgres")
-    production_postgres_envs_path = Path(".envs", ".production", ".postgres")
-
-    set_django_secret_key(production_django_envs_path)
-    set_django_admin_url(production_django_envs_path)
-
-    set_postgres_user(local_postgres_envs_path, value=postgres_user)
-    set_postgres_password(local_postgres_envs_path, value=DEBUG_VALUE if debug else None)
-    set_postgres_user(production_postgres_envs_path, value=postgres_user)
-    set_postgres_password(production_postgres_envs_path, value=DEBUG_VALUE if debug else None)
-
-    set_celery_flower_user(local_django_envs_path, value=celery_flower_user)
-    set_celery_flower_password(local_django_envs_path, value=DEBUG_VALUE if debug else None)
-    set_celery_flower_user(production_django_envs_path, value=celery_flower_user)
-    set_celery_flower_password(production_django_envs_path, value=DEBUG_VALUE if debug else None)
-
-
-def set_flags_in_settings_files():
-    set_django_secret_key(Path("config", "settings", "local.py"))
-    set_django_secret_key(Path("config", "settings", "test.py"))
-
-
-def remove_envs_and_associated_files():
-    shutil.rmtree(".envs")
-    Path("merge_production_dotenvs_in_dotenv.py").unlink()
-    shutil.rmtree("tests")
-
-
-def remove_celery_compose_dirs():
-    shutil.rmtree(Path("compose", "local", "django", "celery"))
-    shutil.rmtree(Path("compose", "production", "django", "celery"))
-
-
-def remove_node_dockerfile():
-    shutil.rmtree(Path("compose", "local", "node"))
-
-
-def remove_aws_dockerfile():
-    shutil.rmtree(Path("compose", "production", "aws"))
-
-
-def remove_drf_starter_files():
-    Path("config", "api_router.py").unlink()
-    Path("{{cookiecutter.project_slug}}", "users", "api", "serializers.py").unlink()
-
-
-def remove_ninja_starter_files():
-    Path("config", "api.py").unlink()
-    Path("{{cookiecutter.project_slug}}", "users", "api", "schema.py").unlink()
-
-
-def remove_rest_api_files():
-    remove_drf_starter_files()
-    remove_ninja_starter_files()
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "api"))
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "tests", "api"))
-
-
-def main():  # noqa: C901, PLR0912, PLR0915
-    debug = "{{ cookiecutter.debug }}".lower() == "y"
-
-    set_flags_in_envs(
-        DEBUG_VALUE if debug else generate_random_user(),
-        DEBUG_VALUE if debug else generate_random_user(),
-        debug=debug,
-    )
-    set_flags_in_settings_files()
-
-    if "{{ cookiecutter.open_source_license }}" == "Not open source":
-        remove_open_source_files()
-    if "{{ cookiecutter.open_source_license}}" != "GPLv3":
-        remove_gplv3_files()
-
-    if "{{ cookiecutter.username_type }}" == "username":
-        remove_custom_user_manager_files()
-
-    if "{{ cookiecutter.editor }}" != "PyCharm":
-        remove_pycharm_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y":
-        remove_utility_files()
-        if "{{ cookiecutter.cloud_provider }}".lower() != "none":
-            remove_nginx_docker_files()
-    else:
-        remove_docker_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y" and "{{ cookiecutter.cloud_provider}}" != "AWS":
-        remove_aws_dockerfile()
-
-    if "{{ cookiecutter.use_heroku }}".lower() == "n":
-        remove_heroku_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "n" and "{{ cookiecutter.use_heroku }}".lower() == "n":
-        if "{{ cookiecutter.keep_local_envs_in_vcs }}".lower() == "y":
-            print(
-                INFO + ".env(s) are only utilized when Docker Compose and/or "
-                "Heroku support is enabled. Keeping them as requested, but they may not be useful "
-                "in your current setup." + TERMINATOR,
-            )
-        else:
-            remove_envs_and_associated_files()
-    else:
-        append_to_gitignore_file(".env")
-        append_to_gitignore_file(".envs/*")
-        if "{{ cookiecutter.keep_local_envs_in_vcs }}".lower() == "y":
-            append_to_gitignore_file("!.envs/.local/")
-
-    if "{{ cookiecutter.frontend_pipeline }}" in ["None", "Django Compressor"]:
-        remove_gulp_files()
-        remove_webpack_files()
-        remove_sass_files()
-        remove_packagejson_file()
-        remove_prettier_pre_commit()
-        if "{{ cookiecutter.use_docker }}".lower() == "y":
-            remove_node_dockerfile()
-    else:
-        remove_project_css()
-        handle_js_runner(
-            "{{ cookiecutter.frontend_pipeline }}",
-            use_docker=("{{ cookiecutter.use_docker }}".lower() == "y"),
-            use_async=("{{ cookiecutter.use_async }}".lower() == "y"),
-        )
-
-    if "{{ cookiecutter.cloud_provider }}" == "None" and "{{ cookiecutter.use_docker }}".lower() == "n":
+from hooks.core import (
+    DEBUG_VALUE,
+    INFO,
+    SUCCESS,
+    TERMINATOR,
+    WARNING,
+    ExecutionContext,
+    FailureStrategy,
+    generate_random_string,
+    generate_random_user,
+)
+from hooks.strategies import ALL_STRATEGIES
+
+
+def get_cookiecutter_context() -> dict:
+    return {
+        "open_source_license": "{{ cookiecutter.open_source_license }}",
+        "username_type": "{{ cookiecutter.username_type }}",
+        "editor": "{{ cookiecutter.editor }}",
+        "use_docker": "{{ cookiecutter.use_docker }}",
+        "cloud_provider": "{{ cookiecutter.cloud_provider }}",
+        "use_heroku": "{{ cookiecutter.use_heroku }}",
+        "ci_tool": "{{ cookiecutter.ci_tool }}",
+        "keep_local_envs_in_vcs": "{{ cookiecutter.keep_local_envs_in_vcs }}",
+        "frontend_pipeline": "{{ cookiecutter.frontend_pipeline }}",
+        "use_celery": "{{ cookiecutter.use_celery }}",
+        "rest_api": "{{ cookiecutter.rest_api }}",
+        "use_async": "{{ cookiecutter.use_async }}",
+        "debug": "{{ cookiecutter.debug }}",
+    }
+
+
+def main() -> None:
+    context = get_cookiecutter_context()
+    debug = context["debug"].lower() == "y"
+
+    if (
+        context["cloud_provider"] == "None"
+        and context["use_docker"].lower() == "n"
+    ):
         print(
             WARNING + "You chose to not use any cloud providers nor Docker, "
             "media files won't be served in production." + TERMINATOR,
         )
 
-    if "{{ cookiecutter.use_celery }}".lower() == "n":
-        remove_celery_files()
-        if "{{ cookiecutter.use_docker }}".lower() == "y":
-            remove_celery_compose_dirs()
+    execution_context = ExecutionContext(
+        failure_strategy=FailureStrategy.ROLLBACK,
+        dry_run=False,
+    )
 
-    if "{{ cookiecutter.ci_tool }}" != "Travis":
-        remove_dottravisyml_file()
+    print("Phase 1: Collecting operations from strategies...")
+    for strategy_class in ALL_STRATEGIES:
+        strategy = strategy_class()
+        if strategy.should_apply(context):
+            operations = strategy.collect_operations(context)
+            for op in operations:
+                execution_context.add_operation(op)
 
-    if "{{ cookiecutter.ci_tool }}" != "Gitlab":
-        remove_dotgitlabciyml_file()
+    print(f"Collected {len(execution_context.operations)} operations to execute.")
+    if debug:
+        print("\nOperations preview:")
+        for i, op in enumerate(execution_context.operations, 1):
+            print(f"  {i}. [{op.operation_type.value}] {op.target}")
+        print()
 
-    if "{{ cookiecutter.ci_tool }}" != "Github":
-        remove_dotgithub_folder()
+    print("Phase 2: Executing all operations...")
+    try:
+        execution_context.execute_all()
+    except Exception as e:
+        print(f"Fatal error during execution: {e}", file=sys.stderr)
+        sys.exit(1)
 
-    if "{{ cookiecutter.ci_tool }}" != "Drone":
-        remove_dotdrone_file()
-
-    if "{{ cookiecutter.rest_api }}" == "DRF":
-        remove_ninja_starter_files()
-    elif "{{ cookiecutter.rest_api }}" == "Django Ninja":
-        remove_drf_starter_files()
-    else:
-        remove_rest_api_files()
-
-    if "{{ cookiecutter.use_async }}".lower() == "n":
-        remove_async_files()
-
-    setup_dependencies()
-
+    execution_context.print_report()
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 
 
-def setup_dependencies():
-    print("Installing python dependencies using uv...")
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y":
-        # Build a trimmed down Docker image add dependencies with uv
-        uv_docker_image_path = Path("compose/local/uv/Dockerfile")
-        uv_image_tag = "cookiecutter-django-uv-runner:latest"
-        try:
-            subprocess.run(  # noqa: S603
-                [  # noqa: S607
-                    "docker",
-                    "build",
-                    "--load",
-                    "-t",
-                    uv_image_tag,
-                    "-f",
-                    str(uv_docker_image_path),
-                    "-q",
-                    ".",
-                ],
-                check=True,
-                env={
-                    **os.environ,
-                    "DOCKER_BUILDKIT": "1",
-                },
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"Error building Docker image: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        current_path = Path.cwd().absolute()
-        # Use Docker to run the uv command
-        uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]
-    else:
-        # Use uv command directly
-        uv_cmd = ["uv"]
-
-    # Install production dependencies
-    try:
-        subprocess.run([*uv_cmd, "add", "--no-sync", "-r", "requirements/production.txt"], check=True)  # noqa: S603
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing production dependencies: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # Install local (development) dependencies
-    try:
-        subprocess.run([*uv_cmd, "add", "--no-sync", "--dev", "-r", "requirements/local.txt"], check=True)  # noqa: S603
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing local dependencies: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # Remove the requirements directory
-    requirements_dir = Path("requirements")
-    if requirements_dir.exists():
-        try:
-            shutil.rmtree(requirements_dir)
-        except Exception as e:  # noqa: BLE001
-            print(f"Error removing 'requirements' folder: {e}", file=sys.stderr)
-            sys.exit(1)
-
-    uv_image_parent_dir_path = Path("compose/local/uv")
-    if uv_image_parent_dir_path.exists():
-        shutil.rmtree(str(uv_image_parent_dir_path))
-
-    print("Setup complete!")
+def append_to_gitignore_file(ignored_line: str) -> None:
+    with Path(".gitignore").open("a") as gitignore_file:
+        gitignore_file.write(ignored_line)
+        gitignore_file.write("\n")
 
 
 if __name__ == "__main__":

--- a/hooks/strategies.py
+++ b/hooks/strategies.py
@@ -3,19 +3,16 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from hooks.core import (
-    AppendFileOperation,
-    DeleteDirOperation,
-    DeleteFileOperation,
-    ModifyFileOperation,
-    Operation,
-    RunCommandOperation,
-    SetFlagOperation,
-    Strategy,
-    remove_repo_from_pre_commit_modifier,
-    update_package_json_modifier,
-)
-
+from hooks.core import AppendFileOperation
+from hooks.core import DeleteDirOperation
+from hooks.core import DeleteFileOperation
+from hooks.core import ModifyFileOperation
+from hooks.core import Operation
+from hooks.core import RunCommandOperation
+from hooks.core import SetFlagOperation
+from hooks.core import Strategy
+from hooks.core import remove_repo_from_pre_commit_modifier
+from hooks.core import update_package_json_modifier
 
 PROJECT_SLUG = "{{ cookiecutter.project_slug }}"
 
@@ -202,15 +199,15 @@ class FrontendPipelineStrategy(Strategy):
                 ]
                 if not use_docker:
                     dev_django_cmd = (
-                        "uvicorn config.asgi:application --reload"
-                        if use_async
-                        else "python manage.py runserver_plus"
+                        "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
                     )
-                    scripts.update({
-                        "dev": "concurrently npm:dev:*",
-                        "dev:webpack": "webpack serve --config webpack/dev.config.js",
-                        "dev:django": dev_django_cmd,
-                    })
+                    scripts.update(
+                        {
+                            "dev": "concurrently npm:dev:*",
+                            "dev:webpack": "webpack serve --config webpack/dev.config.js",
+                            "dev:django": dev_django_cmd,
+                        }
+                    )
                 else:
                     remove_dev_deps.append("concurrently")
                 operations.append(
@@ -310,11 +307,9 @@ class SecretGenerationStrategy(Strategy):
         return True
 
     def collect_operations(self, context: dict) -> list[Operation]:
-        from hooks.core import (
-            DEBUG_VALUE,
-            generate_random_string,
-            generate_random_user,
-        )
+        from hooks.core import DEBUG_VALUE
+        from hooks.core import generate_random_string
+        from hooks.core import generate_random_user
 
         operations = []
         debug = context["debug"].lower() == "y"
@@ -329,10 +324,14 @@ class SecretGenerationStrategy(Strategy):
             if env_path.exists():
                 if is_production:
                     secret_key = generate_random_string(
-                        length=64, using_digits=True, using_ascii_letters=True,
+                        length=64,
+                        using_digits=True,
+                        using_ascii_letters=True,
                     )
                     admin_url = generate_random_string(
-                        length=32, using_digits=True, using_ascii_letters=True,
+                        length=32,
+                        using_digits=True,
+                        using_ascii_letters=True,
                     )
                     operations.append(
                         SetFlagOperation(env_path, "!!!SET DJANGO_SECRET_KEY!!!", secret_key),
@@ -341,11 +340,23 @@ class SecretGenerationStrategy(Strategy):
                         SetFlagOperation(env_path, "!!!SET DJANGO_ADMIN_URL!!!", f"{admin_url}/"),
                     )
 
-                pg_pwd = DEBUG_VALUE if debug else generate_random_string(
-                    length=64, using_digits=True, using_ascii_letters=True,
+                pg_pwd = (
+                    DEBUG_VALUE
+                    if debug
+                    else generate_random_string(
+                        length=64,
+                        using_digits=True,
+                        using_ascii_letters=True,
+                    )
                 )
-                flower_pwd = DEBUG_VALUE if debug else generate_random_string(
-                    length=64, using_digits=True, using_ascii_letters=True,
+                flower_pwd = (
+                    DEBUG_VALUE
+                    if debug
+                    else generate_random_string(
+                        length=64,
+                        using_digits=True,
+                        using_ascii_letters=True,
+                    )
                 )
                 operations.append(
                     SetFlagOperation(env_path, "!!!SET POSTGRES_USER!!!", postgres_user),
@@ -364,7 +375,9 @@ class SecretGenerationStrategy(Strategy):
             settings_path = Path("config", "settings", settings_file)
             if settings_path.exists():
                 secret_key = generate_random_string(
-                    length=64, using_digits=True, using_ascii_letters=True,
+                    length=64,
+                    using_digits=True,
+                    using_ascii_letters=True,
                 )
                 operations.append(
                     SetFlagOperation(settings_path, "!!!SET DJANGO_SECRET_KEY!!!", secret_key),
@@ -385,10 +398,20 @@ class SetupDependenciesStrategy(Strategy):
             uv_docker_image_path = Path("compose/local/uv/Dockerfile")
             uv_image_tag = "cookiecutter-django-uv-runner:latest"
             operations.append(
-                RunCommandOperation([
-                    "docker", "build", "--load", "-t", uv_image_tag,
-                    "-f", str(uv_docker_image_path), "-q", ".",
-                ], env={**os.environ, "DOCKER_BUILDKIT": "1"}),
+                RunCommandOperation(
+                    [
+                        "docker",
+                        "build",
+                        "--load",
+                        "-t",
+                        uv_image_tag,
+                        "-f",
+                        str(uv_docker_image_path),
+                        "-q",
+                        ".",
+                    ],
+                    env={**os.environ, "DOCKER_BUILDKIT": "1"},
+                ),
             )
             current_path = Path.cwd().absolute()
             uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]

--- a/hooks/strategies.py
+++ b/hooks/strategies.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hooks.core import (
+    AppendFileOperation,
+    DeleteDirOperation,
+    DeleteFileOperation,
+    ModifyFileOperation,
+    Operation,
+    RunCommandOperation,
+    SetFlagOperation,
+    Strategy,
+    remove_repo_from_pre_commit_modifier,
+    update_package_json_modifier,
+)
+
+
+PROJECT_SLUG = "{{ cookiecutter.project_slug }}"
+
+
+class LicenseStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        license_type = context["open_source_license"]
+        if license_type == "Not open source":
+            operations.append(DeleteFileOperation("CONTRIBUTORS.txt"))
+            operations.append(DeleteFileOperation("LICENSE"))
+        if license_type != "GPLv3":
+            operations.append(DeleteFileOperation("COPYING"))
+        return operations
+
+
+class UsernameTypeStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        if context["username_type"] == "username":
+            users_path = Path(PROJECT_SLUG, "users")
+            operations.append(DeleteFileOperation(users_path / "managers.py"))
+            operations.append(DeleteFileOperation(users_path / "tests" / "test_managers.py"))
+        return operations
+
+
+class EditorStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        if context["editor"] != "PyCharm":
+            operations.append(DeleteDirOperation(".idea"))
+            operations.append(DeleteDirOperation(Path("docs", "pycharm")))
+        return operations
+
+
+class DockerStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        use_docker = context["use_docker"].lower() == "y"
+        cloud_provider = context["cloud_provider"]
+
+        if use_docker:
+            operations.append(DeleteDirOperation("utility"))
+            if cloud_provider.lower() != "none":
+                operations.append(DeleteDirOperation(Path("compose", "production", "nginx")))
+        else:
+            operations.append(DeleteDirOperation(".devcontainer"))
+            operations.append(DeleteDirOperation("compose"))
+            docker_files = [
+                "docker-compose.local.yml",
+                "docker-compose.production.yml",
+                ".dockerignore",
+                "justfile",
+            ]
+            for fname in docker_files:
+                operations.append(DeleteFileOperation(fname))
+
+        if use_docker and cloud_provider != "AWS":
+            operations.append(DeleteDirOperation(Path("compose", "production", "aws")))
+
+        return operations
+
+
+class HerokuStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        if context["use_heroku"].lower() == "n":
+            operations.append(DeleteFileOperation("Procfile"))
+            operations.append(DeleteDirOperation("bin"))
+        return operations
+
+
+class EnvsStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        use_docker = context["use_docker"].lower() == "y"
+        use_heroku = context["use_heroku"].lower() == "y"
+        keep_envs = context["keep_local_envs_in_vcs"].lower() == "y"
+
+        if not use_docker and not use_heroku:
+            if not keep_envs:
+                operations.append(DeleteDirOperation(".envs"))
+                operations.append(DeleteFileOperation("merge_production_dotenvs_in_dotenv.py"))
+                operations.append(DeleteDirOperation("tests"))
+        else:
+            operations.append(AppendFileOperation(".gitignore", ".env"))
+            operations.append(AppendFileOperation(".gitignore", ".envs/*"))
+            if keep_envs:
+                operations.append(AppendFileOperation(".gitignore", "!.envs/.local/"))
+        return operations
+
+
+class FrontendPipelineStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        pipeline = context["frontend_pipeline"]
+        use_docker = context["use_docker"].lower() == "y"
+        use_async = context["use_async"].lower() == "y"
+
+        static_path = Path(PROJECT_SLUG, "static")
+
+        if pipeline in ["None", "Django Compressor"]:
+            operations.append(DeleteFileOperation("gulpfile.mjs"))
+            operations.append(DeleteDirOperation("webpack"))
+            operations.append(DeleteDirOperation(static_path / "sass"))
+            operations.append(DeleteFileOperation("package.json"))
+            operations.append(
+                ModifyFileOperation(
+                    ".pre-commit-config.yaml",
+                    remove_repo_from_pre_commit_modifier("mirrors-prettier"),
+                ),
+            )
+            if use_docker:
+                operations.append(DeleteDirOperation(Path("compose", "local", "node")))
+        else:
+            operations.append(DeleteFileOperation(static_path / "css" / "project.css"))
+            if pipeline == "Gulp":
+                operations.append(
+                    ModifyFileOperation(
+                        "package.json",
+                        update_package_json_modifier(
+                            remove_dev_deps=[
+                                "@babel/core",
+                                "@babel/preset-env",
+                                "babel-loader",
+                                "concurrently",
+                                "css-loader",
+                                "mini-css-extract-plugin",
+                                "postcss-loader",
+                                "postcss-preset-env",
+                                "sass-loader",
+                                "webpack",
+                                "webpack-bundle-tracker",
+                                "webpack-cli",
+                                "webpack-dev-server",
+                                "webpack-merge",
+                            ],
+                            remove_keys=["babel"],
+                            scripts={
+                                "dev": "gulp",
+                                "build": "gulp build",
+                            },
+                        ),
+                    ),
+                )
+                operations.append(DeleteDirOperation("webpack"))
+            elif pipeline == "Webpack":
+                scripts = {
+                    "dev": "webpack serve --config webpack/dev.config.js",
+                    "build": "webpack --config webpack/prod.config.js",
+                }
+                remove_dev_deps = [
+                    "browser-sync",
+                    "cssnano",
+                    "gulp",
+                    "gulp-concat",
+                    "gulp-imagemin",
+                    "gulp-plumber",
+                    "gulp-postcss",
+                    "gulp-rename",
+                    "gulp-sass",
+                    "gulp-uglify-es",
+                ]
+                if not use_docker:
+                    dev_django_cmd = (
+                        "uvicorn config.asgi:application --reload"
+                        if use_async
+                        else "python manage.py runserver_plus"
+                    )
+                    scripts.update({
+                        "dev": "concurrently npm:dev:*",
+                        "dev:webpack": "webpack serve --config webpack/dev.config.js",
+                        "dev:django": dev_django_cmd,
+                    })
+                else:
+                    remove_dev_deps.append("concurrently")
+                operations.append(
+                    ModifyFileOperation(
+                        "package.json",
+                        update_package_json_modifier(
+                            remove_dev_deps=remove_dev_deps,
+                            scripts=scripts,
+                        ),
+                    ),
+                )
+                operations.append(DeleteFileOperation("gulpfile.mjs"))
+
+        return operations
+
+
+class CeleryStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        if context["use_celery"].lower() == "n":
+            operations.append(DeleteFileOperation(Path("config", "celery_app.py")))
+            operations.append(
+                DeleteFileOperation(Path(PROJECT_SLUG, "users", "tasks.py")),
+            )
+            operations.append(
+                DeleteFileOperation(Path(PROJECT_SLUG, "users", "tests", "test_tasks.py")),
+            )
+            if context["use_docker"].lower() == "y":
+                operations.append(
+                    DeleteDirOperation(Path("compose", "local", "django", "celery")),
+                )
+                operations.append(
+                    DeleteDirOperation(Path("compose", "production", "django", "celery")),
+                )
+        return operations
+
+
+class CiToolStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        ci_tool = context["ci_tool"]
+        if ci_tool != "Travis":
+            operations.append(DeleteFileOperation(".travis.yml"))
+        if ci_tool != "Gitlab":
+            operations.append(DeleteFileOperation(".gitlab-ci.yml"))
+        if ci_tool != "Github":
+            operations.append(DeleteDirOperation(".github"))
+        if ci_tool != "Drone":
+            operations.append(DeleteFileOperation(".drone.yml"))
+        return operations
+
+
+class RestApiStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        rest_api = context["rest_api"]
+        users_path = Path(PROJECT_SLUG, "users")
+        if rest_api == "DRF":
+            operations.append(DeleteFileOperation(Path("config", "api.py")))
+            operations.append(DeleteFileOperation(users_path / "api" / "schema.py"))
+        elif rest_api == "Django Ninja":
+            operations.append(DeleteFileOperation(Path("config", "api_router.py")))
+            operations.append(DeleteFileOperation(users_path / "api" / "serializers.py"))
+        else:
+            operations.append(DeleteFileOperation(Path("config", "api_router.py")))
+            operations.append(DeleteFileOperation(Path("config", "api.py")))
+            operations.append(DeleteFileOperation(users_path / "api" / "serializers.py"))
+            operations.append(DeleteFileOperation(users_path / "api" / "schema.py"))
+            operations.append(DeleteDirOperation(users_path / "api"))
+            operations.append(DeleteDirOperation(users_path / "tests" / "api"))
+        return operations
+
+
+class AsyncStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        if context["use_async"].lower() == "n":
+            operations.append(DeleteFileOperation(Path("config", "asgi.py")))
+            operations.append(DeleteFileOperation(Path("config", "websocket.py")))
+        return operations
+
+
+class SecretGenerationStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        from hooks.core import (
+            DEBUG_VALUE,
+            generate_random_string,
+            generate_random_user,
+        )
+
+        operations = []
+        debug = context["debug"].lower() == "y"
+        postgres_user = DEBUG_VALUE if debug else generate_random_user()
+        celery_user = DEBUG_VALUE if debug else generate_random_user()
+
+        envs = [
+            (Path(".envs", ".local", ".django"), False),
+            (Path(".envs", ".production", ".django"), True),
+        ]
+        for env_path, is_production in envs:
+            if env_path.exists():
+                if is_production:
+                    secret_key = generate_random_string(
+                        length=64, using_digits=True, using_ascii_letters=True,
+                    )
+                    admin_url = generate_random_string(
+                        length=32, using_digits=True, using_ascii_letters=True,
+                    )
+                    operations.append(
+                        SetFlagOperation(env_path, "!!!SET DJANGO_SECRET_KEY!!!", secret_key),
+                    )
+                    operations.append(
+                        SetFlagOperation(env_path, "!!!SET DJANGO_ADMIN_URL!!!", f"{admin_url}/"),
+                    )
+
+                pg_pwd = DEBUG_VALUE if debug else generate_random_string(
+                    length=64, using_digits=True, using_ascii_letters=True,
+                )
+                flower_pwd = DEBUG_VALUE if debug else generate_random_string(
+                    length=64, using_digits=True, using_ascii_letters=True,
+                )
+                operations.append(
+                    SetFlagOperation(env_path, "!!!SET POSTGRES_USER!!!", postgres_user),
+                )
+                operations.append(
+                    SetFlagOperation(env_path, "!!!SET POSTGRES_PASSWORD!!!", pg_pwd),
+                )
+                operations.append(
+                    SetFlagOperation(env_path, "!!!SET CELERY_FLOWER_USER!!!", celery_user),
+                )
+                operations.append(
+                    SetFlagOperation(env_path, "!!!SET CELERY_FLOWER_PASSWORD!!!", flower_pwd),
+                )
+
+        for settings_file in ["local.py", "test.py"]:
+            settings_path = Path("config", "settings", settings_file)
+            if settings_path.exists():
+                secret_key = generate_random_string(
+                    length=64, using_digits=True, using_ascii_letters=True,
+                )
+                operations.append(
+                    SetFlagOperation(settings_path, "!!!SET DJANGO_SECRET_KEY!!!", secret_key),
+                )
+
+        return operations
+
+
+class SetupDependenciesStrategy(Strategy):
+    def should_apply(self, context: dict) -> bool:
+        return True
+
+    def collect_operations(self, context: dict) -> list[Operation]:
+        operations = []
+        use_docker = context["use_docker"].lower() == "y"
+
+        if use_docker:
+            uv_docker_image_path = Path("compose/local/uv/Dockerfile")
+            uv_image_tag = "cookiecutter-django-uv-runner:latest"
+            operations.append(
+                RunCommandOperation([
+                    "docker", "build", "--load", "-t", uv_image_tag,
+                    "-f", str(uv_docker_image_path), "-q", ".",
+                ], env={**os.environ, "DOCKER_BUILDKIT": "1"}),
+            )
+            current_path = Path.cwd().absolute()
+            uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]
+        else:
+            uv_cmd = ["uv"]
+
+        operations.append(
+            RunCommandOperation([*uv_cmd, "add", "--no-sync", "-r", "requirements/production.txt"]),
+        )
+        operations.append(
+            RunCommandOperation([*uv_cmd, "add", "--no-sync", "--dev", "-r", "requirements/local.txt"]),
+        )
+
+        operations.append(DeleteDirOperation("requirements"))
+        operations.append(DeleteDirOperation(Path("compose/local/uv")))
+
+        return operations
+
+
+ALL_STRATEGIES: list[type[Strategy]] = [
+    LicenseStrategy,
+    UsernameTypeStrategy,
+    EditorStrategy,
+    DockerStrategy,
+    HerokuStrategy,
+    EnvsStrategy,
+    FrontendPipelineStrategy,
+    CeleryStrategy,
+    CiToolStrategy,
+    RestApiStrategy,
+    AsyncStrategy,
+    SecretGenerationStrategy,
+    SetupDependenciesStrategy,
+]

--- a/tests/test_refactored_architecture.py
+++ b/tests/test_refactored_architecture.py
@@ -1,0 +1,375 @@
+"""Tests for the refactored architecture: audit, operations, strategies, rollback"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hooks.core import (
+    AppendFileOperation,
+    AuditLog,
+    DeleteDirOperation,
+    DeleteFileOperation,
+    DryRunExecutor,
+    ExecutionContext,
+    FailureStrategy,
+    ModifyFileOperation,
+    RealExecutor,
+    RollbackManager,
+    RunCommandOperation,
+    SetFlagOperation,
+)
+from hooks.strategies import (
+    ALL_STRATEGIES,
+    AsyncStrategy,
+    CeleryStrategy,
+    CiToolStrategy,
+    DockerStrategy,
+    EnvsStrategy,
+    FrontendPipelineStrategy,
+    HerokuStrategy,
+    LicenseStrategy,
+    RestApiStrategy,
+    SecretGenerationStrategy,
+    SetupDependenciesStrategy,
+    UsernameTypeStrategy,
+)
+
+
+class TestAuditLog:
+    def test_audit_log_records_operations(self):
+        audit = AuditLog()
+        assert len(audit.entries) == 0
+
+        from hooks.core import AuditEntry, OperationType
+
+        entry = AuditEntry(
+            operation_type=OperationType.DELETE_FILE,
+            target="test.txt",
+            success=True,
+        )
+        audit.record(entry)
+        assert len(audit.entries) == 1
+        assert audit.entries[0].target == "test.txt"
+
+    def test_generate_report_summary(self):
+        audit = AuditLog()
+        from hooks.core import AuditEntry, OperationType
+
+        audit.record(AuditEntry(OperationType.DELETE_FILE, "f1.txt", success=True))
+        audit.record(AuditEntry(OperationType.DELETE_FILE, "f2.txt", success=True))
+        audit.record(AuditEntry(OperationType.MODIFY_FILE, "f3.txt", success=False, error="test error"))
+
+        report = audit.generate_report()
+        assert report["summary"]["total_operations"] == 3
+        assert report["summary"]["successful"] == 2
+        assert report["summary"]["failed"] == 1
+        assert report["operations_by_type"]["delete_file"] == 2
+        assert report["operations_by_type"]["modify_file"] == 1
+
+
+class TestOperations:
+    def test_delete_file_operation(self, working_directory):
+        test_file = Path("test_delete.txt")
+        test_file.write_text("content")
+
+        op = DeleteFileOperation(test_file)
+        audit = AuditLog()
+
+        op.execute(audit)
+        assert not test_file.exists()
+        assert op.executed
+        assert audit.entries[0].success
+
+    def test_delete_file_rollback(self, working_directory):
+        test_file = Path("test_rollback.txt")
+        original_content = "important content"
+        test_file.write_text(original_content)
+
+        op = DeleteFileOperation(test_file)
+        audit = AuditLog()
+        op.execute(audit)
+        assert not test_file.exists()
+
+        op.rollback(audit)
+        assert test_file.exists()
+        assert test_file.read_text() == original_content
+
+    def test_modify_file_operation_and_rollback(self, working_directory):
+        test_file = Path("test_modify.txt")
+        test_file.write_text("Hello World")
+
+        def modifier(content):
+            return content.replace("World", "Django")
+
+        op = ModifyFileOperation(test_file, modifier)
+        audit = AuditLog()
+        op.execute(audit)
+
+        assert test_file.read_text() == "Hello Django"
+
+        op.rollback(audit)
+        assert test_file.read_text() == "Hello World"
+
+    def test_append_file_operation_and_rollback(self, working_directory):
+        test_file = Path("test_append.txt")
+        test_file.write_text("line1\n")
+
+        op = AppendFileOperation(test_file, "line2")
+        audit = AuditLog()
+        op.execute(audit)
+
+        lines = test_file.read_text().splitlines()
+        assert len(lines) == 2
+        assert lines[1] == "line2"
+
+        op.rollback(audit)
+        assert test_file.read_text() == "line1\n"
+
+    def test_set_flag_operation(self, working_directory):
+        test_file = Path("test_flag.txt")
+        test_file.write_text("SECRET_KEY = '!!!SET MY_KEY!!!'")
+
+        op = SetFlagOperation(test_file, "!!!SET MY_KEY!!!", "super-secret-123")
+        audit = AuditLog()
+        op.execute(audit)
+
+        assert "super-secret-123" in test_file.read_text()
+        assert "!!!SET MY_KEY!!!" not in test_file.read_text()
+
+    def test_delete_dir_operation_and_rollback(self, working_directory):
+        test_dir = Path("test_dir")
+        test_dir.mkdir()
+        (test_dir / "file1.txt").write_text("content1")
+        (test_dir / "file2.txt").write_text("content2")
+
+        op = DeleteDirOperation(test_dir)
+        audit = AuditLog()
+        op.execute(audit)
+
+        assert not test_dir.exists()
+
+        op.rollback(audit)
+        assert test_dir.exists()
+        assert (test_dir / "file1.txt").read_text() == "content1"
+        assert (test_dir / "file2.txt").read_text() == "content2"
+
+
+class TestExecutors:
+    def test_dry_run_executor(self, working_directory):
+        test_file = Path("test_dryrun.txt")
+        test_file.write_text("content")
+
+        ctx = ExecutionContext(dry_run=True)
+        ctx.add_operation(DeleteFileOperation(test_file))
+        ctx.execute_all()
+
+        assert test_file.exists()
+        report = ctx.get_report()
+        assert report["entries"][0]["details"]["dry_run"] is True
+
+    def test_real_executor(self, working_directory):
+        test_file = Path("test_real.txt")
+        test_file.write_text("content")
+
+        ctx = ExecutionContext(executor=RealExecutor())
+        ctx.add_operation(DeleteFileOperation(test_file))
+        ctx.execute_all()
+
+        assert not test_file.exists()
+
+
+class TestRollbackManager:
+    def test_rollback_all_on_failure(self, working_directory):
+        f1 = Path("f1.txt")
+        f2 = Path("f2.txt")
+        f1.write_text("content1")
+        f2.write_text("content2")
+
+        class FailingOperation(DeleteFileOperation):
+            def _execute(self):
+                super()._execute()
+                raise RuntimeError("Simulated failure")
+
+        ctx = ExecutionContext(failure_strategy=FailureStrategy.ROLLBACK)
+        ctx.add_operation(DeleteFileOperation(f1))
+        ctx.add_operation(FailingOperation(f2))
+
+        with pytest.raises(RuntimeError):
+            ctx.execute_all()
+
+        assert f1.exists()
+
+    def test_checkpoint_and_resume(self, working_directory):
+        ctx = ExecutionContext()
+        f1 = Path("f1.txt")
+        f2 = Path("f2.txt")
+        f3 = Path("f3.txt")
+        for f in [f1, f2, f3]:
+            f.write_text("content")
+
+        ctx.add_operation(DeleteFileOperation(f1))
+        ctx.checkpoint()
+        ctx.add_operation(DeleteFileOperation(f2))
+        ctx.add_operation(DeleteFileOperation(f3))
+
+        assert ctx.checkpoint_index == 1
+
+        ctx.operations[1]._execute = lambda: (_ for _ in ()).throw(RuntimeError("Oops"))
+        ctx.failure_strategy = FailureStrategy.ABORT
+
+        with pytest.raises(RuntimeError):
+            ctx.execute_all()
+
+        assert not f1.exists()
+
+
+class TestStrategies:
+    def test_all_strategies_have_should_apply(self):
+        for strategy_class in ALL_STRATEGIES:
+            strategy = strategy_class()
+            assert callable(strategy.should_apply)
+            assert callable(strategy.collect_operations)
+
+    def test_license_strategy(self):
+        strategy = LicenseStrategy()
+        closed_ops = strategy.collect_operations({"open_source_license": "Not open source"})
+        mit_ops = strategy.collect_operations({"open_source_license": "MIT"})
+        assert len(closed_ops) >= len(mit_ops)
+
+    def test_username_type_strategy(self):
+        strategy = UsernameTypeStrategy()
+        ops = strategy.collect_operations({"username_type": "username"})
+        assert len(ops) == 2
+
+        ops_email = strategy.collect_operations({"username_type": "email"})
+        assert len(ops_email) == 0
+
+    def test_docker_strategy(self):
+        strategy = DockerStrategy()
+        ops_with_docker = strategy.collect_operations({
+            "use_docker": "y",
+            "cloud_provider": "AWS",
+        })
+        ops_no_docker = strategy.collect_operations({
+            "use_docker": "n",
+            "cloud_provider": "None",
+        })
+        assert len(ops_no_docker) > len(ops_with_docker)
+
+    def test_celery_strategy(self):
+        strategy = CeleryStrategy()
+        ops_no_celery = strategy.collect_operations({
+            "use_celery": "n",
+            "use_docker": "y",
+        })
+        ops_with_celery = strategy.collect_operations({
+            "use_celery": "y",
+            "use_docker": "y",
+        })
+        assert len(ops_no_celery) > len(ops_with_celery)
+
+    def test_ci_tool_strategy(self):
+        strategy = CiToolStrategy()
+        ops_none = strategy.collect_operations({"ci_tool": "None"})
+        ops_github = strategy.collect_operations({"ci_tool": "Github"})
+        assert len(ops_none) > len(ops_github)
+
+    def test_rest_api_strategy(self):
+        strategy = RestApiStrategy()
+        ops_none = strategy.collect_operations({"rest_api": "None"})
+        ops_drf = strategy.collect_operations({"rest_api": "DRF"})
+        ops_ninja = strategy.collect_operations({"rest_api": "Django Ninja"})
+        assert len(ops_none) > len(ops_drf)
+        assert len(ops_none) > len(ops_ninja)
+
+    def test_async_strategy(self):
+        strategy = AsyncStrategy()
+        ops_no_async = strategy.collect_operations({"use_async": "n"})
+        ops_async = strategy.collect_operations({"use_async": "y"})
+        assert len(ops_no_async) == 2
+        assert len(ops_async) == 0
+
+    def test_frontend_pipeline_strategy(self):
+        strategy = FrontendPipelineStrategy()
+        ops_none = strategy.collect_operations({
+            "frontend_pipeline": "None",
+            "use_docker": "y",
+            "use_async": "n",
+        })
+        assert len(ops_none) > 0
+
+    def test_all_strategies_produce_operations(self):
+        default_context = {
+            "open_source_license": "MIT",
+            "username_type": "email",
+            "editor": "None",
+            "use_docker": "n",
+            "cloud_provider": "None",
+            "use_heroku": "n",
+            "ci_tool": "None",
+            "keep_local_envs_in_vcs": "y",
+            "frontend_pipeline": "None",
+            "use_celery": "n",
+            "rest_api": "None",
+            "use_async": "n",
+            "debug": "y",
+        }
+
+        all_ops = []
+        for strategy_class in ALL_STRATEGIES:
+            strategy = strategy_class()
+            if strategy.should_apply(default_context):
+                ops = strategy.collect_operations(default_context)
+                all_ops.extend(ops)
+
+        assert len(all_ops) > 0
+
+
+class TestExecutionContext:
+    def test_two_phase_execution(self, working_directory):
+        f1 = Path("f1.txt")
+        f2 = Path("f2.txt")
+        f1.write_text("c1")
+        f2.write_text("c2")
+
+        ctx = ExecutionContext()
+
+        assert len(ctx.operations) == 0
+
+        ctx.add_operation(DeleteFileOperation(f1))
+        ctx.add_operation(DeleteFileOperation(f2))
+
+        assert len(ctx.operations) == 2
+        assert f1.exists()
+        assert f2.exists()
+
+        ctx.execute_all()
+
+        assert not f1.exists()
+        assert not f2.exists()
+
+    def test_report_generation_after_execution(self, working_directory):
+        f1 = Path("report_test.txt")
+        f1.write_text("test")
+
+        ctx = ExecutionContext()
+        ctx.add_operation(DeleteFileOperation(f1))
+        ctx.execute_all()
+
+        report = ctx.get_report()
+        assert report["summary"]["total_operations"] == 1
+        assert report["summary"]["successful"] == 1
+        assert "delete_file" in report["operations_by_type"]
+
+
+@pytest.fixture
+def working_directory(tmp_path):
+    prev_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(prev_cwd)

--- a/tests/test_refactored_architecture.py
+++ b/tests/test_refactored_architecture.py
@@ -1,41 +1,28 @@
 """Tests for the refactored architecture: audit, operations, strategies, rollback"""
 
-import json
 import os
-import subprocess
 from pathlib import Path
 
 import pytest
 
-from hooks.core import (
-    AppendFileOperation,
-    AuditLog,
-    DeleteDirOperation,
-    DeleteFileOperation,
-    DryRunExecutor,
-    ExecutionContext,
-    FailureStrategy,
-    ModifyFileOperation,
-    RealExecutor,
-    RollbackManager,
-    RunCommandOperation,
-    SetFlagOperation,
-)
-from hooks.strategies import (
-    ALL_STRATEGIES,
-    AsyncStrategy,
-    CeleryStrategy,
-    CiToolStrategy,
-    DockerStrategy,
-    EnvsStrategy,
-    FrontendPipelineStrategy,
-    HerokuStrategy,
-    LicenseStrategy,
-    RestApiStrategy,
-    SecretGenerationStrategy,
-    SetupDependenciesStrategy,
-    UsernameTypeStrategy,
-)
+from hooks.core import AppendFileOperation
+from hooks.core import AuditLog
+from hooks.core import DeleteDirOperation
+from hooks.core import DeleteFileOperation
+from hooks.core import ExecutionContext
+from hooks.core import FailureStrategy
+from hooks.core import ModifyFileOperation
+from hooks.core import RealExecutor
+from hooks.core import SetFlagOperation
+from hooks.strategies import ALL_STRATEGIES
+from hooks.strategies import AsyncStrategy
+from hooks.strategies import CeleryStrategy
+from hooks.strategies import CiToolStrategy
+from hooks.strategies import DockerStrategy
+from hooks.strategies import FrontendPipelineStrategy
+from hooks.strategies import LicenseStrategy
+from hooks.strategies import RestApiStrategy
+from hooks.strategies import UsernameTypeStrategy
 
 
 class TestAuditLog:
@@ -43,7 +30,8 @@ class TestAuditLog:
         audit = AuditLog()
         assert len(audit.entries) == 0
 
-        from hooks.core import AuditEntry, OperationType
+        from hooks.core import AuditEntry
+        from hooks.core import OperationType
 
         entry = AuditEntry(
             operation_type=OperationType.DELETE_FILE,
@@ -56,7 +44,8 @@ class TestAuditLog:
 
     def test_generate_report_summary(self):
         audit = AuditLog()
-        from hooks.core import AuditEntry, OperationType
+        from hooks.core import AuditEntry
+        from hooks.core import OperationType
 
         audit.record(AuditEntry(OperationType.DELETE_FILE, "f1.txt", success=True))
         audit.record(AuditEntry(OperationType.DELETE_FILE, "f2.txt", success=True))
@@ -249,26 +238,34 @@ class TestStrategies:
 
     def test_docker_strategy(self):
         strategy = DockerStrategy()
-        ops_with_docker = strategy.collect_operations({
-            "use_docker": "y",
-            "cloud_provider": "AWS",
-        })
-        ops_no_docker = strategy.collect_operations({
-            "use_docker": "n",
-            "cloud_provider": "None",
-        })
+        ops_with_docker = strategy.collect_operations(
+            {
+                "use_docker": "y",
+                "cloud_provider": "AWS",
+            }
+        )
+        ops_no_docker = strategy.collect_operations(
+            {
+                "use_docker": "n",
+                "cloud_provider": "None",
+            }
+        )
         assert len(ops_no_docker) > len(ops_with_docker)
 
     def test_celery_strategy(self):
         strategy = CeleryStrategy()
-        ops_no_celery = strategy.collect_operations({
-            "use_celery": "n",
-            "use_docker": "y",
-        })
-        ops_with_celery = strategy.collect_operations({
-            "use_celery": "y",
-            "use_docker": "y",
-        })
+        ops_no_celery = strategy.collect_operations(
+            {
+                "use_celery": "n",
+                "use_docker": "y",
+            }
+        )
+        ops_with_celery = strategy.collect_operations(
+            {
+                "use_celery": "y",
+                "use_docker": "y",
+            }
+        )
         assert len(ops_no_celery) > len(ops_with_celery)
 
     def test_ci_tool_strategy(self):
@@ -294,11 +291,13 @@ class TestStrategies:
 
     def test_frontend_pipeline_strategy(self):
         strategy = FrontendPipelineStrategy()
-        ops_none = strategy.collect_operations({
-            "frontend_pipeline": "None",
-            "use_docker": "y",
-            "use_async": "n",
-        })
+        ops_none = strategy.collect_operations(
+            {
+                "frontend_pipeline": "None",
+                "use_docker": "y",
+                "use_async": "n",
+            }
+        )
         assert len(ops_none) > 0
 
     def test_all_strategies_produce_operations(self):


### PR DESCRIPTION
我现在有一个重构需求：
1. 操作可审计化 问题 ：现在整个生成过程是"黑盒"，做完了什么操作用户完全不知道 重构方向 ：
给所有变更操作增加 审计追踪 能力
任何文件删除、内容修改、命令执行，都要被记录下来
最终输出一份"变更清单报告"（删了N个文件，改了M个配置）
支持后续"回滚"可能性的设计
2. 依赖去硬编码化 问题 ：逻辑和执行方式强耦合 重构方向 ：
把"要做什么"和"实际怎么执行"彻底分开
比如"删除文件"这个动作，可以有真实执行、打印模拟、记录日志三种实现
业务逻辑只声明"我要删除A"，不关心具体是谁来删、怎么删
3. 错误自愈能力 问题 ：任何一步出错就整个流程崩溃，前面做的改动都遗留一半 重构方向 ：
引入补偿机制：第一步成功了，第二步失败，自动回滚第一步的操作
定义清晰的失败策略：遇到错误是立刻中止？还是跳过继续？还是回滚全部？
支持失败后从中断处继续执行，而不是从头再来
4. 条件判断去分支化 问题 ：大量 if/elif/else 判断用户选择 重构方向 ：
把每一个"特性选项"变成一个 独立的策略对象
比如 UseDocker、UseCelery、UseWebpack 各是一个策略类
每个策略自己声明：我要删什么文件、改什么配置、加什么依赖
主流程只负责按用户选择组装要执行的策略列表，再也没有 if
 5. 副作用隔离 问题 ：纯计算逻辑和文件系统操作混在一起 重构方向 ：
严格划分"纯函数"和"有副作用的操作"
第一步：所有决策逻辑都在内存中完成（计算"最终应该删哪些文件"）
第二步：统一执行所有副作用
两阶段之间可以插入：预览、人工确认、dry-run 等能力

约束：
1.只修改与代码重构直接相关的代码
2 必须为重构完的代码新增专门的测试用例

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
