### PR TITLE
Fix uv lock file Python requirement

### DIFF
--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -1,2 +1,2 @@
 version = 1
-requires-python = "==3.13.*"
+requires-python = "==3.14.*"


### PR DESCRIPTION
<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

This was probably missed when project was switched from Python v3.13 to v3.14.
This fixes the after installation warning:
```
warning: Resolving despite existing lockfile due to fork markers being disjoint with requires-python: python_full_version == '3.13.*' vs python_full_version == '3.14.*'
```

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
