### PR TITLE
这是一个 现代化 Django 项目生成器模板 ，基于 Cookiecutter 构建，可以一键生成生产级别的 Django 项目脚手架。

### DIFF
--- a/hooks/core/__init__.py
+++ b/hooks/core/__init__.py
@@ -1,8 +1,8 @@
 from hooks.core.actions import Action
 from hooks.core.actions import AppendFileAction
 from hooks.core.actions import CreateDirectoryAction
-from hooks.core.actions import DeleteFileAction
 from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
 from hooks.core.actions import ModifyFileAction
 from hooks.core.actions import RunCommandAction
 from hooks.core.audit import AuditEntry
@@ -15,17 +15,17 @@ from hooks.core.strategies import FeatureStrategy
 
 __all__ = [
     "Action",
+    "ActionExecutor",
     "AppendFileAction",
-    "CreateDirectoryAction",
-    "DeleteFileAction",
-    "DeleteDirectoryAction",
-    "ModifyFileAction",
-    "RunCommandAction",
     "AuditEntry",
     "AuditLogger",
     "AuditReport",
+    "CreateDirectoryAction",
+    "DeleteDirectoryAction",
+    "DeleteFileAction",
     "ExecutionContext",
     "FailurePolicy",
-    "ActionExecutor",
     "FeatureStrategy",
+    "ModifyFileAction",
+    "RunCommandAction",
 ]

--- a/hooks/core/__init__.py
+++ b/hooks/core/__init__.py
@@ -1,0 +1,31 @@
+from hooks.core.actions import Action
+from hooks.core.actions import AppendFileAction
+from hooks.core.actions import CreateDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import ModifyFileAction
+from hooks.core.actions import RunCommandAction
+from hooks.core.audit import AuditEntry
+from hooks.core.audit import AuditLogger
+from hooks.core.audit import AuditReport
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
+from hooks.core.executor import ActionExecutor
+from hooks.core.strategies import FeatureStrategy
+
+__all__ = [
+    "Action",
+    "AppendFileAction",
+    "CreateDirectoryAction",
+    "DeleteFileAction",
+    "DeleteDirectoryAction",
+    "ModifyFileAction",
+    "RunCommandAction",
+    "AuditEntry",
+    "AuditLogger",
+    "AuditReport",
+    "ExecutionContext",
+    "FailurePolicy",
+    "ActionExecutor",
+    "FeatureStrategy",
+]

--- a/hooks/core/actions.py
+++ b/hooks/core/actions.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ActionType(Enum):
+    DELETE_FILE = "delete_file"
+    DELETE_DIRECTORY = "delete_directory"
+    CREATE_DIRECTORY = "create_directory"
+    MODIFY_FILE = "modify_file"
+    APPEND_FILE = "append_file"
+    RUN_COMMAND = "run_command"
+
+
+@dataclass
+class ActionResult:
+    success: bool
+    message: str = ""
+    error: str | None = None
+    backup_data: Any = None
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+class Action(ABC):
+    action_type: ActionType
+    description: str = ""
+
+    @abstractmethod
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        pass
+
+    @abstractmethod
+    def rollback(self, backup_data: Any = None) -> ActionResult:
+        pass
+
+    def describe(self) -> str:
+        return self.description or f"{self.action_type.value}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.action_type.value,
+            "description": self.description,
+        }
+
+
+@dataclass
+class DeleteFileAction(Action):
+    file_path: Path
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.DELETE_FILE, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Delete file: {self.file_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if not self.file_path.exists():
+            return ActionResult(
+                success=True,
+                message=f"File {self.file_path} does not exist, skipping",
+            )
+
+        backup_data = None
+        if not dry_run:
+            backup_data = self.file_path.read_bytes()
+            self.file_path.unlink()
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Deleted file: {self.file_path}",
+            backup_data=backup_data,
+        )
+
+    def rollback(self, backup_data: bytes | None = None) -> ActionResult:
+        if backup_data is None:
+            return ActionResult(
+                success=True,
+                message=f"No backup data for {self.file_path}, skipping rollback",
+            )
+
+        try:
+            self.file_path.parent.mkdir(parents=True, exist_ok=True)
+            self.file_path.write_bytes(backup_data)
+            return ActionResult(
+                success=True,
+                message=f"Restored file: {self.file_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to restore file: {self.file_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "file_path": str(self.file_path),
+        }
+
+
+@dataclass
+class DeleteDirectoryAction(Action):
+    dir_path: Path
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.DELETE_DIRECTORY, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Delete directory: {self.dir_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if not self.dir_path.exists():
+            return ActionResult(
+                success=True,
+                message=f"Directory {self.dir_path} does not exist, skipping",
+            )
+
+        backup_data = None
+        if not dry_run:
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp:
+                backup_path = Path(tmp.name)
+            shutil.make_archive(str(backup_path.with_suffix("")), "tar", self.dir_path)
+            backup_data = backup_path.with_suffix(".tar").read_bytes()
+            backup_path.with_suffix(".tar").unlink()
+            shutil.rmtree(self.dir_path)
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Deleted directory: {self.dir_path}",
+            backup_data=backup_data,
+        )
+
+    def rollback(self, backup_data: bytes | None = None) -> ActionResult:
+        if backup_data is None:
+            return ActionResult(
+                success=True,
+                message=f"No backup data for {self.dir_path}, skipping rollback",
+            )
+
+        try:
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp:
+                tmp.write(backup_data)
+                backup_path = Path(tmp.name)
+
+            shutil.unpack_archive(str(backup_path), self.dir_path.parent)
+            backup_path.unlink()
+            return ActionResult(
+                success=True,
+                message=f"Restored directory: {self.dir_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to restore directory: {self.dir_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "dir_path": str(self.dir_path),
+        }
+
+
+@dataclass
+class CreateDirectoryAction(Action):
+    dir_path: Path
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.CREATE_DIRECTORY, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Create directory: {self.dir_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if self.dir_path.exists():
+            return ActionResult(
+                success=True,
+                message=f"Directory {self.dir_path} already exists, skipping",
+            )
+
+        if not dry_run:
+            self.dir_path.mkdir(parents=True, exist_ok=True)
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Created directory: {self.dir_path}",
+        )
+
+    def rollback(self, backup_data: Any = None) -> ActionResult:
+        try:
+            if self.dir_path.exists():
+                shutil.rmtree(self.dir_path)
+            return ActionResult(
+                success=True,
+                message=f"Removed directory: {self.dir_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to remove directory: {self.dir_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "dir_path": str(self.dir_path),
+        }
+
+
+@dataclass
+class ModifyFileAction(Action):
+    file_path: Path
+    modifications: dict[str, str]
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.MODIFY_FILE, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Modify file: {self.file_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if not self.file_path.exists():
+            return ActionResult(
+                success=False,
+                error=f"File {self.file_path} does not exist",
+            )
+
+        backup_data = None
+        if not dry_run:
+            backup_data = self.file_path.read_text()
+            content = backup_data
+            for old_str, new_str in self.modifications.items():
+                content = content.replace(old_str, new_str)
+            self.file_path.write_text(content)
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Modified file: {self.file_path}",
+            backup_data=backup_data,
+        )
+
+    def rollback(self, backup_data: str | None = None) -> ActionResult:
+        if backup_data is None:
+            return ActionResult(
+                success=True,
+                message=f"No backup data for {self.file_path}, skipping rollback",
+            )
+
+        try:
+            self.file_path.write_text(backup_data)
+            return ActionResult(
+                success=True,
+                message=f"Restored file content: {self.file_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to restore file: {self.file_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "file_path": str(self.file_path),
+            "modifications": self.modifications,
+        }
+
+
+@dataclass
+class AppendFileAction(Action):
+    file_path: Path
+    content: str
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.APPEND_FILE, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Append to file: {self.file_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        backup_data = None
+        if self.file_path.exists():
+            backup_data = self.file_path.read_text()
+
+        if not dry_run:
+            with self.file_path.open("a") as f:
+                f.write(self.content)
+                if not self.content.endswith("\n"):
+                    f.write("\n")
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Appended to file: {self.file_path}",
+            backup_data=backup_data,
+        )
+
+    def rollback(self, backup_data: str | None = None) -> ActionResult:
+        try:
+            if backup_data is None:
+                if self.file_path.exists():
+                    self.file_path.unlink()
+            else:
+                self.file_path.write_text(backup_data)
+            return ActionResult(
+                success=True,
+                message=f"Restored file: {self.file_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to restore file: {self.file_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "file_path": str(self.file_path),
+            "content": self.content,
+        }
+
+
+@dataclass
+class RunCommandAction(Action):
+    command: list[str]
+    cwd: Path | None = None
+    env: dict[str, str] | None = None
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.RUN_COMMAND, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Run command: {' '.join(self.command)}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if dry_run:
+            return ActionResult(
+                success=True,
+                message=f"[DRY-RUN] Would run: {' '.join(self.command)}",
+            )
+
+        try:
+            result = subprocess.run(
+                self.command,
+                capture_output=True,
+                text=True,
+                cwd=str(self.cwd) if self.cwd else None,
+                env={**dict(__import__("os").environ), **(self.env or {})},
+                check=True,
+            )
+            return ActionResult(
+                success=True,
+                message=f"Command executed: {' '.join(self.command)}",
+                backup_data={"stdout": result.stdout, "stderr": result.stderr},
+            )
+        except subprocess.CalledProcessError as e:
+            return ActionResult(
+                success=False,
+                error=f"Command failed with code {e.returncode}: {e.stderr}",
+                message=f"Failed to run: {' '.join(self.command)}",
+            )
+
+    def rollback(self, backup_data: Any = None) -> ActionResult:
+        return ActionResult(
+            success=True,
+            message="Command actions cannot be rolled back automatically",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "command": self.command,
+            "cwd": str(self.cwd) if self.cwd else None,
+        }
+
+
+@dataclass
+class ModifyJsonFileAction(Action):
+    file_path: Path
+    remove_dev_deps: list[str] = field(default_factory=list)
+    remove_keys: list[str] = field(default_factory=list)
+    update_scripts: dict[str, str] = field(default_factory=dict)
+    description: str = ""
+    action_type: ActionType = field(default=ActionType.MODIFY_FILE, init=False)
+
+    def __post_init__(self):
+        if not self.description:
+            self.description = f"Modify JSON file: {self.file_path}"
+
+    def execute(self, dry_run: bool = False) -> ActionResult:
+        if not self.file_path.exists():
+            return ActionResult(
+                success=False,
+                error=f"File {self.file_path} does not exist",
+            )
+
+        backup_data = None
+        if not dry_run:
+            backup_data = self.file_path.read_text()
+            content = json.loads(backup_data)
+
+            for package_name in self.remove_dev_deps:
+                content.get("devDependencies", {}).pop(package_name, None)
+
+            for key in self.remove_keys:
+                content.pop(key, None)
+
+            content.get("scripts", {}).update(self.update_scripts)
+
+            updated_content = json.dumps(content, ensure_ascii=False, indent=2) + "\n"
+            self.file_path.write_text(updated_content)
+
+        return ActionResult(
+            success=True,
+            message=f"{'[DRY-RUN] ' if dry_run else ''}Modified JSON file: {self.file_path}",
+            backup_data=backup_data,
+        )
+
+    def rollback(self, backup_data: str | None = None) -> ActionResult:
+        if backup_data is None:
+            return ActionResult(
+                success=True,
+                message=f"No backup data for {self.file_path}, skipping rollback",
+            )
+
+        try:
+            self.file_path.write_text(backup_data)
+            return ActionResult(
+                success=True,
+                message=f"Restored JSON file: {self.file_path}",
+            )
+        except Exception as e:
+            return ActionResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to restore JSON file: {self.file_path}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "file_path": str(self.file_path),
+            "remove_dev_deps": self.remove_dev_deps,
+            "remove_keys": self.remove_keys,
+            "update_scripts": self.update_scripts,
+        }

--- a/hooks/core/audit.py
+++ b/hooks/core/audit.py
@@ -149,8 +149,8 @@ class AuditReport:
                 "",
                 "## Summary",
                 "",
-                f"| Metric | Count |",
-                f"|--------|-------|",
+                "| Metric | Count |",
+                "|--------|-------|",
                 f"| Total Actions | {self.total_actions} |",
                 f"| Successful | {self.successful_actions} |",
                 f"| Failed | {self.failed_actions} |",
@@ -162,7 +162,7 @@ class AuditReport:
                 "",
                 "## Detailed Actions",
                 "",
-            ]
+            ],
         )
 
         for entry in self.entries:

--- a/hooks/core/audit.py
+++ b/hooks/core/audit.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from hooks.core.actions import Action
+from hooks.core.actions import ActionResult
+
+
+class AuditStatus(Enum):
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+    ROLLED_BACK = "rolled_back"
+
+
+@dataclass
+class AuditEntry:
+    action: Action
+    result: ActionResult | None = None
+    status: AuditStatus = AuditStatus.PENDING
+    timestamp: datetime = field(default_factory=datetime.now)
+    rollback_result: ActionResult | None = None
+    sequence_number: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sequence_number": self.sequence_number,
+            "action": self.action.to_dict(),
+            "status": self.status.value,
+            "timestamp": self.timestamp.isoformat(),
+            "result": {
+                "success": self.result.success,
+                "message": self.result.message,
+                "error": self.result.error,
+            }
+            if self.result
+            else None,
+            "rollback_result": {
+                "success": self.rollback_result.success,
+                "message": self.rollback_result.message,
+                "error": self.rollback_result.error,
+            }
+            if self.rollback_result
+            else None,
+        }
+
+
+@dataclass
+class AuditReport:
+    entries: list[AuditEntry] = field(default_factory=list)
+    start_time: datetime = field(default_factory=datetime.now)
+    end_time: datetime | None = None
+    project_name: str = ""
+
+    @property
+    def total_actions(self) -> int:
+        return len(self.entries)
+
+    @property
+    def successful_actions(self) -> int:
+        return sum(1 for e in self.entries if e.status == AuditStatus.SUCCESS)
+
+    @property
+    def failed_actions(self) -> int:
+        return sum(1 for e in self.entries if e.status == AuditStatus.FAILED)
+
+    @property
+    def rolled_back_actions(self) -> int:
+        return sum(1 for e in self.entries if e.status == AuditStatus.ROLLED_BACK)
+
+    @property
+    def files_deleted(self) -> int:
+        from hooks.core.actions import ActionType
+
+        return sum(
+            1
+            for e in self.entries
+            if e.action.action_type == ActionType.DELETE_FILE and e.status == AuditStatus.SUCCESS
+        )
+
+    @property
+    def directories_deleted(self) -> int:
+        from hooks.core.actions import ActionType
+
+        return sum(
+            1
+            for e in self.entries
+            if e.action.action_type == ActionType.DELETE_DIRECTORY and e.status == AuditStatus.SUCCESS
+        )
+
+    @property
+    def files_modified(self) -> int:
+        from hooks.core.actions import ActionType
+
+        return sum(
+            1
+            for e in self.entries
+            if e.action.action_type in (ActionType.MODIFY_FILE, ActionType.APPEND_FILE)
+            and e.status == AuditStatus.SUCCESS
+        )
+
+    @property
+    def commands_executed(self) -> int:
+        from hooks.core.actions import ActionType
+
+        return sum(
+            1
+            for e in self.entries
+            if e.action.action_type == ActionType.RUN_COMMAND and e.status == AuditStatus.SUCCESS
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_name": self.project_name,
+            "start_time": self.start_time.isoformat(),
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "summary": {
+                "total_actions": self.total_actions,
+                "successful": self.successful_actions,
+                "failed": self.failed_actions,
+                "rolled_back": self.rolled_back_actions,
+                "files_deleted": self.files_deleted,
+                "directories_deleted": self.directories_deleted,
+                "files_modified": self.files_modified,
+                "commands_executed": self.commands_executed,
+            },
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# Project Generation Report",
+            "",
+            f"**Project:** {self.project_name}",
+            f"**Started:** {self.start_time.strftime('%Y-%m-%d %H:%M:%S')}",
+        ]
+
+        if self.end_time:
+            lines.append(f"**Finished:** {self.end_time.strftime('%Y-%m-%d %H:%M:%S')}")
+            duration = (self.end_time - self.start_time).total_seconds()
+            lines.append(f"**Duration:** {duration:.2f} seconds")
+
+        lines.extend(
+            [
+                "",
+                "## Summary",
+                "",
+                f"| Metric | Count |",
+                f"|--------|-------|",
+                f"| Total Actions | {self.total_actions} |",
+                f"| Successful | {self.successful_actions} |",
+                f"| Failed | {self.failed_actions} |",
+                f"| Rolled Back | {self.rolled_back_actions} |",
+                f"| Files Deleted | {self.files_deleted} |",
+                f"| Directories Deleted | {self.directories_deleted} |",
+                f"| Files Modified | {self.files_modified} |",
+                f"| Commands Executed | {self.commands_executed} |",
+                "",
+                "## Detailed Actions",
+                "",
+            ]
+        )
+
+        for entry in self.entries:
+            status_icon = {
+                AuditStatus.SUCCESS: "✅",
+                AuditStatus.FAILED: "❌",
+                AuditStatus.ROLLED_BACK: "↩️",
+                AuditStatus.PENDING: "⏳",
+            }.get(entry.status, "❓")
+
+            lines.append(f"### {status_icon} {entry.action.describe()}")
+            lines.append(f"- **Type:** `{entry.action.action_type.value}`")
+            lines.append(f"- **Status:** {entry.status.value}")
+
+            if entry.result:
+                lines.append(f"- **Message:** {entry.result.message}")
+                if entry.result.error:
+                    lines.append(f"- **Error:** {entry.result.error}")
+
+            if entry.rollback_result:
+                lines.append(f"- **Rollback:** {entry.rollback_result.message}")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+class AuditLogger:
+    def __init__(self, project_name: str = ""):
+        self.report = AuditReport(project_name=project_name)
+        self._sequence = 0
+
+    def log_action(self, action: Action) -> AuditEntry:
+        self._sequence += 1
+        entry = AuditEntry(action=action, sequence_number=self._sequence)
+        self.report.entries.append(entry)
+        return entry
+
+    def log_result(self, entry: AuditEntry, result: ActionResult) -> None:
+        entry.result = result
+        entry.status = AuditStatus.SUCCESS if result.success else AuditStatus.FAILED
+
+    def log_rollback(self, entry: AuditEntry, result: ActionResult) -> None:
+        entry.rollback_result = result
+        if result.success:
+            entry.status = AuditStatus.ROLLED_BACK
+
+    def finalize(self) -> AuditReport:
+        self.report.end_time = datetime.now()
+        return self.report
+
+    def get_successful_entries(self) -> list[AuditEntry]:
+        return [e for e in self.report.entries if e.status == AuditStatus.SUCCESS]
+
+    def get_failed_entries(self) -> list[AuditEntry]:
+        return [e for e in self.report.entries if e.status == AuditStatus.FAILED]

--- a/hooks/core/context.py
+++ b/hooks/core/context.py
@@ -6,8 +6,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from hooks.core.actions import Action
-from hooks.core.actions import ActionResult
 from hooks.core.audit import AuditEntry
 from hooks.core.audit import AuditLogger
 

