### PR TITLE
Migrate DATABASE_URL settings directly into config/settings/base.py

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
+++ b/{{cookiecutter.project_slug}}/compose/production/django/entrypoint
@@ -4,12 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-if [ -z "${POSTGRES_USER}" ]; then
-    base_postgres_image_default_user='postgres'
-    export POSTGRES_USER="${base_postgres_image_default_user}"
-fi
-export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
-
 wait-for-it "${POSTGRES_HOST}:${POSTGRES_PORT}" -t 30
 
 >&2 echo 'PostgreSQL is available'

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -6,6 +6,9 @@ import ssl
 from pathlib import Path
 
 import environ
+{%- if cookiecutter.use_docker == "y" %}
+from django.core.exceptions import ImproperlyConfigured
+{%- endif %}
 
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # {{ cookiecutter.project_slug }}/
@@ -48,7 +51,23 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 {% if cookiecutter.use_docker == "y" -%}
-DATABASES = {"default": env.db("DATABASE_URL")}
+# Prefer a full DATABASE_URL when one is provided, otherwise assemble the
+# connection from the individual POSTGRES_* variables. The latter keeps database
+# settings working for processes that bypass the container entrypoint (e.g.
+# `docker exec`), since those variables are supplied via the compose env_file.
+try:
+    DATABASES = {"default": env.db("DATABASE_URL")}
+except ImproperlyConfigured:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "HOST": env("POSTGRES_HOST"),
+            "NAME": env("POSTGRES_DB"),
+            "PASSWORD": env("POSTGRES_PASSWORD"),
+            "PORT": env.int("POSTGRES_PORT", default=5432),
+            "USER": env("POSTGRES_USER"),
+        },
+    }
 {%- else %}
 DATABASES = {
     "default": env.db(


### PR DESCRIPTION
Fixes an issue from #6273, #2821, #1888, #3224, #1085, and others.

Currently if you run "docker exec" to an existing container, DATABASE_URL isn't set, because that variable is configured by the entrypoint and "docker exec" will bypass the entrypoint.   This is a fragile configuration which requires developers to understand the mechanism and work around it by manually assigning the variable, or calling the entrypoint.  It keeps tripping people up, as demonstrated by the number of github issues.

A solution is to ensure "DATABASES" is populated directly in config/settings/base.py.   Then it's fine if entrypoint is missed.  We have been using this method in production for years without incident.