### PR TITLE
feat: add optional django-import-export with generic FK-context import support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -35,6 +35,7 @@
   "use_async": "n",
   "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack"],
   "use_celery": "n",
+  "use_django_import_export": "n",
   "use_mailpit": "n",
   "use_sentry": "n",
   "use_whitenoise": "n",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -424,6 +424,10 @@ def remove_rest_api_files():
     shutil.rmtree(Path("{{cookiecutter.project_slug}}", "users", "tests", "api"))
 
 
+def remove_import_export_files():
+    shutil.rmtree(Path("{{ cookiecutter.project_slug }}", "contrib", "import_export"))
+
+
 def main():  # noqa: C901, PLR0912, PLR0915
     debug = "{{ cookiecutter.debug }}".lower() == "y"
 
@@ -521,6 +525,9 @@ def main():  # noqa: C901, PLR0912, PLR0915
 
     if "{{ cookiecutter.use_async }}".lower() == "n":
         remove_async_files()
+
+    if "{{ cookiecutter.use_django_import_export }}".lower() == "n":
+        remove_import_export_files()
 
     setup_dependencies()
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -452,15 +452,44 @@ def test_pre_commit_without_heroku(cookies, context):
 
 
 def test_django_import_export_optional(cookies, context):
+    slug = context["project_slug"]
     context.update({"use_django_import_export": "y"})
     result = cookies.bake(extra_context=context)
     assert result.exit_code == 0
 
     pyproject_toml = result.project_path / "pyproject.toml"
     base_settings = result.project_path / "config" / "settings" / "base.py"
-    users_admin = result.project_path / context["project_slug"] / "users" / "admin.py"
+    users_admin = result.project_path / slug / "users" / "admin.py"
+    contrib_admin = result.project_path / slug / "contrib" / "import_export" / "admin.py"
+    contrib_resources = result.project_path / slug / "contrib" / "import_export" / "resources.py"
 
+    # dependency and app wiring
     assert "django-import-export" in pyproject_toml.read_text()
     assert '"import_export"' in base_settings.read_text()
-    assert "ImportExportMixin" in users_admin.read_text()
-    assert "class UserAdmin(ImportExportMixin, auth_admin.UserAdmin):" in users_admin.read_text()
+
+    # contrib package is present with the generic base classes
+    assert contrib_admin.exists()
+    assert "FKContextImportExportModelAdmin" in contrib_admin.read_text()
+    assert "import_context_fields" in contrib_admin.read_text()
+    assert contrib_resources.exists()
+    assert "ContextInjectingResource" in contrib_resources.read_text()
+    assert "before_import_row" in contrib_resources.read_text()
+
+    # UserAdmin uses the generic base
+    assert "FKContextImportExportModelAdmin" in users_admin.read_text()
+    assert "class UserAdmin(FKContextImportExportModelAdmin, auth_admin.UserAdmin):" in users_admin.read_text()
+
+
+def test_django_import_export_disabled_by_default(cookies, context):
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+
+    slug = context["project_slug"]
+    contrib_import_export = result.project_path / slug / "contrib" / "import_export"
+    users_admin = result.project_path / slug / "users" / "admin.py"
+
+    # contrib package must be absent when option is off
+    assert not contrib_import_export.exists()
+    # UserAdmin must not reference import_export at all
+    assert "import_export" not in users_admin.read_text()
+    assert "FKContextImportExportModelAdmin" not in users_admin.read_text()

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -449,3 +449,18 @@ def test_pre_commit_without_heroku(cookies, context):
     data = pre_commit_config.read_text()
 
     assert "uv-pre-commit" not in data
+
+
+def test_django_import_export_optional(cookies, context):
+    context.update({"use_django_import_export": "y"})
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+
+    pyproject_toml = result.project_path / "pyproject.toml"
+    base_settings = result.project_path / "config" / "settings" / "base.py"
+    users_admin = result.project_path / context["project_slug"] / "users" / "admin.py"
+
+    assert "django-import-export" in pyproject_toml.read_text()
+    assert '"import_export"' in base_settings.read_text()
+    assert "ImportExportMixin" in users_admin.read_text()
+    assert "class UserAdmin(ImportExportMixin, auth_admin.UserAdmin):" in users_admin.read_text()

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -84,6 +84,9 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "crispy_forms",
     "crispy_bootstrap5",
