### PR TITLE
Avoid duplicated pre-commit autoupdates PRs

### DIFF
--- a/.github/workflows/align-versions.yml
+++ b/.github/workflows/align-versions.yml
@@ -27,6 +27,8 @@ jobs:
             name: Ruff
           - script: scripts/python_dependency_version.py djlint
             name: djLint
+          - script: scripts/python_dependency_version.py django-upgrade
+            name: django-upgrade
           - script: scripts/node_version.py
             name: Node
 

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -26,11 +26,20 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Autoupdate template
-        run: uv tool run pre-commit autoupdate
+        # Ignore repos updated by other means
+        run: |
+          uv tool run pre-commit autoupdate \
+            --repo https://github.com/pre-commit/pre-commit-hooks \
+            --repo https://github.com/pre-commit/mirrors-prettier \
+            --repo https://github.com/tox-dev/pyproject-fmt
 
       - name: Autoupdate generated projects
         working-directory: "{{cookiecutter.project_slug}}"
-        run: uv tool run pre-commit autoupdate
+        run: |
+          uv tool run pre-commit autoupdate \
+            --repo https://github.com/pre-commit/pre-commit-hooks \
+            --repo https://github.com/pre-commit/mirrors-prettier \
+            --repo https://github.com/tox-dev/pyproject-fmt
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/scripts/python_dependency_version.py
+++ b/scripts/python_dependency_version.py
@@ -16,6 +16,7 @@ PYPROJECT_TOML = ROOT / "pyproject.toml"
 PRE_COMMIT_REPOS = {
     "ruff": "https://github.com/astral-sh/ruff-pre-commit",
     "djlint": "https://github.com/djlint/djLint",
+    "django-upgrade": "https://github.com/adamchainz/django-upgrade",
 }
 
 

--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -28,7 +28,8 @@ sphinx-autobuild==2025.8.25 # https://github.com/GaretJax/sphinx-autobuild
 # ------------------------------------------------------------------------------
 ruff==0.15.20  # https://github.com/astral-sh/ruff
 coverage==7.15.0  # https://github.com/nedbat/coveragepy
-djlint==1.40.4  # https://github.com/djlint/djLint 
+django-upgrade==1.31.1  # https://github.com/adamchainz/django-upgrade
+djlint==1.40.4  # https://github.com/djlint/djLint
 pre-commit==4.6.0  # https://github.com/pre-commit/pre-commit
 
 # Django


### PR DESCRIPTION
## Description

- Restrict the pre-commit hooks auto-update to hooks which aren't installed
- Add django-upgrade to the align version script
- Install django-upgrade as CLI in local development

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Some of our pre-commit hooks are also installed as dependency in the template and/or generated project. When we receive and automated update from PyUP, we run a script to make sure the pre-commit hook version is kept up to date.

Our pre-commit auto-update currently tries to update all hooks, which means that we often end with 2 PRs updating the same hooks, and one needs to be closed (e.g. https://github.com/cookiecutter/cookiecutter-django/pull/6703). The maintainer needs to remember that, or we potentially end up with merge conflicts.

This changes the 2 update mechanism to not overlap with each other.