### PR TITLE
Fix RST formatting for keep_local_envs_in_vcs option

### DIFF
--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -141,8 +141,7 @@ ci_tool:
     5. `Drone CI`_
 
 keep_local_envs_in_vcs:
-
-Indicates whether the project’s .envs/.local/ should be kept in VCS (comes in handy when working in teams where local environment reproducibility is strongly encouraged).
+    Indicates whether the project’s .envs/.local/ should be kept in VCS (comes in handy when working in teams where local environment reproducibility is strongly encouraged).
 
 debug:
     Indicates whether the project should be configured for debugging.


### PR DESCRIPTION
## Description
The `keep_local_envs_in_vcs` entry in `docs/1-getting-started/project-generation-options.rst` was not part of the surrounding definition list: there was a blank line between the option name and its description, and the description had no indentation. As a result, Sphinx rendered the option name and the description as two stray paragraphs after the list instead of as a definition list entry, breaking the visual consistency of the page.
Fix: remove the blank line and indent the description by 4 spaces, matching every other option on the page.
Checklist:
- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates
## Rationale
Keeps the option formatting consistent with the rest of the page and restores the expected rendering on Read the Docs.