+{%- if cookiecutter.use_django_import_export == 'y' %}
+    "import_export",
+{%- endif %}
     "allauth",
     "allauth.account",
     "allauth.mfa",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
 dependencies = [
   {# set the an initial indentation for uv to follow #}
   "django",
+  {%- if cookiecutter.use_django_import_export == 'y' %}
+  "django-import-export",
+  {%- endif %}
 ]
 
 [dependency-groups]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/import_export/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/import_export/admin.py
@@ -1,0 +1,85 @@
+"""Generic FK-context import admin for django-import-export.
+
+Usage example
+-------------
+Suppose you have a ``Report`` model that belongs to an ``Organisation`` via a
+FK.  You want the admin operator to pick the organisation **once** at the top
+of the import wizard, and have that value applied to every imported row
+automatically — without requiring a column in the CSV file.
+
+1.  Define a resource that inherits the context-injecting mixin::
+
+        # your_app/resources.py
+        from import_export import resources
+        from {{ cookiecutter.project_slug }}.contrib.import_export.resources import ContextInjectingResource
+
+        class ReportResource(ContextInjectingResource, resources.ModelResource):
+            class Meta:
+                model = Report
+
+2.  Create an import form with the FK field(s)::
+
+        # your_app/forms.py
+        from django import forms
+        from .models import Organisation
+
+        class ReportImportForm(forms.Form):
+            organisation = forms.ModelChoiceField(
+                queryset=Organisation.objects.all(),
+                help_text="Applied to every row that omits this column.",
+            )
+
+3.  Register the admin::
+
+        # your_app/admin.py
+        from django.contrib import admin
+        from {{ cookiecutter.project_slug }}.contrib.import_export.admin import FKContextImportExportModelAdmin
+        from .models import Report
+        from .resources import ReportResource
+        from .forms import ReportImportForm
+
+        @admin.register(Report)
+        class ReportAdmin(FKContextImportExportModelAdmin):
+            resource_classes = [ReportResource]
+            import_form_class = ReportImportForm
+            # map: import-form field name -> CSV/resource column name
+            import_context_fields = {"organisation": "organisation_id"}
+
+When no ``import_context_fields`` are defined the admin behaves identically to
+plain ``ImportExportMixin``.
+"""
+
+from import_export.admin import ImportExportMixin
+
+
+class FKContextImportExportModelAdmin(ImportExportMixin):
+    """Admin mixin that applies a shared FK value to every imported row.
+
+    Configure :attr:`import_context_fields` as a mapping of
+    ``{import_form_field_name: resource_column_name}``.  The value selected
+    in the import wizard is forwarded to the resource as a ``context_fields``
+    kwarg and then injected into each row by
+    :class:`~{{ cookiecutter.project_slug }}.contrib.import_export.resources.ContextInjectingResource`
+    before field-level processing runs.
+
+    CSV rows that already contain the column are left untouched, so per-row
+    overrides still work.
+    """
+
+    #: ``{import-form field name: resource column name}``
+    #: Leave empty to get plain ImportExportMixin behaviour.
+    import_context_fields: dict[str, str] = {}
+
+    def get_import_data_kwargs(self, request, *args, **kwargs):
+        """Collect selected FK values from the import form and forward them."""
+        kw = super().get_import_data_kwargs(request, *args, **kwargs)
+        form = kwargs.get("form")
+        if form and getattr(form, "cleaned_data", None):
+            context_fields = {
+                col_name: form.cleaned_data[form_field]
+                for form_field, col_name in self.import_context_fields.items()
+                if form.cleaned_data.get(form_field) is not None
+            }
+            if context_fields:
+                kw["context_fields"] = context_fields
+        return kw

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/import_export/resources.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/contrib/import_export/resources.py
@@ -1,0 +1,30 @@
+class ContextInjectingResource:
+    """Mixin that injects shared FK context values into every imported row.
+
+    Works together with :class:`~.admin.FKContextImportExportModelAdmin`.
+    Values passed via the ``context_fields`` kwarg are written into each data
+    row *before* field-level processing, so CSV/XLSX files do not need a
+    dedicated column for those fields.
+
+    Usage
+    -----
+    Combine this mixin with ``resources.ModelResource``::
+
+        from import_export import resources
+        from {{ cookiecutter.project_slug }}.contrib.import_export.resources import ContextInjectingResource
+
+        class ReportResource(ContextInjectingResource, resources.ModelResource):
+            class Meta:
+                model = Report
+
+    The mixin will silently skip columns that are already present in the row,
+    so it is safe to include the FK column in the file when you want per-row
+    control and still use the global default for rows that omit it.
+    """
+
+    def before_import_row(self, row, row_number=None, **kwargs):
+        """Inject context-supplied values into the current row when absent."""
+        super().before_import_row(row, row_number=row_number, **kwargs)
+        for col_name, value in kwargs.get("context_fields", {}).items():
+            if not row.get(col_name):
+                row[col_name] = value

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
 {%- if cookiecutter.use_django_import_export == 'y' %}
-from import_export.admin import ImportExportMixin
+from {{ cookiecutter.project_slug }}.contrib.import_export.admin import FKContextImportExportModelAdmin
 {%- endif %}
 
 from .forms import UserAdminChangeForm
@@ -20,7 +20,7 @@ if settings.DJANGO_ADMIN_FORCE_ALLAUTH:
 
 @admin.register(User)
 {%- if cookiecutter.use_django_import_export == 'y' %}
-class UserAdmin(ImportExportMixin, auth_admin.UserAdmin):
+class UserAdmin(FKContextImportExportModelAdmin, auth_admin.UserAdmin):
 {%- else %}
 class UserAdmin(auth_admin.UserAdmin):
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/users/admin.py
@@ -3,6 +3,9 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
+{%- if cookiecutter.use_django_import_export == 'y' %}
+from import_export.admin import ImportExportMixin
+{%- endif %}
 
 from .forms import UserAdminChangeForm
 from .forms import UserAdminCreationForm
@@ -16,7 +19,11 @@ if settings.DJANGO_ADMIN_FORCE_ALLAUTH:
 
 
 @admin.register(User)
+{%- if cookiecutter.use_django_import_export == 'y' %}
+class UserAdmin(ImportExportMixin, auth_admin.UserAdmin):
+{%- else %}
 class UserAdmin(auth_admin.UserAdmin):
+{%- endif %}
     form = UserAdminChangeForm
     add_form = UserAdminCreationForm
     fieldsets = (


### PR DESCRIPTION
## Summary

Adds an **opt-in** `django-import-export` integration to generated projects, including a **reusable contrib package** that solves a common pain point: selecting one FK value once in the import wizard and having it automatically applied to every imported row — without requiring that column in every line of the CSV file.

Default behaviour is unchanged (`"use_django_import_export": "n"`).

---

## Motivation

Admin-side CSV import/export is one of the most frequently needed features for operational Django projects — data migrations, bulk updates, support workflows. Yet wiring it up correctly (especially the shared-FK pattern) requires boilerplate that every team re-writes. This PR gives generated projects the integration out of the box, and eliminates that boilerplate entirely via a two-class contrib package.

---

## What changed (2 commits, 5 files changed, 185 insertions)

### 1 — Template option and app wiring

| File | Change |
|---|---|
| `cookiecutter.json` | New option `use_django_import_export` (default `n`) |
| `pyproject.toml` | Conditionally adds `django-import-export` dependency |
| `config/settings/base.py` | Conditionally adds `import_export` to `THIRD_PARTY_APPS` |

### 2 — Generic FK-context contrib package

When the option is enabled, the generated project gains a ready-to-use contrib package:
