### PR TITLE
Stop setting public read ACL on static files stored in object storage

### DIFF
--- a/docs/3-deployment/cloud-storage.rst
+++ b/docs/3-deployment/cloud-storage.rst
@@ -1,0 +1,114 @@
+.. _cloud-storage:
+
+Configuring cloud storage
+=========================
+
+.. index:: storage, S3, Cloud Storage, Azure Storage
+
+If you generated the project with a cloud provider, static files and user uploads are served from that provider's object storage rather than from your application server. This is independent of the platform you deploy to, so follow this page alongside the deployment guide of your choice.
+
+How the template uses your bucket
+---------------------------------
+
+A single bucket (or container, on Azure) holds both kinds of files, under two prefixes:
+
+- ``static/``: the output of ``collectstatic``, meant to be **publicly readable**.
+- ``media/``: user uploads, served through ``MEDIA_URL``.
+
+The storages do **not** set a per-object ACL on upload. Uploaded objects simply inherit whatever access rules the bucket has, so making static files reachable is a one-off bucket configuration step, described below for each provider. This matches the current default of all three providers, which is to disable per-object ACLs in favour of bucket-wide policies.
+
+.. warning:: The instructions below deliberately expose only the ``static/`` prefix. Granting public read on the whole bucket also exposes ``media/``, and since the template sets unsigned URLs for media, every user upload would then be readable by anyone able to guess its URL. See `Keeping media private`_ if uploads in your project are not meant to be public.
+
+Amazon S3
+---------
+
+New buckets have ACLs disabled (*Object Ownership: bucket owner enforced*) and all four **Block Public Access** settings enabled. You need to relax the two policy-related ones, then attach a bucket policy scoped to the ``static/`` prefix.
+
+.. code-block:: bash
+
+    BUCKET=your-bucket-name
+
+    # Outside of us-east-1, add:
+    #   --create-bucket-configuration LocationConstraint=$AWS_REGION
+    aws s3api create-bucket --bucket $BUCKET --region us-east-1
+
+    # Allow public *policies*, while still blocking public ACLs
+    aws s3api put-public-access-block --bucket $BUCKET \
+        --public-access-block-configuration \
+        "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+    cat > /tmp/static-policy.json <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "PublicReadForStaticFiles",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::$BUCKET/static/*"
+        }
+      ]
+    }
+    EOF
+
+    aws s3api put-bucket-policy --bucket $BUCKET --policy file:///tmp/static-policy.json
+
+The same can be done from the console, under the bucket's **Permissions** tab: first edit **Block public access**, then **Bucket policy**. S3 will label the bucket as *Publicly accessible* afterwards, which is expected.
+
+The policy applies to objects already in the bucket, so there is no need to re-run ``collectstatic``.
+
+.. note:: Requests for a key that does not exist return ``403 Forbidden`` rather than ``404 Not Found``, because anonymous callers lack ``s3:ListBucket``. If static files still 403 after this, check the object is really there with ``aws s3api head-object --bucket $BUCKET --key static/css/project.css``.
+
+Google Cloud Storage
+--------------------
+
+New buckets default to *uniform bucket-level access*, which disables the per-object ACL API. Grant public read through IAM instead. Cloud Storage IAM cannot target a prefix directly, so use a conditional binding to keep the grant limited to ``static/``:
+
+.. code-block:: bash
+
+    BUCKET=your-bucket-name
+
+    gcloud storage buckets add-iam-policy-binding gs://$BUCKET \
+        --member=allUsers \
+        --role=roles/storage.objectViewer \
+        --condition="title=public-static-files,expression=resource.name.startsWith('projects/_/buckets/$BUCKET/objects/static/')"
+
+If you would rather not rely on a conditional binding, use a dedicated bucket for static files and grant ``roles/storage.objectViewer`` to ``allUsers`` on that bucket without a condition.
+
+If the binding is rejected, `public access prevention`_ is enforced on the bucket or inherited from an organization policy, and you will need to either lift it or serve static files from a bucket where it is not enforced.
+
+.. _public access prevention: https://cloud.google.com/storage/docs/public-access-prevention
+
+Azure Storage
+-------------
+
+Azure has no per-blob ACL to set; anonymous access is granted at the container level, and recent storage accounts disallow it account-wide by default:
+
+.. code-block:: bash
+
+    ACCOUNT=your-account-name
+    CONTAINER=your-container-name
+
+    az storage account update --name $ACCOUNT --allow-blob-public-access true
+
+    az storage container set-permission --name $CONTAINER \
+        --account-name $ACCOUNT --public-access blob
+
+.. warning:: Because ``--public-access`` is set on the whole container, and the template stores both ``static/`` and ``media/`` in the same container, this also exposes user uploads. Use a second container or a `stored access policy`_ if that is not acceptable.
+
+.. _stored access policy: https://learn.microsoft.com/en-us/rest/api/storageservices/define-stored-access-policy
+
+Keeping media private
+---------------------
+
+Making ``static/`` public is expected: those files ship with your application. User uploads are a different matter, and the template's defaults assume they are public.
+
+On AWS, ``AWS_QUERYSTRING_AUTH = False`` in ``config/settings/production.py`` makes ``media`` URLs unsigned and permanent. If uploads in your project are sensitive, remove that setting so django-storages returns time-limited signed URLs, and do not extend any public bucket policy to the ``media/`` prefix. The equivalent settings are ``GS_QUERYSTRING_AUTH`` for Google Cloud Storage and Azure's SAS-token support.
+
+Serving through a CDN
+---------------------
+
+Putting a CDN in front of the bucket lets you keep it entirely private, since the CDN authenticates to the origin on your behalf: CloudFront with an `Origin Access Control`_ on AWS, or Cloud CDN backed by a bucket backend on GCP. Once the distribution is set up, point ``DJANGO_AWS_S3_CUSTOM_DOMAIN`` at it so generated URLs use the CDN domain.
+
+.. _Origin Access Control: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html