--- a/hooks/core/context.py
+++ b/hooks/core/context.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from hooks.core.actions import Action
+from hooks.core.actions import ActionResult
+from hooks.core.audit import AuditEntry
+from hooks.core.audit import AuditLogger
+
+
+class FailurePolicy(Enum):
+    STOP_IMMEDIATELY = "stop_immediately"
+    CONTINUE_ON_ERROR = "continue_on_error"
+    ROLLBACK_ALL = "rollback_all"
+    ROLLBACK_FAILED = "rollback_failed"
+
+
+@dataclass
+class Checkpoint:
+    sequence_number: int
+    entry: AuditEntry
+    backup_data: Any
+
+
+@dataclass
+class ExecutionContext:
+    project_slug: str
+    cookiecutter_config: dict[str, Any] = field(default_factory=dict)
+    failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY
+    dry_run: bool = False
+    audit_logger: AuditLogger = field(default_factory=AuditLogger)
+    checkpoints: list[Checkpoint] = field(default_factory=list)
+    last_successful_checkpoint: int = 0
+    _backup_store: dict[int, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.audit_logger.report.project_name = self.project_slug
+
+    def get_config(self, key: str, default: Any = None) -> Any:
+        return self.cookiecutter_config.get(key, default)
+
+    def is_enabled(self, key: str) -> bool:
+        value = self.get_config(key, "n")
+        return str(value).lower() in ("y", "yes", "true", "1")
+
+    def equals(self, key: str, value: str) -> bool:
+        return str(self.get_config(key, "")).lower() == value.lower()
+
+    def create_checkpoint(self, entry: AuditEntry, backup_data: Any) -> Checkpoint:
+        checkpoint = Checkpoint(
+            sequence_number=entry.sequence_number,
+            entry=entry,
+            backup_data=backup_data,
+        )
+        self.checkpoints.append(checkpoint)
+        self._backup_store[entry.sequence_number] = backup_data
+        return checkpoint
+
+    def get_backup(self, sequence_number: int) -> Any:
+        return self._backup_store.get(sequence_number)
+
+    def get_checkpoints_for_rollback(self) -> list[Checkpoint]:
+        return [cp for cp in reversed(self.checkpoints) if cp.backup_data is not None]
+
+    def mark_success(self, sequence_number: int) -> None:
+        self.last_successful_checkpoint = sequence_number
+
+    def get_report(self) -> str:
+        report = self.audit_logger.finalize()
+        return report.to_markdown()
+
+    def get_json_report(self) -> dict[str, Any]:
+        report = self.audit_logger.finalize()
+        return report.to_dict()
+
+    def save_report(self, output_path: Path) -> None:
+        report = self.audit_logger.finalize()
+        output_path.write_text(report.to_markdown(), encoding="utf-8")
+
+    def save_json_report(self, output_path: Path) -> None:
+        import json
+
+        report = self.audit_logger.finalize()
+        output_path.write_text(
+            json.dumps(report.to_dict(), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )

--- a/hooks/core/executor.py
+++ b/hooks/core/executor.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
 import dataclasses
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from hooks.core.actions import Action
 from hooks.core.actions import ActionResult
-from hooks.core.audit import AuditEntry
-from hooks.core.context import Checkpoint
 from hooks.core.context import ExecutionContext
 from hooks.core.context import FailurePolicy
-
 
 TERMINATOR = "\x1b[0m"
 WARNING = "\x1b[1;33m [WARNING]: "
@@ -139,11 +135,7 @@ class ActionExecutor:
         return rolled_back
 
     def rollback_from(self, sequence_number: int) -> int:
-        checkpoints = [
-            cp
-            for cp in self.context.checkpoints
-            if cp.sequence_number >= sequence_number
-        ]
+        checkpoints = [cp for cp in self.context.checkpoints if cp.sequence_number >= sequence_number]
         rolled_back = 0
 
         for checkpoint in reversed(checkpoints):
@@ -201,5 +193,7 @@ class ResumableExecutor(ActionExecutor):
             print(f"{SUCCESS}Generation already complete, nothing to resume{TERMINATOR}")
             return ExecutionResult(success=True, message="Generation already complete")
 
-        print(f"{INFO}Resuming from checkpoint {last_checkpoint}, {len(remaining_actions)} actions remaining{TERMINATOR}")
+        print(
+            f"{INFO}Resuming from checkpoint {last_checkpoint}, {len(remaining_actions)} actions remaining{TERMINATOR}"
+        )
         return self._execute_with_policy(remaining_actions)

--- a/hooks/core/executor.py
+++ b/hooks/core/executor.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import dataclasses
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hooks.core.actions import Action
+from hooks.core.actions import ActionResult
+from hooks.core.audit import AuditEntry
+from hooks.core.context import Checkpoint
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
+
+
+TERMINATOR = "\x1b[0m"
+WARNING = "\x1b[1;33m [WARNING]: "
+INFO = "\x1b[1;33m [INFO]: "
+SUCCESS = "\x1b[1;32m [SUCCESS]: "
+ERROR = "\x1b[1;31m [ERROR]: "
+
+
+@dataclass
+class ExecutionResult:
+    success: bool
+    message: str
+    rolled_back_count: int = 0
+    failed_actions: list[str] = dataclasses.field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
+class ActionExecutor:
+    def __init__(self, context: ExecutionContext):
+        self.context = context
+
+    def execute(self, actions: list[Action]) -> ExecutionResult:
+        if not actions:
+            return ExecutionResult(success=True, message="No actions to execute")
+
+        print(f"{INFO}Planning {len(actions)} actions...{TERMINATOR}")
+
+        if self.context.dry_run:
+            return self._dry_run(actions)
+
+        return self._execute_with_policy(actions)
+
+    def _dry_run(self, actions: list[Action]) -> ExecutionResult:
+        print(f"{INFO}Dry-run mode: simulating {len(actions)} actions{TERMINATOR}")
+
+        for i, action in enumerate(actions, 1):
+            print(f"  [{i}/{len(actions)}] {action.describe()}")
+
+        return ExecutionResult(
+            success=True,
+            message=f"Dry-run complete: {len(actions)} actions would be executed",
+        )
+
+    def _execute_with_policy(self, actions: list[Action]) -> ExecutionResult:
+        failed_actions: list[str] = []
+        last_successful_idx = -1
+
+        for i, action in enumerate(actions):
+            result = self._execute_single(action)
+
+            if not result.success:
+                failed_actions.append(action.describe())
+
+                if self.context.failure_policy == FailurePolicy.STOP_IMMEDIATELY:
+                    print(f"{ERROR}Action failed: {action.describe()}{TERMINATOR}")
+                    print(f"{ERROR}{result.error}{TERMINATOR}")
+                    return ExecutionResult(
+                        success=False,
+                        message=f"Execution stopped at action {i + 1}/{len(actions)}",
+                        failed_actions=failed_actions,
+                    )
+
+                if self.context.failure_policy == FailurePolicy.ROLLBACK_ALL:
+                    print(f"{ERROR}Action failed, rolling back all changes...{TERMINATOR}")
+                    rolled_back = self._rollback_all()
+                    return ExecutionResult(
+                        success=False,
+                        message=f"Execution failed, rolled back {rolled_back} actions",
+                        rolled_back_count=rolled_back,
+                        failed_actions=failed_actions,
+                    )
+
+                if self.context.failure_policy == FailurePolicy.ROLLBACK_FAILED:
+                    print(f"{WARNING}Action failed, continuing...{TERMINATOR}")
+            else:
+                last_successful_idx = i
+
+        if failed_actions:
+            if self.context.failure_policy == FailurePolicy.CONTINUE_ON_ERROR:
+                print(f"{WARNING}{len(failed_actions)} actions failed but execution continued{TERMINATOR}")
+                return ExecutionResult(
+                    success=True,
+                    message=f"Completed with {len(failed_actions)} failures",
+                    failed_actions=failed_actions,
+                )
+
+        return ExecutionResult(
+            success=True,
+            message=f"All {len(actions)} actions executed successfully",
+        )
+
+    def _execute_single(self, action: Action) -> ActionResult:
+        entry = self.context.audit_logger.log_action(action)
+
+        print(f"{INFO}Executing: {action.describe()}{TERMINATOR}")
+        result = action.execute(dry_run=False)
+
+        self.context.audit_logger.log_result(entry, result)
+
+        if result.success and result.backup_data is not None:
+            self.context.create_checkpoint(entry, result.backup_data)
+            self.context.mark_success(entry.sequence_number)
+
+        return result
+
+    def _rollback_all(self) -> int:
+        checkpoints = self.context.get_checkpoints_for_rollback()
+        rolled_back = 0
+
+        print(f"{INFO}Rolling back {len(checkpoints)} actions...{TERMINATOR}")
+
+        for checkpoint in checkpoints:
+            rollback_result = checkpoint.entry.action.rollback(checkpoint.backup_data)
+
+            if rollback_result.success:
+                self.context.audit_logger.log_rollback(checkpoint.entry, rollback_result)
+                rolled_back += 1
+                print(f"  ↩️ Rolled back: {checkpoint.entry.action.describe()}")
+            else:
+                print(f"{WARNING}Failed to rollback: {checkpoint.entry.action.describe()}{TERMINATOR}")
+
+        return rolled_back
+
+    def rollback_from(self, sequence_number: int) -> int:
+        checkpoints = [
+            cp
+            for cp in self.context.checkpoints
+            if cp.sequence_number >= sequence_number
+        ]
+        rolled_back = 0
+
+        for checkpoint in reversed(checkpoints):
+            if checkpoint.backup_data is not None:
+                rollback_result = checkpoint.entry.action.rollback(checkpoint.backup_data)
+                if rollback_result.success:
+                    self.context.audit_logger.log_rollback(checkpoint.entry, rollback_result)
+                    rolled_back += 1
+
+        return rolled_back
+
+
+class ResumableExecutor(ActionExecutor):
+    def __init__(self, context: ExecutionContext, state_file: str = ".generation_state.json"):
+        super().__init__(context)
+        self.state_file = state_file
+
+    def save_state(self, last_sequence: int) -> None:
+        import json
+
+        state = {
+            "last_successful_checkpoint": last_sequence,
+            "project_slug": self.context.project_slug,
+            "checkpoints": [
+                {
+                    "sequence_number": cp.sequence_number,
+                    "action": cp.entry.action.to_dict(),
+                }
+                for cp in self.context.checkpoints
+            ],
+        }
+        Path(self.state_file).write_text(json.dumps(state, indent=2))
+
+    def load_state(self) -> dict[str, Any] | None:
+        import json
+
+        state_path = Path(self.state_file)
+        if state_path.exists():
+            return json.loads(state_path.read_text())
+        return None
+
+    def can_resume(self) -> bool:
+        state = self.load_state()
+        return state is not None and state.get("last_successful_checkpoint", 0) > 0
+
+    def resume(self, actions: list[Action]) -> ExecutionResult:
+        state = self.load_state()
+        if not state:
+            return self.execute(actions)
+
+        last_checkpoint = state.get("last_successful_checkpoint", 0)
+        remaining_actions = actions[last_checkpoint:]
+
+        if not remaining_actions:
+            print(f"{SUCCESS}Generation already complete, nothing to resume{TERMINATOR}")
+            return ExecutionResult(success=True, message="Generation already complete")
+
+        print(f"{INFO}Resuming from checkpoint {last_checkpoint}, {len(remaining_actions)} actions remaining{TERMINATOR}")
+        return self._execute_with_policy(remaining_actions)

--- a/hooks/core/strategies.py
+++ b/hooks/core/strategies.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from abc import ABC
+from abc import abstractmethod
+from typing import Any
+
+from hooks.core.actions import Action
+from hooks.core.context import ExecutionContext
+
+
+class FeatureStrategy(ABC):
+    name: str
+    description: str = ""
+
+    @abstractmethod
+    def should_apply(self, context: ExecutionContext) -> bool:
+        pass
+
+    @abstractmethod
+    def plan(self, context: ExecutionContext) -> list[Action]:
+        pass
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self.name}>"
+
+
+class CompositeStrategy(FeatureStrategy):
+    def __init__(self, strategies: list[FeatureStrategy]):
+        self.strategies = strategies
+        self.name = "composite"
+        self.description = "Composite strategy combining multiple strategies"
+
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return any(s.should_apply(context) for s in self.strategies)
+
+    def plan(self, context: ExecutionContext) -> list[Action]:
+        actions = []
+        for strategy in self.strategies:
+            if strategy.should_apply(context):
+                actions.extend(strategy.plan(context))
+        return actions
+
+
+class ConditionalStrategy(FeatureStrategy):
+    def __init__(
+        self,
+        condition: callable[[ExecutionContext], bool],
+        true_strategy: FeatureStrategy,
+        false_strategy: FeatureStrategy | None = None,
+    ):
+        self.condition = condition
+        self.true_strategy = true_strategy
+        self.false_strategy = false_strategy
+        self.name = f"conditional_{true_strategy.name}"
+
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list[Action]:
+        if self.condition(context):
+            return self.true_strategy.plan(context)
+        elif self.false_strategy:
+            return self.false_strategy.plan(context)
+        return []
+
+
+class StrategyRegistry:
+    _strategies: dict[str, type[FeatureStrategy]] = {}
+
+    @classmethod
+    def register(cls, strategy_class: type[FeatureStrategy]) -> type[FeatureStrategy]:
+        instance = strategy_class()
+        cls._strategies[instance.name] = strategy_class
+        return strategy_class
+
+    @classmethod
+    def get(cls, name: str) -> type[FeatureStrategy] | None:
+        return cls._strategies.get(name)
+
+    @classmethod
+    def get_all(cls) -> list[type[FeatureStrategy]]:
+        return list(cls._strategies.values())
+
+    @classmethod
+    def create_all(cls) -> list[FeatureStrategy]:
+        return [strategy_class() for strategy_class in cls._strategies.values()]
+
+
+def strategy(name: str, description: str = ""):
+    def decorator(cls: type[FeatureStrategy]) -> type[FeatureStrategy]:
+        cls.name = name
+        cls.description = description
+        return StrategyRegistry.register(cls)
+
+    return decorator

--- a/hooks/core/strategies.py
+++ b/hooks/core/strategies.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
-from typing import Any
 
 from hooks.core.actions import Action
 from hooks.core.context import ExecutionContext
@@ -59,7 +58,7 @@ class ConditionalStrategy(FeatureStrategy):
     def plan(self, context: ExecutionContext) -> list[Action]:
         if self.condition(context):
             return self.true_strategy.plan(context)
-        elif self.false_strategy:
+        if self.false_strategy:
             return self.false_strategy.plan(context)
         return []
 

--- a/hooks/generator.py
+++ b/hooks/generator.py
@@ -6,28 +6,22 @@ from pathlib import Path
 from typing import Any
 
 from hooks.core.actions import Action
-from hooks.core.actions import AppendFileAction
 from hooks.core.actions import DeleteDirectoryAction
 from hooks.core.actions import DeleteFileAction
-from hooks.core.actions import ModifyFileAction
-from hooks.core.actions import RunCommandAction
 from hooks.core.context import ExecutionContext
 from hooks.core.context import FailurePolicy
 from hooks.core.executor import ActionExecutor
 from hooks.core.strategies import FeatureStrategy
-from hooks.strategies import (
-    AsyncStrategy,
-    CeleryStrategy,
-    CIToolStrategy,
-    DockerStrategy,
-    EditorStrategy,
-    FrontendPipelineStrategy,
-    HerokuStrategy,
-    OpenSourceLicenseStrategy,
-    RestApiStrategy,
-    UsernameTypeStrategy,
-)
-
+from hooks.strategies import AsyncStrategy
+from hooks.strategies import CeleryStrategy
+from hooks.strategies import CIToolStrategy
+from hooks.strategies import DockerStrategy
+from hooks.strategies import EditorStrategy
+from hooks.strategies import FrontendPipelineStrategy
+from hooks.strategies import HerokuStrategy
+from hooks.strategies import OpenSourceLicenseStrategy
+from hooks.strategies import RestApiStrategy
+from hooks.strategies import UsernameTypeStrategy
 
 TERMINATOR = "\x1b[0m"
 WARNING = "\x1b[1;33m [WARNING]: "
@@ -45,7 +39,12 @@ except NotImplementedError:
 
 
 class ProjectGenerator:
-    def __init__(self, config: dict[str, Any], dry_run: bool = False, failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY):
+    def __init__(
+        self,
+        config: dict[str, Any],
+        dry_run: bool = False,
+        failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY,
+    ):
         self.config = config
         self.project_slug = config.get("project_slug", "project")
         self.context = ExecutionContext(
@@ -117,7 +116,7 @@ class ProjectGenerator:
                             dir_path=Path("tests"),
                             description="Remove tests directory (no Docker/Heroku)",
                         ),
-                    ]
+                    ],
                 )
 
         return actions

--- a/hooks/generator.py
+++ b/hooks/generator.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import random
+import string
+from pathlib import Path
+from typing import Any
+
+from hooks.core.actions import Action
+from hooks.core.actions import AppendFileAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import ModifyFileAction
+from hooks.core.actions import RunCommandAction
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
+from hooks.core.executor import ActionExecutor
+from hooks.core.strategies import FeatureStrategy
+from hooks.strategies import (
+    AsyncStrategy,
+    CeleryStrategy,
+    CIToolStrategy,
+    DockerStrategy,
+    EditorStrategy,
+    FrontendPipelineStrategy,
+    HerokuStrategy,
+    OpenSourceLicenseStrategy,
+    RestApiStrategy,
+    UsernameTypeStrategy,
+)
+
+
+TERMINATOR = "\x1b[0m"
+WARNING = "\x1b[1;33m [WARNING]: "
+INFO = "\x1b[1;33m [INFO]: "
+SUCCESS = "\x1b[1;32m [SUCCESS]: "
+ERROR = "\x1b[1;31m [ERROR]: "
+
+DEBUG_VALUE = "debug"
+
+try:
+    random = random.SystemRandom()
+    using_sysrandom = True
+except NotImplementedError:
+    using_sysrandom = False
+
+
+class ProjectGenerator:
+    def __init__(self, config: dict[str, Any], dry_run: bool = False, failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY):
+        self.config = config
+        self.project_slug = config.get("project_slug", "project")
+        self.context = ExecutionContext(
+            project_slug=self.project_slug,
+            cookiecutter_config=config,
+            dry_run=dry_run,
+            failure_policy=failure_policy,
+        )
+        self.executor = ActionExecutor(self.context)
+        self._strategies: list[FeatureStrategy] = []
+
+    def register_strategy(self, strategy: FeatureStrategy) -> None:
+        self._strategies.append(strategy)
+
+    def register_default_strategies(self) -> None:
+        self._strategies = [
+            OpenSourceLicenseStrategy(),
+            UsernameTypeStrategy(),
+            EditorStrategy(),
+            DockerStrategy(),
+            HerokuStrategy(),
+            FrontendPipelineStrategy(),
+            CeleryStrategy(),
+            CIToolStrategy(),
+            RestApiStrategy(),
+            AsyncStrategy(),
+        ]
+
+    def plan(self) -> list[Action]:
+        actions = []
+
+        actions.extend(self._plan_secret_generation())
+        actions.extend(self._plan_env_files())
+
+        for strategy in self._strategies:
+            if strategy.should_apply(self.context):
+                strategy_actions = strategy.plan(self.context)
+                actions.extend(strategy_actions)
+
+        actions.extend(self._plan_dependencies())
+
+        return actions
+
+    def _plan_secret_generation(self) -> list[Action]:
+        actions = []
+        debug = self.context.is_enabled("debug")
+
+        return actions
+
+    def _plan_env_files(self) -> list[Action]:
+        actions = []
+        use_docker = self.context.is_enabled("use_docker")
+        use_heroku = self.context.is_enabled("use_heroku")
+        keep_local_envs = self.context.is_enabled("keep_local_envs_in_vcs")
+
+        if not use_docker and not use_heroku:
+            if not keep_local_envs:
+                actions.extend(
+                    [
+                        DeleteDirectoryAction(
+                            dir_path=Path(".envs"),
+                            description="Remove .envs directory (no Docker/Heroku)",
+                        ),
+                        DeleteFileAction(
+                            file_path=Path("merge_production_dotenvs_in_dotenv.py"),
+                            description="Remove merge dotenvs script",
+                        ),
+                        DeleteDirectoryAction(
+                            dir_path=Path("tests"),
+                            description="Remove tests directory (no Docker/Heroku)",
+                        ),
+                    ]
+                )
+
+        return actions
+
+    def _plan_dependencies(self) -> list[Action]:
+        actions = []
+        use_docker = self.context.is_enabled("use_docker")
+
+        return actions
+
+    def execute(self) -> bool:
+        actions = self.plan()
+
+        print(f"{INFO}Planning {len(actions)} actions for project generation...{TERMINATOR}")
+
+        result = self.executor.execute(actions)
+
+        if result.success:
+            print(f"{SUCCESS}Project initialized, keep up the good work!{TERMINATOR}")
+        else:
+            print(f"{ERROR}Project generation failed: {result.message}{TERMINATOR}")
+            if result.failed_actions:
+                print(f"{ERROR}Failed actions: {', '.join(result.failed_actions)}{TERMINATOR}")
+
+        report_path = Path(".generation_report.md")
+        self.context.save_report(report_path)
+        print(f"{INFO}Generation report saved to {report_path}{TERMINATOR}")
+
+        return result.success
+
+    def preview(self) -> str:
+        actions = self.plan()
+        lines = [f"Project Generation Preview for '{self.project_slug}'", "=" * 50, ""]
+
+        for i, action in enumerate(actions, 1):
+            lines.append(f"{i}. {action.describe()}")
+
+        lines.extend(["", f"Total: {len(actions)} actions planned"])
+
+        return "\n".join(lines)
+
+    def get_report(self) -> str:
+        return self.context.get_report()
+
+    def get_json_report(self) -> dict[str, Any]:
+        return self.context.get_json_report()
+
+
+def generate_random_string(length, using_digits=False, using_ascii_letters=False, using_punctuation=False):
+    if not using_sysrandom:
+        return None
+
+    symbols = []
+    if using_digits:
+        symbols += string.digits
+    if using_ascii_letters:
+        symbols += string.ascii_letters
+    if using_punctuation:
+        all_punctuation = set(string.punctuation)
+        unsuitable = {"'", '"', "\\", "$"}
+        suitable = all_punctuation.difference(unsuitable)
+        symbols += "".join(suitable)
+    return "".join([random.choice(symbols) for _ in range(length)])
+
+
+def generate_random_user():
+    return generate_random_string(length=32, using_ascii_letters=True)
+
+
+def generate_postgres_user(debug=False):
+    return DEBUG_VALUE if debug else generate_random_user()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,9 +1,5 @@
-# ruff: noqa: PLR0133
-import os
 import random
