### PR TITLE
Downgrade tiangolo/issue-manager from 0.8.0 to 0.6.0

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@0.8.0
+      - uses: tiangolo/issue-manager@0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >


### PR DESCRIPTION
Reverts cookiecutter/cookiecutter-django#6666 as it fails