--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -55,6 +55,11 @@ Run these commands to deploy the project to Heroku:
 Notes
 -----
 
+Static & Media Files
+++++++++++++++++++++
+
+Setting the credentials above is not enough on its own: the bucket also needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`.
+
 Email Service
 +++++++++++++
 

--- a/docs/3-deployment/deployment-on-pythonanywhere.rst
+++ b/docs/3-deployment/deployment-on-pythonanywhere.rst
@@ -74,6 +74,8 @@ Add these env variables:
 
 .. note:: The AWS details are not required if you're using whitenoise or the built-in PythonAnywhere static files service, but you do need to set them to blank, as above.
 
+.. note:: If you are using S3, the bucket also needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`.
+
 
 Database setup
 --------------

--- a/docs/3-deployment/deployment-with-docker.rst
+++ b/docs/3-deployment/deployment-with-docker.rst
@@ -37,6 +37,8 @@ Configuring the Stack
 
 The majority of services above are configured through the use of environment variables. Just check out :ref:`envs` and you will know the drill.
 
+If you generated the project with a cloud provider, the bucket holding your static files needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`.
+
 To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable. Logs of level `logging.ERROR` are sent as Sentry events. Therefore, in order to send a Sentry event use:
 
 .. code-block:: python

--- a/docs/5-help/troubleshooting.rst
+++ b/docs/5-help/troubleshooting.rst
@@ -48,6 +48,30 @@ Example::
 
 You have probably opted for Docker + Webpack without Whitenoise. This is a know limitation of the combination, which needs a little bit of manual intervention. See the :ref:`dedicated section about it <webpack-whitenoise-limitation>`.
 
+AWS S3: ``AccessControlListNotSupported`` on ``collectstatic``
+---------------------------------------------------------------
+
+Example::
+
+    botocore.exceptions.ClientError: An error occurred (AccessControlListNotSupported) when calling the PutObject operation: The bucket does not allow ACLs
+
+New S3 buckets are created with ACLs disabled (Object Ownership: bucket owner enforced), which is the AWS default and their recommended setting. Since the static files storage no longer sets an ACL on upload, you need to make the ``static`` prefix publicly readable with a bucket policy instead, for example::
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "PublicReadForStaticFiles",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::your-bucket-name/static/*"
+        }
+      ]
+    }
+
+Replace ``your-bucket-name`` with your ``DJANGO_AWS_STORAGE_BUCKET_NAME`` value, and attach the policy under the bucket's Permissions tab.
+
 Others
 ------
 

--- a/docs/5-help/troubleshooting.rst
+++ b/docs/5-help/troubleshooting.rst
@@ -48,29 +48,12 @@ Example::
 
 You have probably opted for Docker + Webpack without Whitenoise. This is a know limitation of the combination, which needs a little bit of manual intervention. See the :ref:`dedicated section about it <webpack-whitenoise-limitation>`.
 
-AWS S3: ``AccessControlListNotSupported`` on ``collectstatic``
----------------------------------------------------------------
+Static files return a 403 in production
+---------------------------------------
 
-Example::
+Your bucket does not allow public reads of the ``static`` prefix. The storages don't set a per-object ACL on upload, so this is granted with a bucket policy (S3), an IAM binding (GCP) or a container access level (Azure). See :ref:`cloud-storage`.
 
-    botocore.exceptions.ClientError: An error occurred (AccessControlListNotSupported) when calling the PutObject operation: The bucket does not allow ACLs
-
-New S3 buckets are created with ACLs disabled (Object Ownership: bucket owner enforced), which is the AWS default and their recommended setting. Since the static files storage no longer sets an ACL on upload, you need to make the ``static`` prefix publicly readable with a bucket policy instead, for example::
-
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "PublicReadForStaticFiles",
-          "Effect": "Allow",
-          "Principal": "*",
-          "Action": "s3:GetObject",
-          "Resource": "arn:aws:s3:::your-bucket-name/static/*"
-        }
-      ]
-    }
-
-Replace ``your-bucket-name`` with your ``DJANGO_AWS_STORAGE_BUCKET_NAME`` value, and attach the policy under the bucket's Permissions tab.
+The same page applies if you are upgrading an older project and ``collectstatic`` fails with ``AccessControlListNotSupported`` (S3) or ``Cannot insert legacy ACL for an object when uniform bucket-level access is enabled`` (GCP): drop the ``default_acl`` option from your ``STORAGES`` setting, then configure the bucket as described there.
 
 Others
 ------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Powered by Cookiecutter_, Cookiecutter Django is a project template for jumpstar
    3-deployment/deployment-on-pythonanywhere
    3-deployment/deployment-on-heroku
    3-deployment/deployment-with-docker
+   3-deployment/cloud-storage
 
 .. toctree::
    :maxdepth: 2

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -141,7 +141,8 @@ STORAGES = {
         "BACKEND": "storages.backends.s3.S3Storage",
         "OPTIONS": {
             "location": "static",
-            "default_acl": "public-read",
+            # New S3 buckets have ACLs disabled, so objects must not be written
+            # with an ACL. Grant public read access via a bucket policy instead.
         },
     },
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -106,7 +106,6 @@ AWS_S3_CUSTOM_DOMAIN = env("DJANGO_AWS_S3_CUSTOM_DOMAIN", default=None)
 aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
 {% elif cookiecutter.cloud_provider == 'GCP' %}
 GS_BUCKET_NAME = env("DJANGO_GCP_STORAGE_BUCKET_NAME")
-GS_DEFAULT_ACL = "publicRead"
 {% elif cookiecutter.cloud_provider == 'Azure' %}
 AZURE_ACCOUNT_KEY = env("DJANGO_AZURE_ACCOUNT_KEY")
 AZURE_ACCOUNT_NAME = env("DJANGO_AZURE_ACCOUNT_NAME")
@@ -161,7 +160,6 @@ STORAGES = {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
         "OPTIONS": {
             "location": "static",
-            "default_acl": "publicRead",
         },
     },
     {%- endif %}

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -141,8 +141,6 @@ STORAGES = {
         "BACKEND": "storages.backends.s3.S3Storage",
         "OPTIONS": {
             "location": "static",
-            # New S3 buckets have ACLs disabled, so objects must not be written
-            # with an ACL. Grant public read access via a bucket policy instead.
         },
     },
     {%- endif %}


### PR DESCRIPTION
Fixes #6713

New S3 buckets are created with ACLs disabled (Object Ownership: bucket owner enforced), which AWS has made the default and recommends keeping. On such buckets, any `PutObject` that carries an ACL fails with `AccessControlListNotSupported` — so `collectstatic` crashes for projects generated with `cloud_provider=AWS` and `use_whitenoise=n`, because the staticfiles storage sets `default_acl: public-read`. The media storage already writes without an ACL and works fine on the same buckets.

This drops the ACL from the staticfiles options (django-storages then sends no ACL at all) and leaves public read access to a bucket policy, matching AWS's guidance for ACL-disabled buckets. A comment in the template points users at the bucket-policy approach.

Verified by generating projects from the modified template for both `use_whitenoise=y` and `=n` with `cloud_provider=AWS`: no `default_acl` remains anywhere and both rendered `production.py` files parse.