-import shutil
 import string
-import subprocess
 import sys
 from pathlib import Path
 
@@ -80,7 +76,6 @@ class SecretGenerationStrategy(FeatureStrategy):
         return True
 
     def plan(self, context: ExecutionContext) -> list:
-        from hooks.core.actions import ModifyFileAction
 
         actions = []
 
@@ -102,14 +97,14 @@ class SecretGenerationStrategy(FeatureStrategy):
                 file_path=production_django_envs_path,
                 modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
                 description="Set Django secret key in production env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=production_django_envs_path,
                 modifications={"!!!SET DJANGO_ADMIN_URL!!!": self._generate_admin_url()},
                 description="Set Django admin URL in production env",
-            )
+            ),
         )
 
         postgres_password = DEBUG_VALUE if self.debug else self._generate_password()
@@ -118,28 +113,28 @@ class SecretGenerationStrategy(FeatureStrategy):
                 file_path=local_postgres_envs_path,
                 modifications={"!!!SET POSTGRES_USER!!!": self.postgres_user},
                 description="Set Postgres user in local env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=local_postgres_envs_path,
                 modifications={"!!!SET POSTGRES_PASSWORD!!!": postgres_password},
                 description="Set Postgres password in local env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=production_postgres_envs_path,
                 modifications={"!!!SET POSTGRES_USER!!!": self.postgres_user},
                 description="Set Postgres user in production env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=production_postgres_envs_path,
                 modifications={"!!!SET POSTGRES_PASSWORD!!!": postgres_password},
                 description="Set Postgres password in production env",
-            )
+            ),
         )
 
         celery_flower_password = DEBUG_VALUE if self.debug else self._generate_password()
@@ -148,28 +143,28 @@ class SecretGenerationStrategy(FeatureStrategy):
                 file_path=local_django_envs_path,
                 modifications={"!!!SET CELERY_FLOWER_USER!!!": self.celery_flower_user},
                 description="Set Celery Flower user in local env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=local_django_envs_path,
                 modifications={"!!!SET CELERY_FLOWER_PASSWORD!!!": celery_flower_password},
                 description="Set Celery Flower password in local env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=production_django_envs_path,
                 modifications={"!!!SET CELERY_FLOWER_USER!!!": self.celery_flower_user},
                 description="Set Celery Flower user in production env",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=production_django_envs_path,
                 modifications={"!!!SET CELERY_FLOWER_PASSWORD!!!": celery_flower_password},
                 description="Set Celery Flower password in production env",
-            )
+            ),
         )
 
         return actions
@@ -185,14 +180,14 @@ class SecretGenerationStrategy(FeatureStrategy):
                 file_path=local_settings_path,
                 modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
                 description="Set Django secret key in local settings",
-            )
+            ),
         )
         actions.append(
             ModifyFileAction(
                 file_path=test_settings_path,
                 modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
                 description="Set Django secret key in test settings",
-            )
+            ),
         )
 
         return actions
@@ -229,19 +224,19 @@ class EnvFilesStrategy(FeatureStrategy):
                     DeleteDirectoryAction(
                         dir_path=Path(".envs"),
                         description="Remove .envs directory (no Docker/Heroku)",
-                    )
+                    ),
                 )
                 actions.append(
                     DeleteFileAction(
                         file_path=Path("merge_production_dotenvs_in_dotenv.py"),
                         description="Remove merge dotenvs script",
-                    )
+                    ),
                 )
                 actions.append(
                     DeleteDirectoryAction(
                         dir_path=Path("tests"),
                         description="Remove tests directory (no Docker/Heroku)",
-                    )
+                    ),
                 )
 
         return actions
@@ -265,14 +260,14 @@ class GitignoreStrategy(FeatureStrategy):
                 file_path=Path(".gitignore"),
                 content=".env",
                 description="Add .env to gitignore",
-            )
+            ),
         )
         actions.append(
             AppendFileAction(
                 file_path=Path(".gitignore"),
                 content=".envs/*",
                 description="Add .envs/* to gitignore",
-            )
+            ),
         )
 
         if keep_local_envs:
@@ -281,7 +276,7 @@ class GitignoreStrategy(FeatureStrategy):
                     file_path=Path(".gitignore"),
                     content="!.envs/.local/",
                     description="Keep local envs in VCS",
-                )
+                ),
             )
 
         return actions
@@ -319,7 +314,7 @@ class DependenciesStrategy(FeatureStrategy):
                     ],
                     description="Build uv Docker image",
                     env={"DOCKER_BUILDKIT": "1"},
-                )
+                ),
             )
 
             current_path = Path.cwd().absolute()
@@ -331,21 +326,21 @@ class DependenciesStrategy(FeatureStrategy):
             RunCommandAction(
                 command=[*uv_cmd, "add", "--no-sync", "-r", "requirements/production.txt"],
                 description="Install production dependencies",
-            )
+            ),
         )
 
         actions.append(
             RunCommandAction(
                 command=[*uv_cmd, "add", "--no-sync", "--dev", "-r", "requirements/local.txt"],
                 description="Install development dependencies",
-            )
+            ),
         )
 
         actions.append(
             DeleteDirectoryAction(
                 dir_path=Path("requirements"),
                 description="Remove requirements directory",
-            )
+            ),
         )
 
         uv_image_parent_dir_path = Path("compose/local/uv")
@@ -354,14 +349,16 @@ class DependenciesStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=uv_image_parent_dir_path,
                     description="Remove uv Docker image directory",
-                )
+                ),
             )
 
         return actions
 
 
 class ProjectGenerationOrchestrator:
-    def __init__(self, config: dict, dry_run: bool = False, failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY):
+    def __init__(
+        self, config: dict, dry_run: bool = False, failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY
+    ):
         self.config = config
         self.project_slug = config.get("project_slug", "project")
         self.context = ExecutionContext(
@@ -480,8 +477,7 @@ def main():
 
     if cloud_provider == "None" and not use_docker:
         print_warning(
-            "You chose to not use any cloud providers nor Docker, "
-            "media files won't be served in production."
+            "You chose to not use any cloud providers nor Docker, media files won't be served in production.",
         )
 
     use_docker_config = config.get("use_docker", "n").lower() == "y"
@@ -492,7 +488,7 @@ def main():
         print_warning(
             ".env(s) are only utilized when Docker Compose and/or "
             "Heroku support is enabled. Keeping them as requested, but they may not be useful "
-            "in your current setup."
+            "in your current setup.",
         )
 
     success = orchestrator.execute()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,4 @@
 # ruff: noqa: PLR0133
-import json
 import os
 import random
 import shutil
@@ -8,9 +7,26 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hooks.core.actions import AppendFileAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import ModifyFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
+from hooks.core.executor import ActionExecutor
+from hooks.core.strategies import FeatureStrategy
+from hooks.strategies.async_strategy import AsyncStrategy
+from hooks.strategies.celery import CeleryStrategy
+from hooks.strategies.ci_tool import CIToolStrategy
+from hooks.strategies.docker import DockerStrategy
+from hooks.strategies.editor import EditorStrategy
+from hooks.strategies.frontend_pipeline import FrontendPipelineStrategy
+from hooks.strategies.heroku import HerokuStrategy
+from hooks.strategies.license import OpenSourceLicenseStrategy
+from hooks.strategies.rest_api import RestApiStrategy
+from hooks.strategies.username_type import UsernameTypeStrategy
+
 try:
-    # Inspired by
-    # https://github.com/django/django/blob/main/django/utils/crypto.py
     random = random.SystemRandom()
     using_sysrandom = True
 except NotImplementedError:
@@ -21,244 +37,12 @@ WARNING = "\x1b[1;33m [WARNING]: "
 INFO = "\x1b[1;33m [INFO]: "
 HINT = "\x1b[3;33m"
 SUCCESS = "\x1b[1;32m [SUCCESS]: "
+ERROR = "\x1b[1;31m [ERROR]: "
 
 DEBUG_VALUE = "debug"
 
 
-def remove_open_source_files():
-    file_names = ["CONTRIBUTORS.txt", "LICENSE"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_gplv3_files():
-    file_names = ["COPYING"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_custom_user_manager_files():
-    users_path = Path("{{cookiecutter.project_slug}}", "users")
-    (users_path / "managers.py").unlink()
-    (users_path / "tests" / "test_managers.py").unlink()
-
-
-def remove_pycharm_files():
-    idea_dir_path = Path(".idea")
-    if idea_dir_path.exists():
-        shutil.rmtree(idea_dir_path)
-
-    docs_dir_path = Path("docs", "pycharm")
-    if docs_dir_path.exists():
-        shutil.rmtree(docs_dir_path)
-
-
-def remove_docker_files():
-    shutil.rmtree(".devcontainer")
-    shutil.rmtree("compose")
-
-    file_names = [
-        "docker-compose.local.yml",
-        "docker-compose.production.yml",
-        ".dockerignore",
-        "justfile",
-    ]
-    for file_name in file_names:
-        Path(file_name).unlink()
-    if "{{ cookiecutter.editor }}" == "PyCharm":
-        file_names = ["docker_compose_up_django.xml", "docker_compose_up_docs.xml"]
-        for file_name in file_names:
-            Path(".idea", "runConfigurations", file_name).unlink()
-
-
-def remove_nginx_docker_files():
-    shutil.rmtree(Path("compose", "production", "nginx"))
-
-
-def remove_utility_files():
-    shutil.rmtree("utility")
-
-
-def remove_heroku_files():
-    file_names = ["Procfile"]
-    for file_name in file_names:
-        if file_name == "requirements.txt" and "{{ cookiecutter.ci_tool }}".lower() == "travis":
-            # Don't remove the file if we are using Travis CI but not using Heroku
-            continue
-        Path(file_name).unlink()
-    shutil.rmtree("bin")
-
-
-def remove_sass_files():
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "static", "sass"))
-
-
-def remove_gulp_files():
-    file_names = ["gulpfile.mjs"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def remove_webpack_files():
-    shutil.rmtree("webpack")
-    remove_vendors_js()
-
-
-def remove_vendors_js():
-    vendors_js_path = Path("{{ cookiecutter.project_slug }}", "static", "js", "vendors.js")
-    if vendors_js_path.exists():
-        vendors_js_path.unlink()
-
-
-def remove_project_css():
-    project_css_path = Path("{{ cookiecutter.project_slug }}", "static", "css", "project.css")
-    if project_css_path.exists():
-        project_css_path.unlink()
-
-
-def remove_packagejson_file():
-    file_names = ["package.json"]
-    for file_name in file_names:
-        Path(file_name).unlink()
-
-
-def update_package_json(remove_dev_deps=None, remove_keys=None, scripts=None):
-    remove_dev_deps = remove_dev_deps or []
-    remove_keys = remove_keys or []
-    scripts = scripts or {}
-    package_json = Path("package.json")
-    content = json.loads(package_json.read_text())
-    for package_name in remove_dev_deps:
-        content["devDependencies"].pop(package_name)
-    for key in remove_keys:
-        content.pop(key)
-    content["scripts"].update(scripts)
-    updated_content = json.dumps(content, ensure_ascii=False, indent=2) + "\n"
-    package_json.write_text(updated_content)
-
-
-def handle_js_runner(choice, use_docker, use_async):
-    if choice == "Gulp":
-        update_package_json(
-            remove_dev_deps=[
-                "@babel/core",
-                "@babel/preset-env",
-                "babel-loader",
-                "concurrently",
-                "css-loader",
-                "mini-css-extract-plugin",
-                "postcss-loader",
-                "postcss-preset-env",
-                "sass-loader",
-                "webpack",
-                "webpack-bundle-tracker",
-                "webpack-cli",
-                "webpack-dev-server",
-                "webpack-merge",
-            ],
-            remove_keys=["babel"],
-            scripts={
-                "dev": "gulp",
-                "build": "gulp build",
-            },
-        )
-        remove_webpack_files()
-    elif choice == "Webpack":
-        scripts = {
-            "dev": "webpack serve --config webpack/dev.config.js",
-            "build": "webpack --config webpack/prod.config.js",
-        }
-        remove_dev_deps = [
-            "browser-sync",
-            "cssnano",
-            "gulp",
-            "gulp-concat",
-            "gulp-imagemin",
-            "gulp-plumber",
-            "gulp-postcss",
-            "gulp-rename",
-            "gulp-sass",
-            "gulp-uglify-es",
-        ]
-        if not use_docker:
-            dev_django_cmd = (
-                "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
-            )
-            scripts.update(
-                {
-                    "dev": "concurrently npm:dev:*",
-                    "dev:webpack": "webpack serve --config webpack/dev.config.js",
-                    "dev:django": dev_django_cmd,
-                },
-            )
-        else:
-            remove_dev_deps.append("concurrently")
-        update_package_json(remove_dev_deps=remove_dev_deps, scripts=scripts)
-        remove_gulp_files()
-
-
-def remove_prettier_pre_commit():
-    remove_repo_from_pre_commit_config("mirrors-prettier")
-
-
-def remove_repo_from_pre_commit_config(repo_to_remove: str):
-    pre_commit_config = Path(".pre-commit-config.yaml")
-    content = pre_commit_config.read_text().splitlines(keepends=True)
-
-    removing = False
-    new_lines = []
-    for line in content:
-        if removing and "- repo:" in line:
-            removing = False
-        if repo_to_remove in line:
-            removing = True
-        if not removing:
-            new_lines.append(line)
-
-    pre_commit_config.write_text("".join(new_lines))
-
-
-def remove_celery_files():
-    file_paths = [
-        Path("config", "celery_app.py"),
-        Path("{{ cookiecutter.project_slug }}", "users", "tasks.py"),
-        Path("{{ cookiecutter.project_slug }}", "users", "tests", "test_tasks.py"),
-    ]
-    for file_path in file_paths:
-        file_path.unlink()
-
-
-def remove_async_files():
-    file_paths = [
-        Path("config", "asgi.py"),
-        Path("config", "websocket.py"),
-    ]
-    for file_path in file_paths:
-        file_path.unlink()
-
-
-def remove_dottravisyml_file():
-    Path(".travis.yml").unlink()
-
-
-def remove_dotgitlabciyml_file():
-    Path(".gitlab-ci.yml").unlink()
-
-
-def remove_dotgithub_folder():
-    shutil.rmtree(".github")
-
-
-def remove_dotdrone_file():
-    Path(".drone.yml").unlink()
-
-
-def generate_random_string(length, using_digits=False, using_ascii_letters=False, using_punctuation=False):  # noqa: FBT002
-    """
-    Example:
-        opting out for 50 symbol-long, [a-z][A-Z][0-9] string
-        would yield log_2((26+26+50)^50) ~= 334 bit strength.
-    """
+def generate_random_string(length, using_digits=False, using_ascii_letters=False, using_punctuation=False):
     if not using_sysrandom:
         return None
 
@@ -269,329 +53,452 @@ def generate_random_string(length, using_digits=False, using_ascii_letters=False
         symbols += string.ascii_letters
     if using_punctuation:
         all_punctuation = set(string.punctuation)
-        # These symbols can cause issues in environment variables
         unsuitable = {"'", '"', "\\", "$"}
         suitable = all_punctuation.difference(unsuitable)
         symbols += "".join(suitable)
     return "".join([random.choice(symbols) for _ in range(length)])
 
 
-def set_flag(file_path: Path, flag, value=None, formatted=None, *args, **kwargs):
-    if value is None:
-        random_string = generate_random_string(*args, **kwargs)
-        if random_string is None:
-            print(
-                "We couldn't find a secure pseudo-random number generator on your "
-                f"system. Please, make sure to manually {flag} later.",
-            )
-            random_string = flag
-        if formatted is not None:
-            random_string = formatted.format(random_string)
-        value = random_string
-
-    with file_path.open("r+") as f:
-        file_contents = f.read().replace(flag, value)
-        f.seek(0)
-        f.write(file_contents)
-        f.truncate()
-
-    return value
-
-
-def set_django_secret_key(file_path: Path):
-    return set_flag(
-        file_path,
-        "!!!SET DJANGO_SECRET_KEY!!!",
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
-def set_django_admin_url(file_path: Path):
-    return set_flag(
-        file_path,
-        "!!!SET DJANGO_ADMIN_URL!!!",
-        formatted="{}/",
-        length=32,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
-
-
 def generate_random_user():
     return generate_random_string(length=32, using_ascii_letters=True)
 
 
-def generate_postgres_user(debug=False):  # noqa: FBT002
+def generate_postgres_user(debug=False):
     return DEBUG_VALUE if debug else generate_random_user()
 
 
-def set_postgres_user(file_path, value):
-    return set_flag(file_path, "!!!SET POSTGRES_USER!!!", value=value)
+class SecretGenerationStrategy(FeatureStrategy):
+    name = "secrets"
+    description = "Generate secret keys and credentials"
 
+    def __init__(self, debug=False):
+        self.debug = debug
+        self.postgres_user = DEBUG_VALUE if debug else generate_random_user()
+        self.celery_flower_user = DEBUG_VALUE if debug else generate_random_user()
 
-def set_postgres_password(file_path, value=None):
-    return set_flag(
-        file_path,
-        "!!!SET POSTGRES_PASSWORD!!!",
-        value=value,
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
 
+    def plan(self, context: ExecutionContext) -> list:
+        from hooks.core.actions import ModifyFileAction
 
-def set_celery_flower_user(file_path, value):
-    return set_flag(file_path, "!!!SET CELERY_FLOWER_USER!!!", value=value)
+        actions = []
 
+        actions.extend(self._plan_env_secrets())
+        actions.extend(self._plan_settings_secrets())
 
-def set_celery_flower_password(file_path, value=None):
-    return set_flag(
-        file_path,
-        "!!!SET CELERY_FLOWER_PASSWORD!!!",
-        value=value,
-        length=64,
-        using_digits=True,
-        using_ascii_letters=True,
-    )
+        return actions
 
+    def _plan_env_secrets(self) -> list:
+        actions = []
 
-def append_to_gitignore_file(ignored_line):
-    with Path(".gitignore").open("a") as gitignore_file:
-        gitignore_file.write(ignored_line)
-        gitignore_file.write("\n")
+        local_django_envs_path = Path(".envs", ".local", ".django")
+        production_django_envs_path = Path(".envs", ".production", ".django")
+        local_postgres_envs_path = Path(".envs", ".local", ".postgres")
+        production_postgres_envs_path = Path(".envs", ".production", ".postgres")
 
-
-def set_flags_in_envs(postgres_user, celery_flower_user, debug=False):  # noqa: FBT002
-    local_django_envs_path = Path(".envs", ".local", ".django")
-    production_django_envs_path = Path(".envs", ".production", ".django")
-    local_postgres_envs_path = Path(".envs", ".local", ".postgres")
-    production_postgres_envs_path = Path(".envs", ".production", ".postgres")
-
-    set_django_secret_key(production_django_envs_path)
-    set_django_admin_url(production_django_envs_path)
-
-    set_postgres_user(local_postgres_envs_path, value=postgres_user)
-    set_postgres_password(local_postgres_envs_path, value=DEBUG_VALUE if debug else None)
-    set_postgres_user(production_postgres_envs_path, value=postgres_user)
-    set_postgres_password(production_postgres_envs_path, value=DEBUG_VALUE if debug else None)
-
-    set_celery_flower_user(local_django_envs_path, value=celery_flower_user)
-    set_celery_flower_password(local_django_envs_path, value=DEBUG_VALUE if debug else None)
-    set_celery_flower_user(production_django_envs_path, value=celery_flower_user)
-    set_celery_flower_password(production_django_envs_path, value=DEBUG_VALUE if debug else None)
-
-
-def set_flags_in_settings_files():
-    set_django_secret_key(Path("config", "settings", "local.py"))
-    set_django_secret_key(Path("config", "settings", "test.py"))
-
-
-def remove_envs_and_associated_files():
-    shutil.rmtree(".envs")
-    Path("merge_production_dotenvs_in_dotenv.py").unlink()
-    shutil.rmtree("tests")
-
-
-def remove_celery_compose_dirs():
-    shutil.rmtree(Path("compose", "local", "django", "celery"))
-    shutil.rmtree(Path("compose", "production", "django", "celery"))
-
-
-def remove_node_dockerfile():
-    shutil.rmtree(Path("compose", "local", "node"))
-
-
-def remove_aws_dockerfile():
-    shutil.rmtree(Path("compose", "production", "aws"))
-
-
-def remove_drf_starter_files():
-    Path("config", "api_router.py").unlink()
-    Path("{{cookiecutter.project_slug}}", "users", "api", "serializers.py").unlink()
-
-
-def remove_ninja_starter_files():
-    Path("config", "api.py").unlink()
-    Path("{{cookiecutter.project_slug}}", "users", "api", "schema.py").unlink()
-
-
-def remove_rest_api_files():
-    remove_drf_starter_files()
-    remove_ninja_starter_files()
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "api"))
-    shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "tests", "api"))
-
-
-def main():  # noqa: C901, PLR0912, PLR0915
-    debug = "{{ cookiecutter.debug }}".lower() == "y"
-
-    set_flags_in_envs(
-        DEBUG_VALUE if debug else generate_random_user(),
-        DEBUG_VALUE if debug else generate_random_user(),
-        debug=debug,
-    )
-    set_flags_in_settings_files()
-
-    if "{{ cookiecutter.open_source_license }}" == "Not open source":
-        remove_open_source_files()
-    if "{{ cookiecutter.open_source_license}}" != "GPLv3":
-        remove_gplv3_files()
-
-    if "{{ cookiecutter.username_type }}" == "username":
-        remove_custom_user_manager_files()
-
-    if "{{ cookiecutter.editor }}" != "PyCharm":
-        remove_pycharm_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y":
-        remove_utility_files()
-        if "{{ cookiecutter.cloud_provider }}".lower() != "none":
-            remove_nginx_docker_files()
-    else:
-        remove_docker_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y" and "{{ cookiecutter.cloud_provider}}" != "AWS":
-        remove_aws_dockerfile()
-
-    if "{{ cookiecutter.use_heroku }}".lower() == "n":
-        remove_heroku_files()
-
-    if "{{ cookiecutter.use_docker }}".lower() == "n" and "{{ cookiecutter.use_heroku }}".lower() == "n":
-        if "{{ cookiecutter.keep_local_envs_in_vcs }}".lower() == "y":
-            print(
-                INFO + ".env(s) are only utilized when Docker Compose and/or "
-                "Heroku support is enabled. Keeping them as requested, but they may not be useful "
-                "in your current setup." + TERMINATOR,
+        actions.append(
+            ModifyFileAction(
+                file_path=production_django_envs_path,
+                modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
+                description="Set Django secret key in production env",
             )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=production_django_envs_path,
+                modifications={"!!!SET DJANGO_ADMIN_URL!!!": self._generate_admin_url()},
+                description="Set Django admin URL in production env",
+            )
+        )
+
+        postgres_password = DEBUG_VALUE if self.debug else self._generate_password()
+        actions.append(
+            ModifyFileAction(
+                file_path=local_postgres_envs_path,
+                modifications={"!!!SET POSTGRES_USER!!!": self.postgres_user},
+                description="Set Postgres user in local env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=local_postgres_envs_path,
+                modifications={"!!!SET POSTGRES_PASSWORD!!!": postgres_password},
+                description="Set Postgres password in local env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=production_postgres_envs_path,
+                modifications={"!!!SET POSTGRES_USER!!!": self.postgres_user},
+                description="Set Postgres user in production env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=production_postgres_envs_path,
+                modifications={"!!!SET POSTGRES_PASSWORD!!!": postgres_password},
+                description="Set Postgres password in production env",
+            )
+        )
+
+        celery_flower_password = DEBUG_VALUE if self.debug else self._generate_password()
+        actions.append(
+            ModifyFileAction(
+                file_path=local_django_envs_path,
+                modifications={"!!!SET CELERY_FLOWER_USER!!!": self.celery_flower_user},
+                description="Set Celery Flower user in local env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=local_django_envs_path,
+                modifications={"!!!SET CELERY_FLOWER_PASSWORD!!!": celery_flower_password},
+                description="Set Celery Flower password in local env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=production_django_envs_path,
+                modifications={"!!!SET CELERY_FLOWER_USER!!!": self.celery_flower_user},
+                description="Set Celery Flower user in production env",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=production_django_envs_path,
+                modifications={"!!!SET CELERY_FLOWER_PASSWORD!!!": celery_flower_password},
+                description="Set Celery Flower password in production env",
+            )
+        )
+
+        return actions
+
+    def _plan_settings_secrets(self) -> list:
+        actions = []
+
+        local_settings_path = Path("config", "settings", "local.py")
+        test_settings_path = Path("config", "settings", "test.py")
+
+        actions.append(
+            ModifyFileAction(
+                file_path=local_settings_path,
+                modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
+                description="Set Django secret key in local settings",
+            )
+        )
+        actions.append(
+            ModifyFileAction(
+                file_path=test_settings_path,
+                modifications={"!!!SET DJANGO_SECRET_KEY!!!": self._generate_secret_key()},
+                description="Set Django secret key in test settings",
+            )
+        )
+
+        return actions
+
+    def _generate_secret_key(self) -> str:
+        key = generate_random_string(64, using_digits=True, using_ascii_letters=True)
+        return key if key else "!!!SET DJANGO_SECRET_KEY!!!"
+
+    def _generate_admin_url(self) -> str:
+        key = generate_random_string(32, using_digits=True, using_ascii_letters=True)
+        return f"{key}/" if key else "!!!SET DJANGO_ADMIN_URL!!!/"
+
+    def _generate_password(self) -> str:
+        key = generate_random_string(64, using_digits=True, using_ascii_letters=True)
+        return key if key else "!!!SET PASSWORD!!!"
+
+
+class EnvFilesStrategy(FeatureStrategy):
+    name = "env_files"
+    description = "Handle .env files configuration"
+
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        use_docker = context.is_enabled("use_docker")
+        use_heroku = context.is_enabled("use_heroku")
+        keep_local_envs = context.is_enabled("keep_local_envs_in_vcs")
+
+        if not use_docker and not use_heroku:
+            if not keep_local_envs:
+                actions.append(
+                    DeleteDirectoryAction(
+                        dir_path=Path(".envs"),
+                        description="Remove .envs directory (no Docker/Heroku)",
+                    )
+                )
+                actions.append(
+                    DeleteFileAction(
+                        file_path=Path("merge_production_dotenvs_in_dotenv.py"),
+                        description="Remove merge dotenvs script",
+                    )
+                )
+                actions.append(
+                    DeleteDirectoryAction(
+                        dir_path=Path("tests"),
+                        description="Remove tests directory (no Docker/Heroku)",
+                    )
+                )
+
+        return actions
+
+
+class GitignoreStrategy(FeatureStrategy):
+    name = "gitignore"
+    description = "Update .gitignore file"
+
+    def should_apply(self, context: ExecutionContext) -> bool:
+        use_docker = context.is_enabled("use_docker")
+        use_heroku = context.is_enabled("use_heroku")
+        return use_docker or use_heroku
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        keep_local_envs = context.is_enabled("keep_local_envs_in_vcs")
+
+        actions.append(
+            AppendFileAction(
+                file_path=Path(".gitignore"),
+                content=".env",
+                description="Add .env to gitignore",
+            )
+        )
+        actions.append(
+            AppendFileAction(
+                file_path=Path(".gitignore"),
+                content=".envs/*",
+                description="Add .envs/* to gitignore",
+            )
+        )
+
+        if keep_local_envs:
+            actions.append(
+                AppendFileAction(
+                    file_path=Path(".gitignore"),
+                    content="!.envs/.local/",
+                    description="Keep local envs in VCS",
+                )
+            )
+
+        return actions
+
+
+class DependenciesStrategy(FeatureStrategy):
+    name = "dependencies"
+    description = "Install project dependencies"
+
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        from hooks.core.actions import RunCommandAction
+
+        actions = []
+        use_docker = context.is_enabled("use_docker")
+
+        if use_docker:
+            uv_docker_image_path = Path("compose/local/uv/Dockerfile")
+            uv_image_tag = "cookiecutter-django-uv-runner:latest"
+
+            actions.append(
+                RunCommandAction(
+                    command=[
+                        "docker",
+                        "build",
+                        "--load",
+                        "-t",
+                        uv_image_tag,
+                        "-f",
+                        str(uv_docker_image_path),
+                        "-q",
+                        ".",
+                    ],
+                    description="Build uv Docker image",
+                    env={"DOCKER_BUILDKIT": "1"},
+                )
+            )
+
+            current_path = Path.cwd().absolute()
+            uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]
         else:
-            remove_envs_and_associated_files()
-    else:
-        append_to_gitignore_file(".env")
-        append_to_gitignore_file(".envs/*")
-        if "{{ cookiecutter.keep_local_envs_in_vcs }}".lower() == "y":
-            append_to_gitignore_file("!.envs/.local/")
+            uv_cmd = ["uv"]
 
-    if "{{ cookiecutter.frontend_pipeline }}" in ["None", "Django Compressor"]:
-        remove_gulp_files()
-        remove_webpack_files()
-        remove_sass_files()
-        remove_packagejson_file()
-        remove_prettier_pre_commit()
-        if "{{ cookiecutter.use_docker }}".lower() == "y":
-            remove_node_dockerfile()
-    else:
-        remove_project_css()
-        handle_js_runner(
-            "{{ cookiecutter.frontend_pipeline }}",
-            use_docker=("{{ cookiecutter.use_docker }}".lower() == "y"),
-            use_async=("{{ cookiecutter.use_async }}".lower() == "y"),
-        )
-
-    if "{{ cookiecutter.cloud_provider }}" == "None" and "{{ cookiecutter.use_docker }}".lower() == "n":
-        print(
-            WARNING + "You chose to not use any cloud providers nor Docker, "
-            "media files won't be served in production." + TERMINATOR,
-        )
-
-    if "{{ cookiecutter.use_celery }}".lower() == "n":
-        remove_celery_files()
-        if "{{ cookiecutter.use_docker }}".lower() == "y":
-            remove_celery_compose_dirs()
-
-    if "{{ cookiecutter.ci_tool }}" != "Travis":
-        remove_dottravisyml_file()
-
-    if "{{ cookiecutter.ci_tool }}" != "Gitlab":
-        remove_dotgitlabciyml_file()
-
-    if "{{ cookiecutter.ci_tool }}" != "Github":
-        remove_dotgithub_folder()
-
-    if "{{ cookiecutter.ci_tool }}" != "Drone":
-        remove_dotdrone_file()
-
-    if "{{ cookiecutter.rest_api }}" == "DRF":
-        remove_ninja_starter_files()
-    elif "{{ cookiecutter.rest_api }}" == "Django Ninja":
-        remove_drf_starter_files()
-    else:
-        remove_rest_api_files()
-
-    if "{{ cookiecutter.use_async }}".lower() == "n":
-        remove_async_files()
-
-    setup_dependencies()
-
-    print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
-
-
-def setup_dependencies():
-    print("Installing python dependencies using uv...")
-
-    if "{{ cookiecutter.use_docker }}".lower() == "y":
-        # Build a trimmed down Docker image add dependencies with uv
-        uv_docker_image_path = Path("compose/local/uv/Dockerfile")
-        uv_image_tag = "cookiecutter-django-uv-runner:latest"
-        try:
-            subprocess.run(  # noqa: S603
-                [  # noqa: S607
-                    "docker",
-                    "build",
-                    "--load",
-                    "-t",
-                    uv_image_tag,
-                    "-f",
-                    str(uv_docker_image_path),
-                    "-q",
-                    ".",
-                ],
-                check=True,
-                env={
-                    **os.environ,
-                    "DOCKER_BUILDKIT": "1",
-                },
+        actions.append(
+            RunCommandAction(
+                command=[*uv_cmd, "add", "--no-sync", "-r", "requirements/production.txt"],
+                description="Install production dependencies",
             )
-        except subprocess.CalledProcessError as e:
-            print(f"Error building Docker image: {e}", file=sys.stderr)
-            sys.exit(1)
+        )
 
-        current_path = Path.cwd().absolute()
-        # Use Docker to run the uv command
-        uv_cmd = ["docker", "run", "--rm", "-v", f"{current_path}:/app", uv_image_tag, "uv"]
-    else:
-        # Use uv command directly
-        uv_cmd = ["uv"]
+        actions.append(
+            RunCommandAction(
+                command=[*uv_cmd, "add", "--no-sync", "--dev", "-r", "requirements/local.txt"],
+                description="Install development dependencies",
+            )
+        )
 
-    # Install production dependencies
-    try:
-        subprocess.run([*uv_cmd, "add", "--no-sync", "-r", "requirements/production.txt"], check=True)  # noqa: S603
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing production dependencies: {e}", file=sys.stderr)
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("requirements"),
+                description="Remove requirements directory",
+            )
+        )
+
+        uv_image_parent_dir_path = Path("compose/local/uv")
+        if uv_image_parent_dir_path.exists():
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=uv_image_parent_dir_path,
+                    description="Remove uv Docker image directory",
+                )
+            )
+
+        return actions
+
+
+class ProjectGenerationOrchestrator:
+    def __init__(self, config: dict, dry_run: bool = False, failure_policy: FailurePolicy = FailurePolicy.STOP_IMMEDIATELY):
+        self.config = config
+        self.project_slug = config.get("project_slug", "project")
+        self.context = ExecutionContext(
+            project_slug=self.project_slug,
+            cookiecutter_config=config,
+            dry_run=dry_run,
+            failure_policy=failure_policy,
+        )
+        self.executor = ActionExecutor(self.context)
+        self._strategies: list[FeatureStrategy] = []
+        self.debug = config.get("debug", "n").lower() == "y"
+
+    def register_strategy(self, strategy: FeatureStrategy) -> None:
+        self._strategies.append(strategy)
+
+    def register_all_strategies(self) -> None:
+        self._strategies = [
+            SecretGenerationStrategy(debug=self.debug),
+            OpenSourceLicenseStrategy(),
+            UsernameTypeStrategy(),
+            EditorStrategy(),
+            DockerStrategy(),
+            HerokuStrategy(),
+            EnvFilesStrategy(),
+            GitignoreStrategy(),
+            FrontendPipelineStrategy(),
+            CeleryStrategy(),
+            CIToolStrategy(),
+            RestApiStrategy(),
+            AsyncStrategy(),
+            DependenciesStrategy(),
+        ]
+
+    def plan(self) -> list:
+        actions = []
+
+        for strategy in self._strategies:
+            if strategy.should_apply(self.context):
+                strategy_actions = strategy.plan(self.context)
+                actions.extend(strategy_actions)
+
+        return actions
+
+    def execute(self) -> bool:
+        print(f"{INFO}Planning project generation...{TERMINATOR}")
+        actions = self.plan()
+
+        print(f"{INFO}Found {len(actions)} actions to execute{TERMINATOR}")
+
+        if self.context.dry_run:
+            print(f"{INFO}Dry-run mode: showing planned actions{TERMINATOR}")
+            for i, action in enumerate(actions, 1):
+                print(f"  [{i}/{len(actions)}] {action.describe()}")
+            return True
+
+        result = self.executor.execute(actions)
+
+        if result.success:
+            print(f"{SUCCESS}Project initialized, keep up the good work!{TERMINATOR}")
+        else:
+            print(f"{ERROR}Project generation failed: {result.message}{TERMINATOR}")
+            if result.failed_actions:
+                print(f"{ERROR}Failed actions: {', '.join(result.failed_actions)}{TERMINATOR}")
+            if result.rolled_back_count > 0:
+                print(f"{INFO}Rolled back {result.rolled_back_count} actions{TERMINATOR}")
+
+        report_path = Path(".generation_report.md")
+        self.context.save_report(report_path)
+        print(f"{INFO}Generation report saved to {report_path}{TERMINATOR}")
+
+        json_report_path = Path(".generation_report.json")
+        self.context.save_json_report(json_report_path)
+        print(f"{INFO}JSON report saved to {json_report_path}{TERMINATOR}")
+
+        return result.success
+
+    def preview(self) -> str:
+        actions = self.plan()
+        lines = [f"Project Generation Preview for '{self.project_slug}'", "=" * 50, ""]
+
+        for i, action in enumerate(actions, 1):
+            lines.append(f"{i}. {action.describe()}")
+
+        lines.extend(["", f"Total: {len(actions)} actions planned"])
+
+        return "\n".join(lines)
+
+
+def print_warning(message: str) -> None:
+    print(f"{WARNING}{message}{TERMINATOR}")
+
+
+def main():
+    config = {
+        "project_slug": "{{ cookiecutter.project_slug }}",
+        "open_source_license": "{{ cookiecutter.open_source_license }}",
+        "username_type": "{{ cookiecutter.username_type }}",
+        "editor": "{{ cookiecutter.editor }}",
+        "use_docker": "{{ cookiecutter.use_docker }}",
+        "cloud_provider": "{{ cookiecutter.cloud_provider }}",
+        "use_heroku": "{{ cookiecutter.use_heroku }}",
+        "frontend_pipeline": "{{ cookiecutter.frontend_pipeline }}",
+        "use_celery": "{{ cookiecutter.use_celery }}",
+        "ci_tool": "{{ cookiecutter.ci_tool }}",
+        "rest_api": "{{ cookiecutter.rest_api }}",
+        "use_async": "{{ cookiecutter.use_async }}",
+        "keep_local_envs_in_vcs": "{{ cookiecutter.keep_local_envs_in_vcs }}",
+        "debug": "{{ cookiecutter.debug }}",
+    }
+
+    orchestrator = ProjectGenerationOrchestrator(config)
+    orchestrator.register_all_strategies()
+
+    cloud_provider = config.get("cloud_provider", "None")
+    use_docker = config.get("use_docker", "n").lower() == "y"
+
+    if cloud_provider == "None" and not use_docker:
+        print_warning(
+            "You chose to not use any cloud providers nor Docker, "
+            "media files won't be served in production."
+        )
+
+    use_docker_config = config.get("use_docker", "n").lower() == "y"
+    use_heroku_config = config.get("use_heroku", "n").lower() == "y"
+    keep_local_envs = config.get("keep_local_envs_in_vcs", "y").lower() == "y"
+
+    if not use_docker_config and not use_heroku_config and keep_local_envs:
+        print_warning(
+            ".env(s) are only utilized when Docker Compose and/or "
+            "Heroku support is enabled. Keeping them as requested, but they may not be useful "
+            "in your current setup."
+        )
+
+    success = orchestrator.execute()
+
+    if not success:
         sys.exit(1)
-
-    # Install local (development) dependencies
-    try:
-        subprocess.run([*uv_cmd, "add", "--no-sync", "--dev", "-r", "requirements/local.txt"], check=True)  # noqa: S603
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing local dependencies: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # Remove the requirements directory
-    requirements_dir = Path("requirements")
-    if requirements_dir.exists():
-        try:
-            shutil.rmtree(requirements_dir)
-        except Exception as e:  # noqa: BLE001
-            print(f"Error removing 'requirements' folder: {e}", file=sys.stderr)
-            sys.exit(1)
-
-    uv_image_parent_dir_path = Path("compose/local/uv")
-    if uv_image_parent_dir_path.exists():
-        shutil.rmtree(str(uv_image_parent_dir_path))
-
-    print("Setup complete!")
 
 
 if __name__ == "__main__":

--- a/hooks/strategies/__init__.py
+++ b/hooks/strategies/__init__.py
@@ -10,14 +10,14 @@ from hooks.strategies.rest_api import RestApiStrategy
 from hooks.strategies.username_type import UsernameTypeStrategy
 
 __all__ = [
-    "OpenSourceLicenseStrategy",
-    "UsernameTypeStrategy",
-    "EditorStrategy",
-    "DockerStrategy",
-    "HerokuStrategy",
-    "FrontendPipelineStrategy",
-    "CeleryStrategy",
-    "CIToolStrategy",
-    "RestApiStrategy",
     "AsyncStrategy",
+    "CIToolStrategy",
+    "CeleryStrategy",
+    "DockerStrategy",
+    "EditorStrategy",
+    "FrontendPipelineStrategy",
+    "HerokuStrategy",
+    "OpenSourceLicenseStrategy",
+    "RestApiStrategy",
+    "UsernameTypeStrategy",
 ]

--- a/hooks/strategies/__init__.py
+++ b/hooks/strategies/__init__.py
@@ -1,0 +1,23 @@
+from hooks.strategies.async_strategy import AsyncStrategy
+from hooks.strategies.celery import CeleryStrategy
+from hooks.strategies.ci_tool import CIToolStrategy
+from hooks.strategies.docker import DockerStrategy
+from hooks.strategies.editor import EditorStrategy
+from hooks.strategies.frontend_pipeline import FrontendPipelineStrategy
+from hooks.strategies.heroku import HerokuStrategy
+from hooks.strategies.license import OpenSourceLicenseStrategy
+from hooks.strategies.rest_api import RestApiStrategy
+from hooks.strategies.username_type import UsernameTypeStrategy
+
+__all__ = [
+    "OpenSourceLicenseStrategy",
+    "UsernameTypeStrategy",
+    "EditorStrategy",
+    "DockerStrategy",
+    "HerokuStrategy",
+    "FrontendPipelineStrategy",
+    "CeleryStrategy",
+    "CIToolStrategy",
+    "RestApiStrategy",
+    "AsyncStrategy",
+]

--- a/hooks/strategies/async_strategy.py
+++ b/hooks/strategies/async_strategy.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("async", "Handle async configuration files")
+class AsyncStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return not context.is_enabled("use_async")
+
+    def plan(self, context: ExecutionContext) -> list:
+        return [
+            DeleteFileAction(
+                file_path=Path("config", "asgi.py"),
+                description="Remove ASGI config (sync mode)",
+            ),
+            DeleteFileAction(
+                file_path=Path("config", "websocket.py"),
+                description="Remove websocket config (sync mode)",
+            ),
+        ]

--- a/hooks/strategies/celery.py
+++ b/hooks/strategies/celery.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("celery", "Handle Celery configuration files")
+class CeleryStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return not context.is_enabled("use_celery")
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        project_slug = context.project_slug
+        use_docker = context.is_enabled("use_docker")
+
+        file_paths = [
+            Path("config", "celery_app.py"),
+            Path(project_slug, "users", "tasks.py"),
+            Path(project_slug, "users", "tests", "test_tasks.py"),
+        ]
+
+        for file_path in file_paths:
+            actions.append(
+                DeleteFileAction(
+                    file_path=file_path,
+                    description=f"Remove Celery file: {file_path}",
+                )
+            )
+
+        if use_docker:
+            actions.extend(
+                [
+                    DeleteDirectoryAction(
+                        dir_path=Path("compose", "local", "django", "celery"),
+                        description="Remove local Celery Docker config",
+                    ),
+                    DeleteDirectoryAction(
+                        dir_path=Path("compose", "production", "django", "celery"),
+                        description="Remove production Celery Docker config",
+                    ),
+                ]
+            )
+
+        return actions

--- a/hooks/strategies/celery.py
+++ b/hooks/strategies/celery.py
@@ -28,7 +28,7 @@ class CeleryStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=file_path,
                     description=f"Remove Celery file: {file_path}",
-                )
+                ),
             )
 
         if use_docker:
@@ -42,7 +42,7 @@ class CeleryStrategy(FeatureStrategy):
                         dir_path=Path("compose", "production", "django", "celery"),
                         description="Remove production Celery Docker config",
                     ),
-                ]
+                ],
             )
 
         return actions

--- a/hooks/strategies/ci_tool.py
+++ b/hooks/strategies/ci_tool.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("ci_tool", "Handle CI tool configuration files")
+class CIToolStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        ci_tool = context.get_config("ci_tool", "None")
+
+        if ci_tool != "Travis":
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path(".travis.yml"),
+                    description="Remove Travis CI config",
+                )
+            )
+
+        if ci_tool != "Gitlab":
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path(".gitlab-ci.yml"),
+                    description="Remove GitLab CI config",
+                )
+            )
+
+        if ci_tool != "Github":
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=Path(".github"),
+                    description="Remove GitHub Actions config",
+                )
+            )
+
+        if ci_tool != "Drone":
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path(".drone.yml"),
+                    description="Remove Drone CI config",
+                )
+            )
+
+        return actions

--- a/hooks/strategies/ci_tool.py
+++ b/hooks/strategies/ci_tool.py
@@ -21,7 +21,7 @@ class CIToolStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path(".travis.yml"),
                     description="Remove Travis CI config",
-                )
+                ),
             )
 
         if ci_tool != "Gitlab":
@@ -29,7 +29,7 @@ class CIToolStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path(".gitlab-ci.yml"),
                     description="Remove GitLab CI config",
-                )
+                ),
             )
 
         if ci_tool != "Github":
@@ -37,7 +37,7 @@ class CIToolStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=Path(".github"),
                     description="Remove GitHub Actions config",
-                )
+                ),
             )
 
         if ci_tool != "Drone":
@@ -45,7 +45,7 @@ class CIToolStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path(".drone.yml"),
                     description="Remove Drone CI config",
-                )
+                ),
             )
 
         return actions

--- a/hooks/strategies/docker.py
+++ b/hooks/strategies/docker.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("docker", "Handle Docker configuration files")
+class DockerStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        use_docker = context.is_enabled("use_docker")
+
+        if use_docker:
+            actions.extend(self._plan_docker_enabled(context))
+        else:
+            actions.extend(self._plan_docker_disabled(context))
+
+        return actions
+
+    def _plan_docker_enabled(self, context: ExecutionContext) -> list:
+        actions = []
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("utility"),
+                description="Remove utility directory (Docker mode)",
+            )
+        )
+
+        cloud_provider = context.get_config("cloud_provider", "")
+        if cloud_provider.lower() != "none":
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=Path("compose", "production", "nginx"),
+                    description="Remove nginx Docker files (cloud provider selected)",
+                )
+            )
+
+        if cloud_provider != "AWS":
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=Path("compose", "production", "aws"),
+                    description="Remove AWS Docker files (non-AWS provider)",
+                )
+            )
+
+        return actions
+
+    def _plan_docker_disabled(self, context: ExecutionContext) -> list:
+        actions = []
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path(".devcontainer"),
+                description="Remove devcontainer directory",
+            )
+        )
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("compose"),
+                description="Remove compose directory",
+            )
+        )
+
+        for file_name in [
+            "docker-compose.local.yml",
+            "docker-compose.production.yml",
+            ".dockerignore",
+            "justfile",
+        ]:
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path(file_name),
+                    description=f"Remove Docker file: {file_name}",
+                )
+            )
+
+        if context.equals("editor", "PyCharm"):
+            for file_name in ["docker_compose_up_django.xml", "docker_compose_up_docs.xml"]:
+                actions.append(
+                    DeleteFileAction(
+                        file_path=Path(".idea", "runConfigurations", file_name),
+                        description=f"Remove PyCharm Docker run config: {file_name}",
+                    )
+                )
+
+        return actions

--- a/hooks/strategies/docker.py
+++ b/hooks/strategies/docker.py
@@ -30,7 +30,7 @@ class DockerStrategy(FeatureStrategy):
             DeleteDirectoryAction(
                 dir_path=Path("utility"),
                 description="Remove utility directory (Docker mode)",
-            )
+            ),
         )
 
         cloud_provider = context.get_config("cloud_provider", "")
@@ -39,7 +39,7 @@ class DockerStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=Path("compose", "production", "nginx"),
                     description="Remove nginx Docker files (cloud provider selected)",
-                )
+                ),
             )
 
         if cloud_provider != "AWS":
@@ -47,7 +47,7 @@ class DockerStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=Path("compose", "production", "aws"),
                     description="Remove AWS Docker files (non-AWS provider)",
-                )
+                ),
             )
 
         return actions
@@ -59,13 +59,13 @@ class DockerStrategy(FeatureStrategy):
             DeleteDirectoryAction(
                 dir_path=Path(".devcontainer"),
                 description="Remove devcontainer directory",
-            )
+            ),
         )
         actions.append(
             DeleteDirectoryAction(
                 dir_path=Path("compose"),
                 description="Remove compose directory",
-            )
+            ),
         )
 
         for file_name in [
@@ -78,7 +78,7 @@ class DockerStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path(file_name),
                     description=f"Remove Docker file: {file_name}",
-                )
+                ),
             )
 
         if context.equals("editor", "PyCharm"):
@@ -87,7 +87,7 @@ class DockerStrategy(FeatureStrategy):
                     DeleteFileAction(
                         file_path=Path(".idea", "runConfigurations", file_name),
                         description=f"Remove PyCharm Docker run config: {file_name}",
-                    )
+                    ),
                 )
 
         return actions

--- a/hooks/strategies/editor.py
+++ b/hooks/strategies/editor.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from hooks.core.actions import DeleteDirectoryAction
-from hooks.core.actions import DeleteFileAction
 from hooks.core.context import ExecutionContext
 from hooks.core.strategies import FeatureStrategy
 from hooks.core.strategies import strategy
@@ -21,7 +20,7 @@ class EditorStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=idea_dir_path,
                     description="Remove PyCharm .idea directory",
-                )
+                ),
             )
 
         docs_dir_path = Path("docs", "pycharm")
@@ -30,7 +29,7 @@ class EditorStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=docs_dir_path,
                     description="Remove PyCharm documentation",
-                )
+                ),
             )
 
         return actions

--- a/hooks/strategies/editor.py
+++ b/hooks/strategies/editor.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("editor", "Handle editor-specific files")
+class EditorStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return not context.equals("editor", "PyCharm")
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+
+        idea_dir_path = Path(".idea")
+        if idea_dir_path.exists():
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=idea_dir_path,
+                    description="Remove PyCharm .idea directory",
+                )
+            )
+
+        docs_dir_path = Path("docs", "pycharm")
+        if docs_dir_path.exists():
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=docs_dir_path,
+                    description="Remove PyCharm documentation",
+                )
+            )
+
+        return actions

--- a/hooks/strategies/frontend_pipeline.py
+++ b/hooks/strategies/frontend_pipeline.py
@@ -1,0 +1,193 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import ModifyJsonFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("frontend_pipeline", "Handle frontend pipeline configuration")
+class FrontendPipelineStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        pipeline = context.get_config("frontend_pipeline", "None")
+        use_docker = context.is_enabled("use_docker")
+        use_async = context.is_enabled("use_async")
+
+        if pipeline in ["None", "Django Compressor"]:
+            return self._plan_no_frontend(use_docker)
+        else:
+            return self._plan_frontend_pipeline(pipeline, use_docker, use_async)
+
+    def _plan_no_frontend(self, use_docker: bool) -> list:
+        actions = []
+
+        actions.append(
+            DeleteFileAction(
+                file_path=Path("gulpfile.mjs"),
+                description="Remove Gulp file",
+            )
+        )
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("webpack"),
+                description="Remove webpack directory",
+            )
+        )
+
+        vendors_js_path = Path("{{ cookiecutter.project_slug }}", "static", "js", "vendors.js")
+        if vendors_js_path.exists():
+            actions.append(
+                DeleteFileAction(
+                    file_path=vendors_js_path,
+                    description="Remove vendors.js",
+                )
+            )
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("{{cookiecutter.project_slug}}", "static", "sass"),
+                description="Remove Sass directory",
+            )
+        )
+
+        actions.append(
+            DeleteFileAction(
+                file_path=Path("package.json"),
+                description="Remove package.json",
+            )
+        )
+
+        actions.append(
+            DeleteFileAction(
+                file_path=Path(".pre-commit-config.yaml"),
+                description="Remove prettier pre-commit (placeholder)",
+            )
+        )
+
+        if use_docker:
+            actions.append(
+                DeleteDirectoryAction(
+                    dir_path=Path("compose", "local", "node"),
+                    description="Remove Node Dockerfile",
+                )
+            )
+
+        return actions
+
+    def _plan_frontend_pipeline(self, pipeline: str, use_docker: bool, use_async: bool) -> list:
+        actions = []
+
+        project_css_path = Path("{{ cookiecutter.project_slug }}", "static", "css", "project.css")
+        if project_css_path.exists():
+            actions.append(
+                DeleteFileAction(
+                    file_path=project_css_path,
+                    description="Remove project.css",
+                )
+            )
+
+        if pipeline == "Gulp":
+            actions.extend(self._plan_gulp(use_docker, use_async))
+        elif pipeline == "Webpack":
+            actions.extend(self._plan_webpack(use_docker, use_async))
+
+        return actions
+
+    def _plan_gulp(self, use_docker: bool, use_async: bool) -> list:
+        actions = []
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("webpack"),
+                description="Remove webpack directory (Gulp mode)",
+            )
+        )
+
+        actions.append(
+            ModifyJsonFileAction(
+                file_path=Path("package.json"),
+                remove_dev_deps=[
+                    "@babel/core",
+                    "@babel/preset-env",
+                    "babel-loader",
+                    "concurrently",
+                    "css-loader",
+                    "mini-css-extract-plugin",
+                    "postcss-loader",
+                    "postcss-preset-env",
+                    "sass-loader",
+                    "webpack",
+                    "webpack-bundle-tracker",
+                    "webpack-cli",
+                    "webpack-dev-server",
+                    "webpack-merge",
+                ],
+                remove_keys=["babel"],
+                update_scripts={
+                    "dev": "gulp",
+                    "build": "gulp build",
+                },
+                description="Update package.json for Gulp",
+            )
+        )
+
+        return actions
+
+    def _plan_webpack(self, use_docker: bool, use_async: bool) -> list:
+        actions = []
+
+        actions.append(
+            DeleteFileAction(
+                file_path=Path("gulpfile.mjs"),
+                description="Remove Gulp file (Webpack mode)",
+            )
+        )
+
+        remove_dev_deps = [
+            "browser-sync",
+            "cssnano",
+            "gulp",
+            "gulp-concat",
+            "gulp-imagemin",
+            "gulp-plumber",
+            "gulp-postcss",
+            "gulp-rename",
+            "gulp-sass",
+            "gulp-uglify-es",
+        ]
+
+        scripts = {
+            "dev": "webpack serve --config webpack/dev.config.js",
+            "build": "webpack --config webpack/prod.config.js",
+        }
+
+        if not use_docker:
+            dev_django_cmd = (
+                "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
+            )
+            scripts.update(
+                {
+                    "dev": "concurrently npm:dev:*",
+                    "dev:webpack": "webpack serve --config webpack/dev.config.js",
+                    "dev:django": dev_django_cmd,
+                }
+            )
+        else:
+            remove_dev_deps.append("concurrently")
+
+        actions.append(
+            ModifyJsonFileAction(
+                file_path=Path("package.json"),
+                remove_dev_deps=remove_dev_deps,
+                update_scripts=scripts,
+                description="Update package.json for Webpack",
+            )
+        )
+
+        return actions

--- a/hooks/strategies/frontend_pipeline.py
+++ b/hooks/strategies/frontend_pipeline.py
@@ -20,8 +20,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
 
         if pipeline in ["None", "Django Compressor"]:
             return self._plan_no_frontend(use_docker)
-        else:
-            return self._plan_frontend_pipeline(pipeline, use_docker, use_async)
+        return self._plan_frontend_pipeline(pipeline, use_docker, use_async)
 
     def _plan_no_frontend(self, use_docker: bool) -> list:
         actions = []
@@ -30,14 +29,14 @@ class FrontendPipelineStrategy(FeatureStrategy):
             DeleteFileAction(
                 file_path=Path("gulpfile.mjs"),
                 description="Remove Gulp file",
-            )
+            ),
         )
 
         actions.append(
             DeleteDirectoryAction(
                 dir_path=Path("webpack"),
                 description="Remove webpack directory",
-            )
+            ),
         )
 
         vendors_js_path = Path("{{ cookiecutter.project_slug }}", "static", "js", "vendors.js")
@@ -46,28 +45,28 @@ class FrontendPipelineStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=vendors_js_path,
                     description="Remove vendors.js",
-                )
+                ),
             )
 
         actions.append(
             DeleteDirectoryAction(
                 dir_path=Path("{{cookiecutter.project_slug}}", "static", "sass"),
                 description="Remove Sass directory",
-            )
+            ),
         )
 
         actions.append(
             DeleteFileAction(
                 file_path=Path("package.json"),
                 description="Remove package.json",
-            )
+            ),
         )
 
         actions.append(
             DeleteFileAction(
                 file_path=Path(".pre-commit-config.yaml"),
                 description="Remove prettier pre-commit (placeholder)",
-            )
+            ),
         )
 
         if use_docker:
@@ -75,7 +74,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
                 DeleteDirectoryAction(
                     dir_path=Path("compose", "local", "node"),
                     description="Remove Node Dockerfile",
-                )
+                ),
             )
 
         return actions
@@ -89,7 +88,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=project_css_path,
                     description="Remove project.css",
-                )
+                ),
             )
 
         if pipeline == "Gulp":
@@ -106,7 +105,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
             DeleteDirectoryAction(
                 dir_path=Path("webpack"),
                 description="Remove webpack directory (Gulp mode)",
-            )
+            ),
         )
 
         actions.append(
@@ -134,7 +133,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
                     "build": "gulp build",
                 },
                 description="Update package.json for Gulp",
-            )
+            ),
         )
 
         return actions
@@ -146,7 +145,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
             DeleteFileAction(
                 file_path=Path("gulpfile.mjs"),
                 description="Remove Gulp file (Webpack mode)",
-            )
+            ),
         )
 
         remove_dev_deps = [
@@ -176,7 +175,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
                     "dev": "concurrently npm:dev:*",
                     "dev:webpack": "webpack serve --config webpack/dev.config.js",
                     "dev:django": dev_django_cmd,
-                }
+                },
             )
         else:
             remove_dev_deps.append("concurrently")
@@ -187,7 +186,7 @@ class FrontendPipelineStrategy(FeatureStrategy):
                 remove_dev_deps=remove_dev_deps,
                 update_scripts=scripts,
                 description="Update package.json for Webpack",
-            )
+            ),
         )
 
         return actions

--- a/hooks/strategies/heroku.py
+++ b/hooks/strategies/heroku.py
@@ -37,14 +37,14 @@ class HerokuStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path(file_name),
                     description=f"Remove Heroku file: {file_name}",
-                )
+                ),
             )
 
         actions.append(
             DeleteDirectoryAction(
                 dir_path=Path("bin"),
                 description="Remove Heroku bin directory",
-            )
+            ),
         )
 
         return actions
@@ -58,14 +58,14 @@ class HerokuStrategy(FeatureStrategy):
                 file_path=Path(".gitignore"),
                 content=".env",
                 description="Add .env to gitignore",
-            )
+            ),
         )
         actions.append(
             AppendFileAction(
                 file_path=Path(".gitignore"),
                 content=".envs/*",
                 description="Add .envs/* to gitignore",
-            )
+            ),
         )
 
         if keep_local_envs:
@@ -74,7 +74,7 @@ class HerokuStrategy(FeatureStrategy):
                     file_path=Path(".gitignore"),
                     content="!.envs/.local/",
                     description="Keep local envs in VCS",
-                )
+                ),
             )
 
         return actions

--- a/hooks/strategies/heroku.py
+++ b/hooks/strategies/heroku.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from hooks.core.actions import AppendFileAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("heroku", "Handle Heroku deployment files")
+class HerokuStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        use_heroku = context.is_enabled("use_heroku")
+        use_docker = context.is_enabled("use_docker")
+
+        if not use_heroku:
+            actions.extend(self._plan_heroku_disabled(context))
+
+        if use_docker or use_heroku:
+            actions.extend(self._plan_env_gitignore(context))
+
+        return actions
+
+    def _plan_heroku_disabled(self, context: ExecutionContext) -> list:
+        actions = []
+        ci_tool = context.get_config("ci_tool", "")
+
+        for file_name in ["Procfile"]:
+            if file_name == "requirements.txt" and ci_tool.lower() == "travis":
+                continue
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path(file_name),
+                    description=f"Remove Heroku file: {file_name}",
+                )
+            )
+
+        actions.append(
+            DeleteDirectoryAction(
+                dir_path=Path("bin"),
+                description="Remove Heroku bin directory",
+            )
+        )
+
+        return actions
+
+    def _plan_env_gitignore(self, context: ExecutionContext) -> list:
+        actions = []
+        keep_local_envs = context.is_enabled("keep_local_envs_in_vcs")
+
+        actions.append(
+            AppendFileAction(
+                file_path=Path(".gitignore"),
+                content=".env",
+                description="Add .env to gitignore",
+            )
+        )
+        actions.append(
+            AppendFileAction(
+                file_path=Path(".gitignore"),
+                content=".envs/*",
+                description="Add .envs/* to gitignore",
+            )
+        )
+
+        if keep_local_envs:
+            actions.append(
+                AppendFileAction(
+                    file_path=Path(".gitignore"),
+                    content="!.envs/.local/",
+                    description="Keep local envs in VCS",
+                )
+            )
+
+        return actions

--- a/hooks/strategies/license.py
+++ b/hooks/strategies/license.py
@@ -22,7 +22,7 @@ class OpenSourceLicenseStrategy(FeatureStrategy):
                     DeleteFileAction(
                         file_path=Path(file_name),
                         description=f"Remove open source file: {file_name}",
-                    )
+                    ),
                 )
 
         if license_value != "GPLv3":
@@ -30,7 +30,7 @@ class OpenSourceLicenseStrategy(FeatureStrategy):
                 DeleteFileAction(
                     file_path=Path("COPYING"),
                     description="Remove GPLv3 license file",
-                )
+                ),
             )
 
         return actions

--- a/hooks/strategies/license.py
+++ b/hooks/strategies/license.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("open_source_license", "Handle open source license file removal")
+class OpenSourceLicenseStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        license_value = context.get_config("open_source_license", "")
+        return license_value == "Not open source" or license_value != "GPLv3"
+
+    def plan(self, context: ExecutionContext) -> list[DeleteFileAction]:
+        actions = []
+        license_value = context.get_config("open_source_license", "")
+
+        if license_value == "Not open source":
+            for file_name in ["CONTRIBUTORS.txt", "LICENSE"]:
+                actions.append(
+                    DeleteFileAction(
+                        file_path=Path(file_name),
+                        description=f"Remove open source file: {file_name}",
+                    )
+                )
+
+        if license_value != "GPLv3":
+            actions.append(
+                DeleteFileAction(
+                    file_path=Path("COPYING"),
+                    description="Remove GPLv3 license file",
+                )
+            )
+
+        return actions

--- a/hooks/strategies/rest_api.py
+++ b/hooks/strategies/rest_api.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("rest_api", "Handle REST API configuration files")
+class RestApiStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return True
+
+    def plan(self, context: ExecutionContext) -> list:
+        actions = []
+        rest_api = context.get_config("rest_api", "None")
+        project_slug = context.project_slug
+
+        if rest_api == "DRF":
+            actions.extend(self._plan_drf(project_slug))
+        elif rest_api == "Django Ninja":
+            actions.extend(self._plan_ninja(project_slug))
+        else:
+            actions.extend(self._plan_no_api(project_slug))
+
+        return actions
+
+    def _plan_drf(self, project_slug: str) -> list:
+        return [
+            DeleteFileAction(
+                file_path=Path("config", "api.py"),
+                description="Remove Ninja API config (DRF mode)",
+            ),
+            DeleteFileAction(
+                file_path=Path(project_slug, "users", "api", "schema.py"),
+                description="Remove Ninja schema (DRF mode)",
+            ),
+        ]
+
+    def _plan_ninja(self, project_slug: str) -> list:
+        return [
+            DeleteFileAction(
+                file_path=Path("config", "api_router.py"),
+                description="Remove DRF router (Ninja mode)",
+            ),
+            DeleteFileAction(
+                file_path=Path(project_slug, "users", "api", "serializers.py"),
+                description="Remove DRF serializers (Ninja mode)",
+            ),
+        ]
+
+    def _plan_no_api(self, project_slug: str) -> list:
+        return [
+            DeleteFileAction(
+                file_path=Path("config", "api_router.py"),
+                description="Remove DRF router (no API)",
+            ),
+            DeleteFileAction(
+                file_path=Path("config", "api.py"),
+                description="Remove Ninja API config (no API)",
+            ),
+            DeleteFileAction(
+                file_path=Path(project_slug, "users", "api", "serializers.py"),
+                description="Remove DRF serializers (no API)",
+            ),
+            DeleteFileAction(
+                file_path=Path(project_slug, "users", "api", "schema.py"),
+                description="Remove Ninja schema (no API)",
+            ),
+            DeleteDirectoryAction(
+                dir_path=Path(project_slug, "users", "api"),
+                description="Remove API directory (no API)",
+            ),
+            DeleteDirectoryAction(
+                dir_path=Path(project_slug, "users", "tests", "api"),
+                description="Remove API tests directory (no API)",
+            ),
+        ]

--- a/hooks/strategies/username_type.py
+++ b/hooks/strategies/username_type.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.strategies import FeatureStrategy
+from hooks.core.strategies import strategy
+
+
+@strategy("username_type", "Handle username type configuration")
+class UsernameTypeStrategy(FeatureStrategy):
+    def should_apply(self, context: ExecutionContext) -> bool:
+        return context.equals("username_type", "username")
+
+    def plan(self, context: ExecutionContext) -> list[DeleteFileAction]:
+        project_slug = context.project_slug
+        users_path = Path(project_slug) / "users"
+
+        return [
+            DeleteFileAction(
+                file_path=users_path / "managers.py",
+                description="Remove custom user manager (username mode)",
+            ),
+            DeleteFileAction(
+                file_path=users_path / "tests" / "test_managers.py",
+                description="Remove user manager tests (username mode)",
+            ),
+        ]

--- a/tests/test_core_actions.py
+++ b/tests/test_core_actions.py
@@ -1,23 +1,13 @@
 """Tests for the core actions module."""
 
 import json
-import os
-import tempfile
-from pathlib import Path
 
-import pytest
-
-from hooks.core.actions import (
-    Action,
-    ActionType,
-    AppendFileAction,
-    CreateDirectoryAction,
-    DeleteDirectoryAction,
-    DeleteFileAction,
-    ModifyFileAction,
-    ModifyJsonFileAction,
-    RunCommandAction,
-)
+from hooks.core.actions import AppendFileAction
+from hooks.core.actions import CreateDirectoryAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import ModifyFileAction
+from hooks.core.actions import ModifyJsonFileAction
 
 
 class TestDeleteFileAction:
@@ -192,8 +182,8 @@ class TestModifyJsonFileAction:
                         "gulp": "4.0.0",
                     },
                     "scripts": {},
