### PR TITLE
Add home directory for the `django` created user in Docker production

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -64,7 +64,7 @@ ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
 
 RUN addgroup --system django \
-  && adduser --system --ingroup django django
+  && adduser --system --ingroup django --home /home/django django
 
 
 # Install required system dependencies


### PR DESCRIPTION
## Description
in debian systems, creating a user without home directory automatically creates it and gives it /nonexistent as a home dir, 
https://manpages.debian.org/trixie/adduser/adduser.8.en.html check here for "nonexistant"

in django prod Dockerfile, we didn't specify the home dir , so when we start the server we get this error when trying to start gunicorn

```[ERROR] Control server error: [Errno 13] Permission denied: '/nonexistent```

Checklist:

- [ x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale
it fixes this error and now instead of the error we get 
```[INFO] Control socket listening at /home/django/.gunicorn/gunicorn.ctl```
