### PR TITLE
Fix missing HTML title to allauth manage template

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/manage.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/allauth/layouts/manage.html
@@ -1,5 +1,10 @@
 {% raw %}{% extends "base.html" %}
 
+{% block title %}
+  {% block head_title %}
+  {% endblock head_title %}
+{% endblock title %}
+
 {% block main %}
   {% block content %}
   {% endblock content %}


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

The manage template from allauth is missing the title block, so the browsers tabs are taking the project name, instead of having meaningful names. This is visible in the Email Addresses and 2FA pages.

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

For example, when changing the password (`/accounts/password/change/`) no title is shown because the base template uses the `title` block and allauth uses `head_title`.