### PR TITLE
Remove deprecated intellicode extensions from `devcontainer.json`

### DIFF
--- a/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -49,8 +49,6 @@
             "extensions": [
                 "davidanson.vscode-markdownlint",
                 "mrmlnc.vscode-duplicate",
-                "visualstudioexptteam.vscodeintellicode",
-                "visualstudioexptteam.intellicode-api-usage-examples",
                 // python
                 "ms-python.python",
                 "ms-python.vscode-pylance",


### PR DESCRIPTION
Intellicode was deprecated by MS in 2025. Remove the extensions.

## Description

Intellicode was deprecated by MS. The repo was archived and set read only on Nov 12, 2025.

See the archived repo:
[https://github.com/MicrosoftDocs/intellicode](https://github.com/MicrosoftDocs/intellicode)

Removed the deprecated extensions.

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option) 
- [x] I've updated the documentation or confirm that my change doesn't require any updates 

## Rationale

Don't include deprecated dependencies in new projects.
