### PR TITLE
Improve djLint config to declare django-allauth tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ blank_line_after_tag = "load,extends"
 close_void_tags = true
 format_css = true
 format_js = true
-custom_blocks = "slot"
+custom_blocks = "element,slot"
 ignore_blocks = "raw"
 # TODO: remove T002 when fixed https://github.com/Riverside-Healthcare/djLint/issues/687
 ignore = "H006,H030,H031,T002,T028"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ format_css = true
 format_js = true
 custom_blocks = "element,slot"
 ignore_blocks = "raw"
-# TODO: remove T002 when fixed https://github.com/Riverside-Healthcare/djLint/issues/687
-ignore = "H006,H030,H031,T002,T028"
+ignore = "H006,H030,H031,T028"
 css.indent_size = 2
 js.indent_size = 2
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 # ==== djLint ====
 [tool.djlint]
 blank_line_after_tag = "load,extends"
-custom_blocks = "slot"
+custom_blocks = "element,slot"
 close_void_tags = true
 format_css = true
 format_js = true

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -30,8 +30,7 @@ custom_blocks = "element,slot"
 close_void_tags = true
 format_css = true
 format_js = true
-# TODO: remove T002 when fixed https://github.com/djlint/djLint/issues/687
-ignore = "H006,H030,H031,T002"
+ignore = "H006,H030,H031"
 include = "H017,H035"
 indent = 2
 max_line_length = 119


### PR DESCRIPTION
## Description

* Includes `element` in djLint config's custom_blocks list
* Remove T002 from ignore list as issue [687](https://github.com/djlint/djLint/issues/687) is now marked closed as of [djLint version 1.40.8](https://github.com/djlint/djLint/blob/master/CHANGELOG.md#1408---2026-07-17)

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

closes #6780 