-                }
-            )
+                },
+            ),
         )
 
         action = ModifyJsonFileAction(
@@ -214,8 +204,8 @@ class TestModifyJsonFileAction:
                 {
                     "devDependencies": {},
                     "scripts": {"old": "script"},
-                }
-            )
+                },
+            ),
         )
 
         action = ModifyJsonFileAction(
@@ -237,8 +227,8 @@ class TestModifyJsonFileAction:
                     "devDependencies": {},
                     "scripts": {},
                     "babel": {"presets": []},
-                }
-            )
+                },
+            ),
         )
 
         action = ModifyJsonFileAction(

--- a/tests/test_core_actions.py
+++ b/tests/test_core_actions.py
@@ -1,0 +1,268 @@
+"""Tests for the core actions module."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hooks.core.actions import (
+    Action,
+    ActionType,
+    AppendFileAction,
+    CreateDirectoryAction,
+    DeleteDirectoryAction,
+    DeleteFileAction,
+    ModifyFileAction,
+    ModifyJsonFileAction,
+    RunCommandAction,
+)
+
+
+class TestDeleteFileAction:
+    def test_delete_existing_file(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        action = DeleteFileAction(file_path=test_file)
+        result = action.execute()
+
+        assert result.success
+        assert not test_file.exists()
+        assert result.backup_data == b"hello world"
+
+    def test_delete_nonexistent_file(self, tmp_path):
+        test_file = tmp_path / "nonexistent.txt"
+
+        action = DeleteFileAction(file_path=test_file)
+        result = action.execute()
+
+        assert result.success
+        assert "does not exist" in result.message
+
+    def test_delete_file_rollback(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        action = DeleteFileAction(file_path=test_file)
+        result = action.execute()
+        rollback_result = action.rollback(result.backup_data)
+
+        assert rollback_result.success
+        assert test_file.exists()
+        assert test_file.read_text() == "hello world"
+
+    def test_dry_run_does_not_delete(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        action = DeleteFileAction(file_path=test_file)
+        result = action.execute(dry_run=True)
+
+        assert result.success
+        assert test_file.exists()
+        assert "[DRY-RUN]" in result.message
+
+
+class TestDeleteDirectoryAction:
+    def test_delete_existing_directory(self, tmp_path):
+        test_dir = tmp_path / "test_dir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+
+        action = DeleteDirectoryAction(dir_path=test_dir)
+        result = action.execute()
+
+        assert result.success
+        assert not test_dir.exists()
+
+    def test_delete_nonexistent_directory(self, tmp_path):
+        test_dir = tmp_path / "nonexistent"
+
+        action = DeleteDirectoryAction(dir_path=test_dir)
+        result = action.execute()
+
+        assert result.success
+        assert "does not exist" in result.message
+
+
+class TestCreateDirectoryAction:
+    def test_create_new_directory(self, tmp_path):
+        new_dir = tmp_path / "new_dir"
+
+        action = CreateDirectoryAction(dir_path=new_dir)
+        result = action.execute()
+
+        assert result.success
+        assert new_dir.exists()
+
+    def test_create_nested_directory(self, tmp_path):
+        new_dir = tmp_path / "parent" / "child" / "grandchild"
+
+        action = CreateDirectoryAction(dir_path=new_dir)
+        result = action.execute()
+
+        assert result.success
+        assert new_dir.exists()
+
+    def test_create_existing_directory(self, tmp_path):
+        existing_dir = tmp_path / "existing"
+        existing_dir.mkdir()
+
+        action = CreateDirectoryAction(dir_path=existing_dir)
+        result = action.execute()
+
+        assert result.success
+        assert "already exists" in result.message
+
+
+class TestModifyFileAction:
+    def test_modify_file_content(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello {{ name }}!")
+
+        action = ModifyFileAction(
+            file_path=test_file,
+            modifications={"{{ name }}": "World"},
+        )
+        result = action.execute()
+
+        assert result.success
+        assert test_file.read_text() == "Hello World!"
+
+    def test_modify_file_multiple_replacements(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("{{ a }} and {{ b }}")
+
+        action = ModifyFileAction(
+            file_path=test_file,
+            modifications={"{{ a }}": "1", "{{ b }}": "2"},
+        )
+        result = action.execute()
+
+        assert result.success
+        assert test_file.read_text() == "1 and 2"
+
+    def test_modify_file_rollback(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        original_content = "original content"
+        test_file.write_text(original_content)
+
+        action = ModifyFileAction(
+            file_path=test_file,
+            modifications={"original": "modified"},
+        )
+        result = action.execute()
+        rollback_result = action.rollback(result.backup_data)
+
+        assert rollback_result.success
+        assert test_file.read_text() == original_content
+
+
+class TestAppendFileAction:
+    def test_append_to_existing_file(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("line1\n")
+
+        action = AppendFileAction(file_path=test_file, content="line2")
+        result = action.execute()
+
+        assert result.success
+        assert test_file.read_text() == "line1\nline2\n"
+
+    def test_append_to_new_file(self, tmp_path):
+        test_file = tmp_path / "new.txt"
+
+        action = AppendFileAction(file_path=test_file, content="first line")
+        result = action.execute()
+
+        assert result.success
+        assert test_file.read_text() == "first line\n"
+
+
+class TestModifyJsonFileAction:
+    def test_remove_dev_dependencies(self, tmp_path):
+        package_json = tmp_path / "package.json"
+        package_json.write_text(
+            json.dumps(
+                {
+                    "devDependencies": {
+                        "webpack": "5.0.0",
+                        "gulp": "4.0.0",
+                    },
+                    "scripts": {},
+                }
+            )
+        )
+
+        action = ModifyJsonFileAction(
+            file_path=package_json,
+            remove_dev_deps=["gulp"],
+        )
+        result = action.execute()
+
+        assert result.success
+        content = json.loads(package_json.read_text())
+        assert "gulp" not in content["devDependencies"]
+        assert "webpack" in content["devDependencies"]
+
+    def test_update_scripts(self, tmp_path):
+        package_json = tmp_path / "package.json"
+        package_json.write_text(
+            json.dumps(
+                {
+                    "devDependencies": {},
+                    "scripts": {"old": "script"},
+                }
+            )
+        )
+
+        action = ModifyJsonFileAction(
+            file_path=package_json,
+            update_scripts={"new": "script", "old": "updated"},
+        )
+        result = action.execute()
+
+        assert result.success
+        content = json.loads(package_json.read_text())
+        assert content["scripts"]["new"] == "script"
+        assert content["scripts"]["old"] == "updated"
+
+    def test_remove_keys(self, tmp_path):
+        package_json = tmp_path / "package.json"
+        package_json.write_text(
+            json.dumps(
+                {
+                    "devDependencies": {},
+                    "scripts": {},
+                    "babel": {"presets": []},
+                }
+            )
+        )
+
+        action = ModifyJsonFileAction(
+            file_path=package_json,
+            remove_keys=["babel"],
+        )
+        result = action.execute()
+
+        assert result.success
+        content = json.loads(package_json.read_text())
+        assert "babel" not in content
+
+
+class TestActionDescription:
+    def test_action_describe(self, tmp_path):
+        action = DeleteFileAction(
+            file_path=tmp_path / "test.txt",
+            description="Custom description",
+        )
+        assert action.describe() == "Custom description"
+
+    def test_action_to_dict(self, tmp_path):
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        d = action.to_dict()
+
+        assert d["type"] == "delete_file"
+        assert "file_path" in d

--- a/tests/test_core_audit.py
+++ b/tests/test_core_audit.py
@@ -1,0 +1,170 @@
+"""Tests for the core audit module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.core.actions import DeleteFileAction, ModifyFileAction
+from hooks.core.audit import AuditEntry, AuditLogger, AuditReport, AuditStatus
+
+
+class TestAuditEntry:
+    def test_audit_entry_creation(self, tmp_path):
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        entry = AuditEntry(action=action, sequence_number=1)
+
+        assert entry.action == action
+        assert entry.status == AuditStatus.PENDING
+        assert entry.sequence_number == 1
+
+    def test_audit_entry_to_dict(self, tmp_path):
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        entry = AuditEntry(action=action, sequence_number=1)
+
+        d = entry.to_dict()
+
+        assert d["sequence_number"] == 1
+        assert d["status"] == "pending"
+        assert d["action"]["type"] == "delete_file"
+
+
+class TestAuditReport:
+    def test_empty_report(self):
+        report = AuditReport()
+
+        assert report.total_actions == 0
+        assert report.successful_actions == 0
+        assert report.failed_actions == 0
+
+    def test_report_counts(self, tmp_path):
+        report = AuditReport()
+
+        action1 = DeleteFileAction(file_path=tmp_path / "test1.txt")
+        action2 = DeleteFileAction(file_path=tmp_path / "test2.txt")
+        action3 = ModifyFileAction(file_path=tmp_path / "test3.txt", modifications={})
+
+        entry1 = AuditEntry(action=action1, status=AuditStatus.SUCCESS)
+        entry2 = AuditEntry(action=action2, status=AuditStatus.FAILED)
+        entry3 = AuditEntry(action=action3, status=AuditStatus.SUCCESS)
+
+        report.entries = [entry1, entry2, entry3]
+
+        assert report.total_actions == 3
+        assert report.successful_actions == 2
+        assert report.failed_actions == 1
+
+    def test_report_to_dict(self, tmp_path):
+        report = AuditReport(project_name="test_project")
+
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        entry = AuditEntry(action=action, status=AuditStatus.SUCCESS, sequence_number=1)
+        report.entries = [entry]
+
+        d = report.to_dict()
+
+        assert d["project_name"] == "test_project"
+        assert d["summary"]["total_actions"] == 1
+        assert d["summary"]["successful"] == 1
+
+    def test_report_to_markdown(self, tmp_path):
+        report = AuditReport(project_name="test_project")
+
+        action = DeleteFileAction(
+            file_path=tmp_path / "test.txt",
+            description="Delete test file",
+        )
+        entry = AuditEntry(action=action, status=AuditStatus.SUCCESS, sequence_number=1)
+        report.entries = [entry]
+        report.end_time = report.start_time
+
+        md = report.to_markdown()
+
+        assert "# Project Generation Report" in md
+        assert "test_project" in md
+        assert "Delete test file" in md
+        assert "✅" in md
+
+
+class TestAuditLogger:
+    def test_log_action(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+
+        entry = logger.log_action(action)
+
+        assert len(logger.report.entries) == 1
+        assert entry.action == action
+        assert entry.sequence_number == 1
+
+    def test_log_result(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        entry = logger.log_action(action)
+
+        from hooks.core.actions import ActionResult
+
+        result = ActionResult(success=True, message="Done")
+        logger.log_result(entry, result)
+
+        assert entry.result == result
+        assert entry.status == AuditStatus.SUCCESS
+
+    def test_log_rollback(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        entry = logger.log_action(action)
+
+        from hooks.core.actions import ActionResult
+
+        rollback_result = ActionResult(success=True, message="Rolled back")
+        logger.log_rollback(entry, rollback_result)
+
+        assert entry.rollback_result == rollback_result
+        assert entry.status == AuditStatus.ROLLED_BACK
+
+    def test_finalize(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        logger.log_action(action)
+
+        report = logger.finalize()
+
+        assert report.end_time is not None
+        assert report.project_name == "test"
+
+    def test_get_successful_entries(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+
+        action1 = DeleteFileAction(file_path=tmp_path / "test1.txt")
+        action2 = DeleteFileAction(file_path=tmp_path / "test2.txt")
+
+        entry1 = logger.log_action(action1)
+        entry2 = logger.log_action(action2)
+
+        from hooks.core.actions import ActionResult
+
+        logger.log_result(entry1, ActionResult(success=True))
+        logger.log_result(entry2, ActionResult(success=False))
+
+        successful = logger.get_successful_entries()
+        assert len(successful) == 1
+        assert successful[0] == entry1
+
+    def test_get_failed_entries(self, tmp_path):
+        logger = AuditLogger(project_name="test")
+
+        action1 = DeleteFileAction(file_path=tmp_path / "test1.txt")
+        action2 = DeleteFileAction(file_path=tmp_path / "test2.txt")
+
+        entry1 = logger.log_action(action1)
+        entry2 = logger.log_action(action2)
+
+        from hooks.core.actions import ActionResult
+
+        logger.log_result(entry1, ActionResult(success=True))
+        logger.log_result(entry2, ActionResult(success=False, error="Failed"))
+
+        failed = logger.get_failed_entries()
+        assert len(failed) == 1
+        assert failed[0] == entry2

--- a/tests/test_core_audit.py
+++ b/tests/test_core_audit.py
@@ -1,12 +1,11 @@
 """Tests for the core audit module."""
 
-import json
-from pathlib import Path
-
-import pytest
-
-from hooks.core.actions import DeleteFileAction, ModifyFileAction
-from hooks.core.audit import AuditEntry, AuditLogger, AuditReport, AuditStatus
+from hooks.core.actions import DeleteFileAction
+from hooks.core.actions import ModifyFileAction
+from hooks.core.audit import AuditEntry
+from hooks.core.audit import AuditLogger
+from hooks.core.audit import AuditReport
+from hooks.core.audit import AuditStatus
 
 
 class TestAuditEntry:

--- a/tests/test_core_context.py
+++ b/tests/test_core_context.py
@@ -1,0 +1,157 @@
+"""Tests for the core context module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import Checkpoint, ExecutionContext, FailurePolicy
+
+
+class TestExecutionContext:
+    def test_context_creation(self):
+        context = ExecutionContext(project_slug="test_project")
+
+        assert context.project_slug == "test_project"
+        assert context.failure_policy == FailurePolicy.STOP_IMMEDIATELY
+        assert not context.dry_run
+
+    def test_context_with_config(self):
+        config = {"use_docker": "y", "use_celery": "n"}
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config=config,
+        )
+
+        assert context.get_config("use_docker") == "y"
+        assert context.get_config("use_celery") == "n"
+        assert context.get_config("missing", "default") == "default"
+
+    def test_is_enabled(self):
+        config = {"use_docker": "y", "use_celery": "n", "debug": "true"}
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config=config,
+        )
+
+        assert context.is_enabled("use_docker")
+        assert not context.is_enabled("use_celery")
+        assert context.is_enabled("debug")
+
+    def test_equals(self):
+        config = {"editor": "PyCharm", "cloud_provider": "AWS"}
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config=config,
+        )
+
+        assert context.equals("editor", "PyCharm")
+        assert context.equals("editor", "pycharm")
+        assert not context.equals("editor", "VS Code")
+
+    def test_create_checkpoint(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        from hooks.core.audit import AuditEntry
+
+        entry = AuditEntry(action=action, sequence_number=1)
+        checkpoint = context.create_checkpoint(entry, b"backup_data")
+
+        assert len(context.checkpoints) == 1
+        assert checkpoint.sequence_number == 1
+        assert checkpoint.backup_data == b"backup_data"
+
+    def test_get_backup(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        from hooks.core.audit import AuditEntry
+
+        entry = AuditEntry(action=action, sequence_number=1)
+        context.create_checkpoint(entry, b"backup_data")
+
+        backup = context.get_backup(1)
+        assert backup == b"backup_data"
+
+    def test_get_checkpoints_for_rollback(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+        from hooks.core.audit import AuditEntry
+
+        action1 = DeleteFileAction(file_path=tmp_path / "test1.txt")
+        entry1 = AuditEntry(action=action1, sequence_number=1)
+        context.create_checkpoint(entry1, b"backup1")
+
+        action2 = DeleteFileAction(file_path=tmp_path / "test2.txt")
+        entry2 = AuditEntry(action=action2, sequence_number=2)
+        context.create_checkpoint(entry2, None)
+
+        action3 = DeleteFileAction(file_path=tmp_path / "test3.txt")
+        entry3 = AuditEntry(action=action3, sequence_number=3)
+        context.create_checkpoint(entry3, b"backup3")
+
+        checkpoints = context.get_checkpoints_for_rollback()
+
+        assert len(checkpoints) == 2
+        assert checkpoints[0].sequence_number == 3
+        assert checkpoints[1].sequence_number == 1
+
+    def test_get_report(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+
+        report = context.get_report()
+
+        assert "test_project" in report
+        assert "Project Generation Report" in report
+
+    def test_get_json_report(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+
+        report = context.get_json_report()
+
+        assert report["project_name"] == "test_project"
+        assert "summary" in report
+
+    def test_save_report(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+        report_path = tmp_path / "report.md"
+
+        context.save_report(report_path)
+
+        assert report_path.exists()
+        content = report_path.read_text()
+        assert "test_project" in content
+
+    def test_save_json_report(self, tmp_path):
+        context = ExecutionContext(project_slug="test_project")
+        report_path = tmp_path / "report.json"
+
+        context.save_json_report(report_path)
+
+        assert report_path.exists()
+        content = json.loads(report_path.read_text())
+        assert content["project_name"] == "test_project"
+
+
+class TestFailurePolicy:
+    def test_failure_policy_values(self):
+        assert FailurePolicy.STOP_IMMEDIATELY.value == "stop_immediately"
+        assert FailurePolicy.CONTINUE_ON_ERROR.value == "continue_on_error"
+        assert FailurePolicy.ROLLBACK_ALL.value == "rollback_all"
+        assert FailurePolicy.ROLLBACK_FAILED.value == "rollback_failed"
+
+
+class TestCheckpoint:
+    def test_checkpoint_creation(self, tmp_path):
+        action = DeleteFileAction(file_path=tmp_path / "test.txt")
+        from hooks.core.audit import AuditEntry
+
+        entry = AuditEntry(action=action, sequence_number=1)
+        checkpoint = Checkpoint(
+            sequence_number=1,
+            entry=entry,
+            backup_data=b"backup",
+        )
+
+        assert checkpoint.sequence_number == 1
+        assert checkpoint.entry == entry
+        assert checkpoint.backup_data == b"backup"

--- a/tests/test_core_context.py
+++ b/tests/test_core_context.py
@@ -1,12 +1,11 @@
 """Tests for the core context module."""
 
 import json
-from pathlib import Path
-
-import pytest
 
 from hooks.core.actions import DeleteFileAction
-from hooks.core.context import Checkpoint, ExecutionContext, FailurePolicy
+from hooks.core.context import Checkpoint
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
 
 
 class TestExecutionContext:

--- a/tests/test_core_executor.py
+++ b/tests/test_core_executor.py
@@ -1,0 +1,152 @@
+"""Tests for the core executor module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.core.actions import DeleteFileAction, ModifyFileAction
+from hooks.core.context import ExecutionContext, FailurePolicy
+from hooks.core.executor import ActionExecutor, ExecutionResult
+
+
+class TestActionExecutor:
+    def test_execute_empty_actions(self):
+        context = ExecutionContext(project_slug="test_project")
+        executor = ActionExecutor(context)
+
+        result = executor.execute([])
+
+        assert result.success
+        assert "No actions" in result.message
+
+    def test_execute_single_action_success(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        context = ExecutionContext(project_slug="test_project")
+        executor = ActionExecutor(context)
+
+        action = DeleteFileAction(file_path=test_file)
+        result = executor.execute([action])
+
+        assert result.success
+        assert not test_file.exists()
+
+    def test_execute_multiple_actions(self, tmp_path):
+        file1 = tmp_path / "test1.txt"
+        file2 = tmp_path / "test2.txt"
+        file1.write_text("content1")
+        file2.write_text("content2")
+
+        context = ExecutionContext(project_slug="test_project")
+        executor = ActionExecutor(context)
+
+        actions = [
+            DeleteFileAction(file_path=file1),
+            DeleteFileAction(file_path=file2),
+        ]
+        result = executor.execute(actions)
+
+        assert result.success
+        assert not file1.exists()
+        assert not file2.exists()
+
+    def test_execute_with_stop_immediately_policy(self, tmp_path):
+        file1 = tmp_path / "test1.txt"
+        file2 = tmp_path / "test2.txt"
+        file1.write_text("content1")
+        file2.write_text("content2")
+
+        context = ExecutionContext(
+            project_slug="test_project",
+            failure_policy=FailurePolicy.STOP_IMMEDIATELY,
+        )
+        executor = ActionExecutor(context)
+
+        actions = [
+            DeleteFileAction(file_path=file1),
+            DeleteFileAction(file_path=tmp_path / "nonexistent"),
+        ]
+        result = executor.execute(actions)
+
+        assert result.success
+
+    def test_dry_run_mode(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        context = ExecutionContext(
+            project_slug="test_project",
+            dry_run=True,
+        )
+        executor = ActionExecutor(context)
+
+        action = DeleteFileAction(file_path=test_file)
+        result = executor.execute([action])
+
+        assert result.success
+        assert test_file.exists()
+
+    def test_rollback_all(self, tmp_path):
+        file1 = tmp_path / "test1.txt"
+        file2 = tmp_path / "test2.txt"
+        file1.write_text("content1")
+        file2.write_text("content2")
+
+        context = ExecutionContext(
+            project_slug="test_project",
+            failure_policy=FailurePolicy.ROLLBACK_ALL,
+        )
+        executor = ActionExecutor(context)
+
+        actions = [
+            DeleteFileAction(file_path=file1),
+            DeleteFileAction(file_path=file2),
+        ]
+        result = executor.execute(actions)
+
+        assert result.success
+        assert not file1.exists()
+        assert not file2.exists()
+
+    def test_audit_logger_records_actions(self, tmp_path):
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        context = ExecutionContext(project_slug="test_project")
+        executor = ActionExecutor(context)
+
+        action = DeleteFileAction(file_path=test_file)
+        executor.execute([action])
+
+        assert len(context.audit_logger.report.entries) == 1
+
+
+class TestExecutionResult:
+    def test_success_result(self):
+        result = ExecutionResult(success=True, message="Done")
+
+        assert result.success
+        assert result.message == "Done"
+        assert bool(result)
+
+    def test_failure_result(self):
+        result = ExecutionResult(
+            success=False,
+            message="Failed",
+            failed_actions=["action1"],
+        )
+
+        assert not result.success
+        assert len(result.failed_actions) == 1
+        assert not bool(result)
+
+    def test_result_with_rollback(self):
+        result = ExecutionResult(
+            success=False,
+            message="Rolled back",
+            rolled_back_count=3,
+        )
+
+        assert result.rolled_back_count == 3

--- a/tests/test_core_executor.py
+++ b/tests/test_core_executor.py
@@ -1,13 +1,10 @@
 """Tests for the core executor module."""
 
-import json
-from pathlib import Path
-
-import pytest
-
-from hooks.core.actions import DeleteFileAction, ModifyFileAction
-from hooks.core.context import ExecutionContext, FailurePolicy
-from hooks.core.executor import ActionExecutor, ExecutionResult
+from hooks.core.actions import DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.core.context import FailurePolicy
+from hooks.core.executor import ActionExecutor
+from hooks.core.executor import ExecutionResult
 
 
 class TestActionExecutor:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,12 +1,9 @@
 """Tests for the generator module."""
 
-import json
-from pathlib import Path
-
-import pytest
-
 from hooks.core.context import FailurePolicy
-from hooks.generator import ProjectGenerator, generate_random_string, generate_random_user
+from hooks.generator import ProjectGenerator
+from hooks.generator import generate_random_string
+from hooks.generator import generate_random_user
 
 
 class TestProjectGenerator:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,192 @@
+"""Tests for the generator module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.core.context import FailurePolicy
+from hooks.generator import ProjectGenerator, generate_random_string, generate_random_user
+
+
+class TestProjectGenerator:
+    def test_generator_creation(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config)
+
+        assert generator.project_slug == "test_project"
+        assert generator.context.project_slug == "test_project"
+
+    def test_generator_with_dry_run(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config, dry_run=True)
+
+        assert generator.context.dry_run
+
+    def test_generator_with_failure_policy(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(
+            config,
+            failure_policy=FailurePolicy.CONTINUE_ON_ERROR,
+        )
+
+        assert generator.context.failure_policy == FailurePolicy.CONTINUE_ON_ERROR
+
+    def test_register_strategy(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config)
+
+        from hooks.strategies.license import OpenSourceLicenseStrategy
+
+        strategy = OpenSourceLicenseStrategy()
+        generator.register_strategy(strategy)
+
+        assert strategy in generator._strategies
+
+    def test_register_default_strategies(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config)
+        generator.register_default_strategies()
+
+        assert len(generator._strategies) == 10
+
+    def test_plan_returns_actions(self):
+        config = {
+            "project_slug": "test_project",
+            "open_source_license": "Not open source",
+            "username_type": "username",
+            "editor": "VS Code",
+            "use_docker": "n",
+            "use_heroku": "n",
+            "frontend_pipeline": "None",
+            "use_celery": "n",
+            "ci_tool": "None",
+            "rest_api": "None",
+            "use_async": "n",
+        }
+        generator = ProjectGenerator(config)
+        generator.register_default_strategies()
+
+        actions = generator.plan()
+
+        assert len(actions) > 0
+        assert all(hasattr(a, "execute") for a in actions)
+
+    def test_preview(self):
+        config = {
+            "project_slug": "test_project",
+            "open_source_license": "Not open source",
+        }
+        generator = ProjectGenerator(config)
+        generator.register_default_strategies()
+
+        preview = generator.preview()
+
+        assert "test_project" in preview
+        assert "Preview" in preview
+
+    def test_get_report(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config)
+
+        report = generator.get_report()
+
+        assert "test_project" in report
+
+    def test_get_json_report(self):
+        config = {"project_slug": "test_project"}
+        generator = ProjectGenerator(config)
+
+        report = generator.get_json_report()
+
+        assert report["project_name"] == "test_project"
+
+    def test_context_helpers(self):
+        config = {
+            "project_slug": "test_project",
+            "use_docker": "y",
+            "editor": "PyCharm",
+        }
+        generator = ProjectGenerator(config)
+
+        assert generator.context.is_enabled("use_docker")
+        assert generator.context.equals("editor", "PyCharm")
+        assert generator.context.get_config("project_slug") == "test_project"
+
+
+class TestRandomGeneration:
+    def test_generate_random_string_digits(self):
+        result = generate_random_string(10, using_digits=True)
+
+        if result:
+            assert len(result) == 10
+            assert result.isdigit()
+
+    def test_generate_random_string_letters(self):
+        result = generate_random_string(10, using_ascii_letters=True)
+
+        if result:
+            assert len(result) == 10
+            assert result.isalpha()
+
+    def test_generate_random_string_mixed(self):
+        result = generate_random_string(
+            20,
+            using_digits=True,
+            using_ascii_letters=True,
+        )
+
+        if result:
+            assert len(result) == 20
+            assert result.isalnum()
+
+    def test_generate_random_user(self):
+        result = generate_random_user()
+
+        if result:
+            assert len(result) == 32
+            assert result.isalpha()
+
+
+class TestGeneratorIntegration:
+    def test_full_generation_flow_dry_run(self, tmp_path):
+        config = {
+            "project_slug": "my_project",
+            "open_source_license": "MIT",
+            "username_type": "email",
+            "editor": "None",
+            "use_docker": "n",
+            "use_heroku": "n",
+            "frontend_pipeline": "None",
+            "use_celery": "n",
+            "ci_tool": "Github",
+            "rest_api": "DRF",
+            "use_async": "n",
+            "keep_local_envs_in_vcs": "n",
+        }
+
+        generator = ProjectGenerator(config, dry_run=True)
+        generator.register_default_strategies()
+
+        actions = generator.plan()
+
+        assert len(actions) > 0
+
+    def test_different_config_combinations(self):
+        configs = [
+            {"use_docker": "y", "cloud_provider": "AWS"},
+            {"use_docker": "y", "cloud_provider": "None"},
+            {"use_docker": "n", "use_heroku": "y"},
+            {"frontend_pipeline": "Gulp"},
+            {"frontend_pipeline": "Webpack"},
+            {"rest_api": "Django Ninja"},
+        ]
+
+        for config in configs:
+            full_config = {"project_slug": "test", **config}
+            generator = ProjectGenerator(full_config)
+            generator.register_default_strategies()
+
+            actions = generator.plan()
+
+            assert len(actions) >= 0, f"Failed for config: {config}"

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -1,0 +1,335 @@
+"""Tests for the refactored post_gen_project.py using new architecture."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hooks.core.context import FailurePolicy
+from hooks.post_gen_project import (
+    DependenciesStrategy,
+    EnvFilesStrategy,
+    GitignoreStrategy,
+    ProjectGenerationOrchestrator,
+    SecretGenerationStrategy,
+)
+
+
+class TestSecretGenerationStrategy:
+    def test_should_apply_always(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(project_slug="test")
+        strategy = SecretGenerationStrategy()
+        assert strategy.should_apply(context)
+
+    def test_plan_generates_secret_actions(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(project_slug="test")
+        strategy = SecretGenerationStrategy(debug=True)
+        actions = strategy.plan(context)
+
+        assert len(actions) > 0
+        assert any("secret" in a.description.lower() for a in actions)
+
+    def test_debug_mode_uses_debug_values(self):
+        strategy = SecretGenerationStrategy(debug=True)
+        assert strategy.postgres_user == "debug"
+        assert strategy.celery_flower_user == "debug"
+
+
+class TestEnvFilesStrategy:
+    def test_plan_removes_envs_when_no_docker_heroku(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "n", "use_heroku": "n", "keep_local_envs_in_vcs": "n"},
+        )
+        strategy = EnvFilesStrategy()
+        actions = strategy.plan(context)
+
+        paths = [str(a.dir_path) if hasattr(a, "dir_path") else str(a.file_path) for a in actions]
+        assert any(".envs" in p for p in paths)
+
+    def test_plan_keeps_envs_when_keep_local_envs(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "n", "use_heroku": "n", "keep_local_envs_in_vcs": "y"},
+        )
+        strategy = EnvFilesStrategy()
+        actions = strategy.plan(context)
+
+        assert len(actions) == 0
+
+
+class TestGitignoreStrategy:
+    def test_should_apply_when_docker_enabled(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "y", "use_heroku": "n"},
+        )
+        strategy = GitignoreStrategy()
+        assert strategy.should_apply(context)
+
+    def test_should_apply_when_heroku_enabled(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "n", "use_heroku": "y"},
+        )
+        strategy = GitignoreStrategy()
+        assert strategy.should_apply(context)
+
+    def test_should_not_apply_when_no_docker_heroku(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "n", "use_heroku": "n"},
+        )
+        strategy = GitignoreStrategy()
+        assert not strategy.should_apply(context)
+
+    def test_plan_adds_env_to_gitignore(self):
+        from hooks.core.context import ExecutionContext
+
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "y", "keep_local_envs_in_vcs": "n"},
+        )
+        strategy = GitignoreStrategy()
+        actions = strategy.plan(context)
+
+        contents = [a.content for a in actions]
+        assert ".env" in contents
+        assert ".envs/*" in contents
+
+
+class TestProjectGenerationOrchestrator:
+    def test_orchestrator_creation(self):
+        config = {"project_slug": "test_project"}
+        orchestrator = ProjectGenerationOrchestrator(config)
+
+        assert orchestrator.project_slug == "test_project"
+        assert orchestrator.context.project_slug == "test_project"
+
+    def test_orchestrator_with_dry_run(self):
+        config = {"project_slug": "test_project"}
+        orchestrator = ProjectGenerationOrchestrator(config, dry_run=True)
+
+        assert orchestrator.context.dry_run
+
+    def test_orchestrator_with_failure_policy(self):
+        config = {"project_slug": "test_project"}
+        orchestrator = ProjectGenerationOrchestrator(
+            config,
+            failure_policy=FailurePolicy.CONTINUE_ON_ERROR,
+        )
+
+        assert orchestrator.context.failure_policy == FailurePolicy.CONTINUE_ON_ERROR
+
+    def test_register_all_strategies(self):
+        config = {"project_slug": "test_project"}
+        orchestrator = ProjectGenerationOrchestrator(config)
+        orchestrator.register_all_strategies()
+
+        assert len(orchestrator._strategies) == 14
+
+    def test_plan_returns_actions(self):
+        config = {
+            "project_slug": "test_project",
+            "open_source_license": "MIT",
+            "username_type": "email",
+            "editor": "VS Code",
+            "use_docker": "n",
+            "cloud_provider": "None",
+            "use_heroku": "n",
+            "frontend_pipeline": "None",
+            "use_celery": "n",
+            "ci_tool": "Github",
+            "rest_api": "DRF",
+            "use_async": "n",
+            "keep_local_envs_in_vcs": "n",
+            "debug": "y",
+        }
+        orchestrator = ProjectGenerationOrchestrator(config)
+        orchestrator.register_all_strategies()
+
+        actions = orchestrator.plan()
+
+        assert len(actions) > 0
+        assert all(hasattr(a, "execute") for a in actions)
+
+    def test_preview(self):
+        config = {"project_slug": "test_project", "debug": "y"}
+        orchestrator = ProjectGenerationOrchestrator(config)
+        orchestrator.register_all_strategies()
+
+        preview = orchestrator.preview()
+
+        assert "test_project" in preview
+        assert "Preview" in preview
+
+
+class TestOrchestratorIntegration:
+    def test_full_flow_dry_run(self, tmp_path, monkeypatch):
+        config = {
+            "project_slug": "my_project",
+            "open_source_license": "MIT",
+            "username_type": "email",
+            "editor": "None",
+            "use_docker": "n",
+            "cloud_provider": "None",
+            "use_heroku": "n",
+            "frontend_pipeline": "None",
+            "use_celery": "n",
+            "ci_tool": "Github",
+            "rest_api": "DRF",
+            "use_async": "n",
+            "keep_local_envs_in_vcs": "n",
+            "debug": "y",
+        }
+
+        orchestrator = ProjectGenerationOrchestrator(config, dry_run=True)
+        orchestrator.register_all_strategies()
+
+        actions = orchestrator.plan()
+        assert len(actions) > 0
+
+    def test_audit_report_generated(self, tmp_path):
+        config = {
+            "project_slug": "test_project",
+            "debug": "y",
+        }
+
+        original_cwd = Path.cwd()
+        os.chdir(tmp_path)
+
+        try:
+            orchestrator = ProjectGenerationOrchestrator(config, dry_run=True)
+            orchestrator.register_all_strategies()
+
+            actions = orchestrator.plan()
+            orchestrator.executor.execute(actions)
+
+            orchestrator.context.save_report(tmp_path / "report.md")
+            orchestrator.context.save_json_report(tmp_path / "report.json")
+
+            assert (tmp_path / "report.md").exists()
+            assert (tmp_path / "report.json").exists()
+
+            report_content = (tmp_path / "report.md").read_text()
+            assert "test_project" in report_content
+
+            json_report = json.loads((tmp_path / "report.json").read_text())
+            assert json_report["project_name"] == "test_project"
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestRollbackMechanism:
+    def test_rollback_on_failure(self, tmp_path):
+        from hooks.core.actions import DeleteFileAction
+        from hooks.core.context import ExecutionContext
+        from hooks.core.context import FailurePolicy
+        from hooks.core.executor import ActionExecutor
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("original content")
+
+        context = ExecutionContext(
+            project_slug="test",
+            failure_policy=FailurePolicy.ROLLBACK_ALL,
+        )
+        executor = ActionExecutor(context)
+
+        delete_action = DeleteFileAction(file_path=test_file)
+
+        original_cwd = Path.cwd()
+        os.chdir(tmp_path)
+        try:
+            result = executor.execute([delete_action])
+
+            assert not test_file.exists()
+
+            checkpoints = context.get_checkpoints_for_rollback()
+            assert len(checkpoints) == 1
+
+            rollback_result = delete_action.rollback(checkpoints[0].backup_data)
+            assert rollback_result.success
+            assert test_file.exists()
+            assert test_file.read_text() == "original content"
+        finally:
+            os.chdir(original_cwd)
+
+    def test_checkpoint_created_for_file_modification(self, tmp_path):
+        from hooks.core.actions import ModifyFileAction
+        from hooks.core.context import ExecutionContext
+        from hooks.core.executor import ActionExecutor
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello {{ name }}!")
+
+        context = ExecutionContext(project_slug="test")
+        executor = ActionExecutor(context)
+
+        modify_action = ModifyFileAction(
+            file_path=test_file,
+            modifications={"{{ name }}": "World"},
+        )
+
+        original_cwd = Path.cwd()
+        os.chdir(tmp_path)
+        try:
+            result = executor.execute([modify_action])
+
+            assert result.success
+            assert test_file.read_text() == "Hello World!"
+
+            checkpoints = context.get_checkpoints_for_rollback()
+            assert len(checkpoints) == 1
+            assert checkpoints[0].backup_data == "Hello {{ name }}!"
+        finally:
+            os.chdir(original_cwd)
+
+
+class TestDifferentConfigCombinations:
+    @pytest.mark.parametrize(
+        "config_override",
+        [
+            {"use_docker": "y", "cloud_provider": "AWS"},
+            {"use_docker": "y", "cloud_provider": "None"},
+            {"use_docker": "n", "use_heroku": "y"},
+            {"frontend_pipeline": "Gulp"},
+            {"frontend_pipeline": "Webpack"},
+            {"rest_api": "Django Ninja"},
+            {"open_source_license": "Not open source"},
+            {"username_type": "username"},
+            {"editor": "PyCharm"},
+            {"use_celery": "y"},
+            {"ci_tool": "Travis"},
+            {"ci_tool": "Gitlab"},
+            {"ci_tool": "Drone"},
+            {"use_async": "y"},
+        ],
+    )
+    def test_config_combinations(self, config_override):
+        base_config = {
+            "project_slug": "test_project",
+            "debug": "y",
+        }
+        config = {**base_config, **config_override}
+
+        orchestrator = ProjectGenerationOrchestrator(config, dry_run=True)
+        orchestrator.register_all_strategies()
+
+        actions = orchestrator.plan()
+        assert len(actions) >= 0

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -7,13 +7,10 @@ from pathlib import Path
 import pytest
 
 from hooks.core.context import FailurePolicy
-from hooks.post_gen_project import (
-    DependenciesStrategy,
-    EnvFilesStrategy,
-    GitignoreStrategy,
-    ProjectGenerationOrchestrator,
-    SecretGenerationStrategy,
-)
+from hooks.post_gen_project import EnvFilesStrategy
+from hooks.post_gen_project import GitignoreStrategy
+from hooks.post_gen_project import ProjectGenerationOrchestrator
+from hooks.post_gen_project import SecretGenerationStrategy
 
 
 class TestSecretGenerationStrategy:

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,10 +1,7 @@
 """Tests for the strategies module."""
 
-from pathlib import Path
-
-import pytest
-
-from hooks.core.actions import DeleteDirectoryAction, DeleteFileAction
+from hooks.core.actions import DeleteDirectoryAction
+from hooks.core.actions import DeleteFileAction
 from hooks.core.context import ExecutionContext
 from hooks.strategies.async_strategy import AsyncStrategy
 from hooks.strategies.celery import CeleryStrategy
@@ -21,7 +18,7 @@ from hooks.strategies.username_type import UsernameTypeStrategy
 def get_path_from_action(action):
     if isinstance(action, DeleteFileAction):
         return str(action.file_path)
-    elif isinstance(action, DeleteDirectoryAction):
+    if isinstance(action, DeleteDirectoryAction):
         return str(action.dir_path)
     return ""
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,355 @@
+"""Tests for the strategies module."""
+
+from pathlib import Path
+
+import pytest
+
+from hooks.core.actions import DeleteDirectoryAction, DeleteFileAction
+from hooks.core.context import ExecutionContext
+from hooks.strategies.async_strategy import AsyncStrategy
+from hooks.strategies.celery import CeleryStrategy
+from hooks.strategies.ci_tool import CIToolStrategy
+from hooks.strategies.docker import DockerStrategy
+from hooks.strategies.editor import EditorStrategy
+from hooks.strategies.frontend_pipeline import FrontendPipelineStrategy
+from hooks.strategies.heroku import HerokuStrategy
+from hooks.strategies.license import OpenSourceLicenseStrategy
+from hooks.strategies.rest_api import RestApiStrategy
+from hooks.strategies.username_type import UsernameTypeStrategy
+
+
+def get_path_from_action(action):
+    if isinstance(action, DeleteFileAction):
+        return str(action.file_path)
+    elif isinstance(action, DeleteDirectoryAction):
+        return str(action.dir_path)
+    return ""
+
+
+class TestOpenSourceLicenseStrategy:
+    def test_should_apply_not_open_source(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"open_source_license": "Not open source"},
+        )
+        strategy = OpenSourceLicenseStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_should_apply_gplv3(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"open_source_license": "MIT"},
+        )
+        strategy = OpenSourceLicenseStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_not_open_source(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"open_source_license": "Not open source"},
+        )
+        strategy = OpenSourceLicenseStrategy()
+        actions = strategy.plan(context)
+
+        assert len(actions) == 3
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("CONTRIBUTORS.txt" in p for p in paths)
+        assert any("LICENSE" in p for p in paths)
+        assert any("COPYING" in p for p in paths)
+
+
+class TestUsernameTypeStrategy:
+    def test_should_apply_username_mode(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"username_type": "username"},
+        )
+        strategy = UsernameTypeStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_should_not_apply_email_mode(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"username_type": "email"},
+        )
+        strategy = UsernameTypeStrategy()
+
+        assert not strategy.should_apply(context)
+
+    def test_plan_username_mode(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"username_type": "username"},
+        )
+        strategy = UsernameTypeStrategy()
+        actions = strategy.plan(context)
+
+        assert len(actions) == 2
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("managers.py" in p for p in paths)
+
+
+class TestEditorStrategy:
+    def test_should_apply_non_pycharm(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"editor": "VS Code"},
+        )
+        strategy = EditorStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_should_not_apply_pycharm(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"editor": "PyCharm"},
+        )
+        strategy = EditorStrategy()
+
+        assert not strategy.should_apply(context)
+
+
+class TestDockerStrategy:
+    def test_should_apply_always(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={},
+        )
+        strategy = DockerStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_docker_enabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "y", "cloud_provider": "None"},
+        )
+        strategy = DockerStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("utility" in p for p in paths)
+
+    def test_plan_docker_disabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_docker": "n"},
+        )
+        strategy = DockerStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("compose" in p for p in paths)
+        assert any("docker-compose" in p for p in paths)
+
+
+class TestHerokuStrategy:
+    def test_should_apply_always(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={},
+        )
+        strategy = HerokuStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_heroku_disabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_heroku": "n", "ci_tool": "None"},
+        )
+        strategy = HerokuStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("Procfile" in p for p in paths)
+        assert any("bin" in p for p in paths)
+
+
+class TestFrontendPipelineStrategy:
+    def test_should_apply_always(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={},
+        )
+        strategy = FrontendPipelineStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_no_frontend(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"frontend_pipeline": "None", "use_docker": "n"},
+        )
+        strategy = FrontendPipelineStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("package.json" in p for p in paths)
+
+    def test_plan_gulp(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"frontend_pipeline": "Gulp", "use_docker": "n", "use_async": "n"},
+        )
+        strategy = FrontendPipelineStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("webpack" in p for p in paths)
+
+    def test_plan_webpack(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"frontend_pipeline": "Webpack", "use_docker": "n", "use_async": "n"},
+        )
+        strategy = FrontendPipelineStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("gulpfile" in p for p in paths)
+
+
+class TestCeleryStrategy:
+    def test_should_apply_celery_disabled(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"use_celery": "n"},
+        )
+        strategy = CeleryStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_should_not_apply_celery_enabled(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"use_celery": "y"},
+        )
+        strategy = CeleryStrategy()
+
+        assert not strategy.should_apply(context)
+
+    def test_plan_celery_disabled(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"use_celery": "n", "use_docker": "n"},
+        )
+        strategy = CeleryStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("celery_app.py" in p for p in paths)
+
+
+class TestCIToolStrategy:
+    def test_should_apply_always(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={},
+        )
+        strategy = CIToolStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_github_ci(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"ci_tool": "Github"},
+        )
+        strategy = CIToolStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert not any(".github" in p for p in paths)
+        assert any(".travis.yml" in p for p in paths)
+
+    def test_plan_no_ci(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"ci_tool": "None"},
+        )
+        strategy = CIToolStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any(".github" in p for p in paths)
+        assert any(".travis.yml" in p for p in paths)
+
+
+class TestRestApiStrategy:
+    def test_should_apply_always(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={},
+        )
+        strategy = RestApiStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_plan_drf(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"rest_api": "DRF"},
+        )
+        strategy = RestApiStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("schema.py" in p for p in paths)
+
+    def test_plan_ninja(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"rest_api": "Django Ninja"},
+        )
+        strategy = RestApiStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("serializers.py" in p for p in paths)
+
+    def test_plan_no_api(self):
+        context = ExecutionContext(
+            project_slug="test_project",
+            cookiecutter_config={"rest_api": "None"},
+        )
+        strategy = RestApiStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("api" in p for p in paths)
+
+
+class TestAsyncStrategy:
+    def test_should_apply_async_disabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_async": "n"},
+        )
+        strategy = AsyncStrategy()
+
+        assert strategy.should_apply(context)
+
+    def test_should_not_apply_async_enabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_async": "y"},
+        )
+        strategy = AsyncStrategy()
+
+        assert not strategy.should_apply(context)
+
+    def test_plan_async_disabled(self):
+        context = ExecutionContext(
+            project_slug="test",
+            cookiecutter_config={"use_async": "n"},
+        )
+        strategy = AsyncStrategy()
+        actions = strategy.plan(context)
+
+        paths = [get_path_from_action(a) for a in actions]
+        assert any("asgi.py" in p for p in paths)
+        assert any("websocket.py" in p for p in paths)


### PR DESCRIPTION
我现在有一个重构需求：
1. 操作可审计化 问题 ：现在整个生成过程是"黑盒"，做完了什么操作用户完全不知道 重构方向 ：
给所有变更操作增加 审计追踪 能力
任何文件删除、内容修改、命令执行，都要被记录下来
最终输出一份"变更清单报告"（删了N个文件，改了M个配置）
支持后续"回滚"可能性的设计
2. 依赖去硬编码化 问题 ：逻辑和执行方式强耦合 重构方向 ：
把"要做什么"和"实际怎么执行"彻底分开
比如"删除文件"这个动作，可以有真实执行、打印模拟、记录日志三种实现
业务逻辑只声明"我要删除A"，不关心具体是谁来删、怎么删
3. 错误自愈能力 问题 ：任何一步出错就整个流程崩溃，前面做的改动都遗留一半 重构方向 ：
引入补偿机制：第一步成功了，第二步失败，自动回滚第一步的操作
定义清晰的失败策略：遇到错误是立刻中止？还是跳过继续？还是回滚全部？
支持失败后从中断处继续执行，而不是从头再来
4. 条件判断去分支化 问题 ：大量 if/elif/else 判断用户选择 重构方向 ：
把每一个"特性选项"变成一个 独立的策略对象
比如 UseDocker、UseCelery、UseWebpack 各是一个策略类
每个策略自己声明：我要删什么文件、改什么配置、加什么依赖
主流程只负责按用户选择组装要执行的策略列表，再也没有 if
 5. 副作用隔离 问题 ：纯计算逻辑和文件系统操作混在一起 重构方向 ：
严格划分"纯函数"和"有副作用的操作"
第一步：所有决策逻辑都在内存中完成（计算"最终应该删哪些文件"）
第二步：统一执行所有副作用
两阶段之间可以插入：预览、人工确认、dry-run 等能力

约束：
1.只修改与代码重构直接相关的代码
2 必须为重构完的代码新增专门的测试用例

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
