### PR TITLE
Add vite as an option for `frontend_pipeline`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
             args: "frontend_pipeline=Gulp"
           - name: Webpack
             args: "frontend_pipeline=Webpack"
+          - name: Vite
+            args: "frontend_pipeline=Vite"
 
     name: "Docker ${{ matrix.script.name }}"
     runs-on: ubuntu-latest
@@ -70,6 +72,8 @@ jobs:
             args: "frontend_pipeline=Gulp"
           - name: Webpack
             args: "frontend_pipeline=Webpack use_heroku=y"
+          - name: Vite
+            args: "frontend_pipeline=Vite use_heroku=y"
           - name: Email Username
             args: "username_type=email ci_tool=Github project_name='Something superduper long - the great amazing project' project_slug=my_awesome_project"
           - name: Email username & DRF

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ production-ready Django projects quickly.
 - Registration via [django-allauth](https://github.com/pennersr/django-allauth)
 - Comes with custom user model ready to go
 - Optional basic ASGI setup for Websockets
-- Optional custom static build using Gulp or Webpack
+- Optional custom static build using Gulp, Webpack or Vite
 - Send emails via [Anymail](https://github.com/anymail/django-anymail) (using [Mailgun](http://www.mailgun.com/) by default or Amazon SES if AWS is selected cloud provider, but switchable)
 - Media storage using Amazon S3, Google Cloud Storage, Azure Storage or nginx
 - Docker support using [docker-compose](https://github.com/docker/compose) for development and production (using [Traefik](https://traefik.io/) with [LetsEncrypt](https://letsencrypt.org/) support)
@@ -162,7 +162,8 @@ Answer the prompts with your own desired [options](http://cookiecutter-django.re
     2 - Django Compressor
     3 - Gulp
     4 - Webpack
-    Choose from 1, 2, 3, 4 [1]: 1
+    5 - Vite
+    Choose from 1, 2, 3, 4, 5 [1]: 1
     use_celery [n]: y
     Select mail_catcher:
     1 - None

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -33,7 +33,7 @@
   ],
   "rest_api": ["None", "DRF", "Django Ninja"],
   "use_async": "n",
-  "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack"],
+  "frontend_pipeline": ["None", "Django Compressor", "Gulp", "Webpack", "Vite"],
   "use_celery": "n",
   "mail_catcher": ["None", "Mailpit", "Mailtrap Local"],
   "use_sentry": "n",

--- a/docs/1-getting-started/project-generation-options.rst
+++ b/docs/1-getting-started/project-generation-options.rst
@@ -112,8 +112,11 @@ frontend_pipeline:
     2. `Django Compressor`_
     3. `Gulp`_
     4. `Webpack`_
+    5. `Vite`_
 
-Both Gulp and Webpack support Bootstrap recompilation with real-time variables alteration.
+Gulp, Webpack and Vite all support Bootstrap recompilation with real-time variables alteration.
+The Vite pipeline is integrated with Django through `django-vite`_, and serves the assets from
+the Vite dev server with hot module replacement during development.
 
 use_celery:
     Indicates whether the project should be configured to use Celery_.
@@ -168,6 +171,8 @@ debug:
 
 .. _Gulp: https://github.com/gulpjs/gulp
 .. _Webpack: https://webpack.js.org
+.. _Vite: https://vite.dev
+.. _django-vite: https://github.com/MrBin99/django-vite
 
 .. _AWS: https://aws.amazon.com/s3/
 .. _GCP: https://cloud.google.com/storage/

--- a/docs/2-local-development/developing-locally-docker.rst
+++ b/docs/2-local-development/developing-locally-docker.rst
@@ -90,7 +90,7 @@ To run the docs with local services just use::
 
     docker compose -f docker-compose.local.yml -f docker-compose.docs.yml up
 
-The site should start and be accessible at http://localhost:3000 if you selected Webpack or Gulp as frontend pipeline and http://localhost:8000 otherwise.
+The site should start and be accessible at http://localhost:3000 if you selected Webpack or Gulp as frontend pipeline and http://localhost:8000 otherwise, Vite included.
 
 Execute Management Commands
 ---------------------------
@@ -271,8 +271,17 @@ If you've opted for Gulp or Webpack as front-end pipeline, the project comes con
 
 The stack comes with a dedicated node service to build the static assets, watch for changes and proxy requests to the Django app with live reloading scripts injected in the response. For everything to work smoothly, you need to access the application at the port served by the node service, which is http://localhost:3000 by default.
 
+Using Vite
+~~~~~~~~~~
+
+If you've opted for Vite as front-end pipeline, the project comes configured with `Sass`_ compilation and `hot module replacement`_. As you change your Sass/JS source files, Vite pushes the updated styles and scripts to the browser without refreshing the page. Changes to your Django templates trigger a full page reload.
+
+The stack comes with a dedicated node service running the Vite dev server. Unlike Gulp and Webpack, it does not proxy the Django app: `django-vite`_ makes your templates load the assets from the dev server, so you keep accessing the application at http://localhost:8000. The dev server itself is published on http://localhost:5173, but there is no page to see there.
+
 .. _Sass: https://sass-lang.com/
 .. _live reloading: https://browsersync.io
+.. _hot module replacement: https://vite.dev/guide/features.html#hot-module-replacement
+.. _django-vite: https://github.com/MrBin99/django-vite
 
 
 Using Just for Docker Commands

--- a/docs/2-local-development/developing-locally.rst
+++ b/docs/2-local-development/developing-locally.rst
@@ -73,7 +73,7 @@ Make sure to have the following on your host:
 
     uv run uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
 
-   If you've opted for Webpack or Gulp as frontend pipeline, please see the :ref:`dedicated section <bare-metal-webpack-gulp>` below.
+   If you've opted for Webpack or Gulp as frontend pipeline, please see the :ref:`dedicated section <bare-metal-webpack-gulp>` below. For Vite, see :ref:`this one <bare-metal-vite>`.
 
 .. _PostgreSQL: https://www.postgresql.org/download/
 .. _Redis: https://redis.io/download
@@ -264,9 +264,37 @@ If you've opted for Gulp or Webpack as front-end pipeline, the project comes con
    .. note:: Do NOT access the application using the Django port (8000 by default), as it will result in broken styles and 404s when accessing static assets.
 
 
+.. _bare-metal-vite:
+
+Using Vite
+----------
+
+If you've opted for Vite as front-end pipeline, the project comes configured with `Sass`_ compilation and `hot module replacement`_. As you change your Sass/JS source files, Vite pushes the updated styles and scripts to the browser without refreshing the page. Changes to your Django templates trigger a full page reload.
+
+Unlike Gulp and Webpack, the Vite dev server does not proxy the Django app. `django-vite`_ makes your templates point at the dev server, so you keep browsing the Django development server as usual.
+
+#. Make sure that `Node.js`_ is installed on your machine.
+#. In the project root, install the JS dependencies with::
+
+    npm install
+
+#. Now - with your virtualenv activated - start the application by running::
+
+    npm run dev
+
+   This will start 2 processes in parallel: the Vite dev server on one side, and the Django server on the other.
+
+#. Access your application at the address of the Django server, http://localhost:8000 by default.
+
+   .. note:: The Vite dev server (http://localhost:5173 by default) only serves the assets, there is no page to see there.
+
+To check the production build of your assets locally, run ``npm run build`` and set ``DJANGO_VITE_DEV_MODE=False`` in your environment. Django will then serve the compiled files from your app's ``static/vite_bundles/`` directory instead of the dev server.
+
 .. _Node.js: http://nodejs.org/download/
 .. _Sass: https://sass-lang.com/
 .. _live reloading: https://browsersync.io
+.. _hot module replacement: https://vite.dev/guide/features.html#hot-module-replacement
+.. _django-vite: https://github.com/MrBin99/django-vite
 
 Summary
 -------

--- a/docs/3-deployment/cloud-storage.rst
+++ b/docs/3-deployment/cloud-storage.rst
@@ -99,6 +99,73 @@ Azure has no per-blob ACL to set; anonymous access is granted at the container l
 
 .. _stored access policy: https://learn.microsoft.com/en-us/rest/api/storageservices/define-stored-access-policy
 
+.. _cloud-storage-cors:
+
+Allowing cross-origin requests
+------------------------------
+
+Public reads are enough for most files, but a few kinds of asset are fetched by the browser in *CORS mode*, and those also need the bucket to answer with an ``Access-Control-Allow-Origin`` header. A bucket has no CORS configuration until you add one, so it sends no such header, the browser discards the response, and the asset silently fails to apply.
+
+You need a CORS configuration if your project serves any of:
+
+- **ES module scripts**, which is how ``{% vite_asset %}`` renders bundles if you picked Vite as your frontend pipeline. The page renders, but no JavaScript runs and the console reports ``CORS Missing Allowed Origin``.
+- **Web fonts** referenced from ``url()`` inside a stylesheet, whichever frontend pipeline you picked.
+- Anything you load with an explicit ``crossorigin`` attribute or a `Subresource Integrity`_ hash.
+
+Substitute your own bucket name and the origin your site is served from:
+
+.. code-block:: bash
+
+    BUCKET=your-bucket-name
+    ORIGIN=https://example.com
+
+    cat > /tmp/cors.json <<EOF
+    {
+      "CORSRules": [
+        {
+          "AllowedMethods": ["GET", "HEAD"],
+          "AllowedOrigins": ["$ORIGIN"],
+          "AllowedHeaders": ["*"],
+          "MaxAgeSeconds": 3600
+        }
+      ]
+    }
+    EOF
+
+    aws s3api put-bucket-cors --bucket $BUCKET --cors-configuration file:///tmp/cors.json
+
+On Google Cloud Storage:
+
+.. code-block:: bash
+
+    cat > /tmp/cors.json <<EOF
+    [
+      {
+        "origin": ["$ORIGIN"],
+        "method": ["GET", "HEAD"],
+        "responseHeader": ["Content-Type"],
+        "maxAgeSeconds": 3600
+      }
+    ]
+    EOF
+
+    gcloud storage buckets update gs://$BUCKET --cors-file=/tmp/cors.json
+
+On Azure Storage, CORS is set per storage account rather than per container:
+
+.. code-block:: bash
+
+    az storage cors add --services b --methods GET HEAD \
+        --origins $ORIGIN --allowed-headers '*' --max-age 3600 \
+        --account-name your-account-name
+
+To confirm a real asset now answers correctly, ask for it with an ``Origin`` header::
+
+    curl -sSI -H "Origin: $ORIGIN" https://$BUCKET.s3.amazonaws.com/static/<some-asset> \
+        | grep -i access-control-allow-origin
+
+.. _Subresource Integrity: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+
 Keeping media private
 ---------------------
 

--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -60,6 +60,8 @@ Static & Media Files
 
 Setting the credentials above is not enough on its own: the bucket also needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`.
 
+If you picked Vite as your frontend pipeline, or your styles pull in web fonts, the bucket needs a CORS configuration on top of that, or the browser will refuse the assets even though they return a ``200``. See :ref:`cloud-storage-cors`.
+
 Email Service
 +++++++++++++
 

--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -110,10 +110,10 @@ Or add the DSN for your account, if you already have one:
 .. _Sentry add-on: https://elements.heroku.com/addons/sentry
 
 
-Gulp or Webpack
-+++++++++++++++
+Gulp, Webpack or Vite
++++++++++++++++++++++
 
-If you've opted for Gulp or Webpack as frontend pipeline, you'll most likely need to setup
+If you've opted for Gulp, Webpack or Vite as frontend pipeline, you'll most likely need to setup
 your app to use `multiple buildpacks`_: one for Python & one for Node.js:
 
 .. code-block:: bash

--- a/docs/3-deployment/deployment-with-docker.rst
+++ b/docs/3-deployment/deployment-with-docker.rst
@@ -88,10 +88,10 @@ You can read more about this feature and how to configure it, at `Automatic HTTP
 
 .. _webpack-whitenoise-limitation:
 
-Webpack without Whitenoise limitation
--------------------------------------
+Webpack or Vite without Whitenoise limitation
+---------------------------------------------
 
-If you opt for Webpack without Whitenoise, Webpack needs to know the static URL at build time, when running ``docker compose build`` (See ``webpack/prod.config.js``). Depending on your setup, this URL may come from the following environment variables:
+If you opt for Webpack or Vite without Whitenoise, the bundler needs to know the static URL at build time, when running ``docker compose build`` (See ``webpack/prod.config.js`` or ``vite.config.mjs``). Depending on your setup, this URL may come from the following environment variables:
 
 - ``AWS_STORAGE_BUCKET_NAME``
 - ``DJANGO_AWS_S3_CUSTOM_DOMAIN``

--- a/docs/3-deployment/deployment-with-docker.rst
+++ b/docs/3-deployment/deployment-with-docker.rst
@@ -37,7 +37,7 @@ Configuring the Stack
 
 The majority of services above are configured through the use of environment variables. Just check out :ref:`envs` and you will know the drill.
 
-If you generated the project with a cloud provider, the bucket holding your static files needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`.
+If you generated the project with a cloud provider, the bucket holding your static files needs to allow public reads of the ``static`` prefix, otherwise your static files will return a ``403``. See :ref:`cloud-storage`. It may also need a CORS configuration, if you picked Vite as your frontend pipeline or your styles pull in web fonts: see :ref:`cloud-storage-cors`.
 
 To obtain logs and information about crashes in a production setup, make sure that you have access to an external Sentry instance (e.g. by creating an account with `sentry.io`_), and set the ``SENTRY_DSN`` variable. Logs of level `logging.ERROR` are sent as Sentry events. Therefore, in order to send a Sentry event use:
 

--- a/docs/5-help/troubleshooting.rst
+++ b/docs/5-help/troubleshooting.rst
@@ -55,6 +55,17 @@ Your bucket does not allow public reads of the ``static`` prefix. The storages d
 
 The same page applies if you are upgrading an older project and ``collectstatic`` fails with ``AccessControlListNotSupported`` (S3) or ``Cannot insert legacy ACL for an object when uniform bucket-level access is enabled`` (GCP): drop the ``default_acl`` option from your ``STORAGES`` setting, then configure the bucket as described there.
 
+No JavaScript runs in production, with a CORS error in the console
+------------------------------------------------------------------
+
+Example::
+
+    CORS Missing Allowed Origin
+
+The bundles return ``200``, they open fine in a browser tab, and the stylesheet from the same directory loads without complaint, only the scripts fail.
+
+Your bucket has no CORS configuration. If you picked Vite as your frontend pipeline, the bundles are ES modules, and those are always fetched in CORS mode, so the browser requires an ``Access-Control-Allow-Origin`` header that a fresh bucket does not send. Web fonts are subject to the same rule on every frontend pipeline. See :ref:`cloud-storage-cors`.
+
 Others
 ------
 

--- a/docs/5-help/troubleshooting.rst
+++ b/docs/5-help/troubleshooting.rst
@@ -46,7 +46,7 @@ Example::
     WARN[0000] The "DJANGO_AWS_STORAGE_BUCKET_NAME" variable is not set. Defaulting to a blank string.
     WARN[0000] The "DJANGO_AWS_S3_CUSTOM_DOMAIN" variable is not set. Defaulting to a blank string.
 
-You have probably opted for Docker + Webpack without Whitenoise. This is a know limitation of the combination, which needs a little bit of manual intervention. See the :ref:`dedicated section about it <webpack-whitenoise-limitation>`.
+You have probably opted for Docker + Webpack or Vite, without Whitenoise. This is a know limitation of the combination, which needs a little bit of manual intervention. See the :ref:`dedicated section about it <webpack-whitenoise-limitation>`.
 
 Static files return a 403 in production
 ---------------------------------------

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -99,9 +99,17 @@ def remove_gulp_files():
         Path(file_name).unlink()
 
 
-def remove_webpack_files():
+def remove_webpack_config_files():
     shutil.rmtree("webpack")
+
+
+def remove_webpack_files():
+    remove_webpack_config_files()
     remove_vendors_js()
+
+
+def remove_vite_files():
+    Path("vite.config.mjs").unlink()
 
 
 def remove_vendors_js():
@@ -137,25 +145,45 @@ def update_package_json(remove_dev_deps=None, remove_keys=None, scripts=None):
     package_json.write_text(updated_content)
 
 
+# Dev dependencies that are only useful to a single frontend pipeline, and are
+# therefore removed from package.json when another one is selected.
+GULP_DEV_DEPS = [
+    "browser-sync",
+    "cssnano",
+    "gulp",
+    "gulp-concat",
+    "gulp-imagemin",
+    "gulp-plumber",
+    "gulp-postcss",
+    "gulp-rename",
+    "gulp-sass",
+    "gulp-uglify-es",
+    "node-sass-tilde-importer",
+]
+
+WEBPACK_DEV_DEPS = [
+    "@babel/core",
+    "@babel/preset-env",
+    "babel-loader",
+    "css-loader",
+    "mini-css-extract-plugin",
+    "postcss-loader",
+    "sass-loader",
+    "webpack",
+    "webpack-bundle-tracker",
+    "webpack-cli",
+    "webpack-dev-server",
+    "webpack-merge",
+]
+
+VITE_DEV_DEPS = ["vite", "vite-plugin-full-reload"]
+
+
 def handle_js_runner(choice, use_docker, use_async):
+    dev_django_cmd = "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
     if choice == "Gulp":
         update_package_json(
-            remove_dev_deps=[
-                "@babel/core",
-                "@babel/preset-env",
-                "babel-loader",
-                "concurrently",
-                "css-loader",
-                "mini-css-extract-plugin",
-                "postcss-loader",
-                "postcss-preset-env",
-                "sass-loader",
-                "webpack",
-                "webpack-bundle-tracker",
-                "webpack-cli",
-                "webpack-dev-server",
-                "webpack-merge",
-            ],
+            remove_dev_deps=[*WEBPACK_DEV_DEPS, *VITE_DEV_DEPS, "concurrently", "postcss-preset-env"],
             remove_keys=["babel"],
             scripts={
                 "dev": "gulp",
@@ -163,27 +191,14 @@ def handle_js_runner(choice, use_docker, use_async):
             },
         )
         remove_webpack_files()
+        remove_vite_files()
     elif choice == "Webpack":
         scripts = {
             "dev": "webpack serve --config webpack/dev.config.js",
             "build": "webpack --config webpack/prod.config.js",
         }
-        remove_dev_deps = [
-            "browser-sync",
-            "cssnano",
-            "gulp",
-            "gulp-concat",
-            "gulp-imagemin",
-            "gulp-plumber",
-            "gulp-postcss",
-            "gulp-rename",
-            "gulp-sass",
-            "gulp-uglify-es",
-        ]
+        remove_dev_deps = [*GULP_DEV_DEPS, *VITE_DEV_DEPS]
         if not use_docker:
-            dev_django_cmd = (
-                "uvicorn config.asgi:application --reload" if use_async else "python manage.py runserver_plus"
-            )
             scripts.update(
                 {
                     "dev": "concurrently npm:dev:*",
@@ -195,6 +210,27 @@ def handle_js_runner(choice, use_docker, use_async):
             remove_dev_deps.append("concurrently")
         update_package_json(remove_dev_deps=remove_dev_deps, scripts=scripts)
         remove_gulp_files()
+        remove_vite_files()
+    elif choice == "Vite":
+        scripts = {
+            "dev": "vite",
+            "build": "vite build",
+        }
+        remove_dev_deps = [*GULP_DEV_DEPS, *WEBPACK_DEV_DEPS]
+        if not use_docker:
+            scripts.update(
+                {
+                    "dev": "concurrently npm:dev:*",
+                    "dev:vite": "vite",
+                    "dev:django": dev_django_cmd,
+                },
+            )
+        else:
+            remove_dev_deps.append("concurrently")
+        update_package_json(remove_dev_deps=remove_dev_deps, remove_keys=["babel"], scripts=scripts)
+        remove_gulp_files()
+        # Vite uses static/js/vendors.js as an entry point, so it must be kept
+        remove_webpack_config_files()
 
 
 def remove_prettier_pre_commit():
@@ -476,6 +512,7 @@ def main():  # noqa: C901, PLR0912, PLR0915
     if "{{ cookiecutter.frontend_pipeline }}" in ["None", "Django Compressor"]:
         remove_gulp_files()
         remove_webpack_files()
+        remove_vite_files()
         remove_sass_files()
         remove_packagejson_file()
         remove_prettier_pre_commit()

--- a/tests/test_bare.sh
+++ b/tests/test_bare.sh
@@ -20,18 +20,18 @@ sudo utility/install_os_dependencies.sh install
 # Install Python deps
 uv sync
 
-# run the project's tests
-uv run pytest
-
-# Make sure the check doesn't raise any warnings
-uv run python manage.py check --fail-level WARNING
-
-# Run npm build script if package.json is present
+# Build the frontend assets if present, some checks below expect them to exist
 if [ -f "package.json" ]
 then
     npm install
     npm run build
 fi
+
+# run the project's tests
+uv run pytest
+
+# Make sure the check doesn't raise any warnings
+uv run python manage.py check --fail-level WARNING
 
 # Generate the HTML for the documentation
 cd docs && uv run make html

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -118,6 +118,7 @@ SUPPORTED_COMBINATIONS = [
     {"frontend_pipeline": "Django Compressor"},
     {"frontend_pipeline": "Gulp"},
     {"frontend_pipeline": "Webpack"},
+    {"frontend_pipeline": "Vite"},
     {"use_celery": "y"},
     {"use_celery": "n"},
     {"mail_catcher": "None"},

--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -36,6 +36,12 @@ docker compose -f docker-compose.local.yml run django uv lock
 
 docker compose -f docker-compose.local.yml build
 
+# Build the frontend assets if present, some checks below expect them to exist
+if [ -f "package.json" ]
+then
+    docker compose -f docker-compose.local.yml run --rm node npm run build
+fi
+
 # run the project's type checks
 docker compose -f docker-compose.local.yml run --rm django mypy my_awesome_project
 
@@ -78,9 +84,3 @@ docker run --rm \
 -e MAILGUN_API_KEY=x \
 -e MAILGUN_DOMAIN=x \
 django-prod python manage.py check --settings=config.settings.production --deploy --database default --fail-level WARNING
-
-# Run npm build script if package.json is present
-if [ -f "package.json" ]
-then
-    docker compose -f docker-compose.local.yml run --rm node npm run build
-fi

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -75,7 +75,7 @@ updates:
           - 'minor'
           - 'patch'
 
-{%- if cookiecutter.frontend_pipeline == 'Gulp' %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Vite'] %}
 
   # Enable version updates for javascript/npm
   - package-ecosystem: 'npm'

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -75,7 +75,7 @@ updates:
           - 'minor'
           - 'patch'
 
-{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Vite'] %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] %}
 
   # Enable version updates for javascript/npm
   - package-ecosystem: 'npm'

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -351,3 +351,6 @@ vendors.js
 {{ cookiecutter.project_slug }}/static/webpack_bundles/
 webpack-stats.json
 {%- endif %}
+{%- if cookiecutter.frontend_pipeline == 'Vite' %}
+{{ cookiecutter.project_slug }}/static/vite_bundles/
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -175,7 +175,7 @@ See detailed [cookiecutter-django Heroku documentation](https://cookiecutter-dja
 See detailed [cookiecutter-django Docker documentation](https://cookiecutter-django.readthedocs.io/en/latest/3-deployment/deployment-with-docker.html).
 
 {%- endif %}
-{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] %}
 
 ### Custom Bootstrap Compilation
 

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-{% if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] -%}
+{% if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] -%}
 FROM docker.io/node:26.5-bookworm-slim AS client-builder
 
 ARG APP_HOME=/app
@@ -7,7 +7,7 @@ WORKDIR ${APP_HOME}
 COPY ./package.json ${APP_HOME}
 RUN npm install && npm cache clean --force
 COPY . ${APP_HOME}
-{%- if cookiecutter.frontend_pipeline == 'Webpack' and cookiecutter.use_whitenoise == 'n' %}
+{%- if cookiecutter.frontend_pipeline in ['Webpack', 'Vite'] and cookiecutter.use_whitenoise == 'n' %}
 {%- if cookiecutter.cloud_provider == 'AWS' %}
 ARG DJANGO_AWS_STORAGE_BUCKET_NAME
 ENV DJANGO_AWS_STORAGE_BUCKET_NAME=${DJANGO_AWS_STORAGE_BUCKET_NAME}
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project --no-dev
-{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] %}
 COPY --from=client-builder ${APP_HOME} ${APP_HOME}
 {% else %}
 COPY . ${APP_HOME}

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -107,6 +107,8 @@ THIRD_PARTY_APPS = [
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
     "webpack_loader",
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}
+    "django_vite",
 {%- endif %}
 ]
 
@@ -403,6 +405,21 @@ WEBPACK_LOADER = {
         "STATS_FILE": BASE_DIR / "webpack-stats.json",
         "POLL_INTERVAL": 0.1,
         "IGNORE": [r".+\.hot-update.js", r".+\.map"],
+    },
+}
+
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}
+# django-vite
+# ------------------------------------------------------------------------------
+# https://github.com/MrBin99/django-vite#configuration
+DJANGO_VITE = {
+    "default": {
+        # Serve assets from the ViteJS dev server instead of the built manifest
+        "dev_mode": False,
+        "dev_server_port": 5173,
+        # This should mirror `staticUrlPrefix` in vite.config.mjs
+        "static_url_prefix": "vite_bundles",
+        "manifest_path": APPS_DIR / "static" / "vite_bundles" / "manifest.json",
     },
 }
 

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -1,4 +1,7 @@
 from .base import *  # noqa: F403
+{%- if cookiecutter.frontend_pipeline == 'Vite' %}
+from .base import DJANGO_VITE
+{%- endif %}
 from .base import INSTALLED_APPS
 from .base import MIDDLEWARE
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
@@ -129,6 +132,13 @@ CELERY_TASK_EAGER_PROPAGATES = True
 # django-webpack-loader
 # ------------------------------------------------------------------------------
 WEBPACK_LOADER["DEFAULT"]["CACHE"] = not DEBUG
+
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}
+# django-vite
+# ------------------------------------------------------------------------------
+# Serve the assets from the ViteJS dev server, with hot module replacement.
+# Set to False to serve the assets built by `npm run build` instead.
+DJANGO_VITE["default"]["dev_mode"] = env.bool("DJANGO_VITE_DEV_MODE", default=True)
 
 {%- endif %}
 # Your stuff...

--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -40,6 +40,12 @@ MEDIA_URL = "http://media.testserver/"
 # ------------------------------------------------------------------------------
 WEBPACK_LOADER["DEFAULT"]["LOADER_CLASS"] = "webpack_loader.loaders.FakeWebpackLoader"  # noqa: F405
 
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}
+# django-vite
+# ------------------------------------------------------------------------------
+# Render asset URLs pointing at the dev server, so the tests don't need a build
+DJANGO_VITE["default"]["dev_mode"] = True  # noqa: F405
+
 {%- endif %}
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/docker-compose.local.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.local.yml
@@ -116,7 +116,7 @@ services:
     command: /start-flower
 
   {%- endif %}
-  {%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack'] %}
+  {%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] %}
 
   node:
     build:
@@ -132,10 +132,15 @@ services:
       - /app/node_modules
     command: npm run dev
     ports:
+      {%- if cookiecutter.frontend_pipeline == 'Vite' %}
+      # The browser loads the assets from the ViteJS dev server directly
+      - '5173:5173'
+      {%- else %}
       - '3000:3000'
       {%- if cookiecutter.frontend_pipeline == 'Gulp' %}
       # Expose browsersync UI: https://www.browsersync.io/docs/options/#option-ui
       - '3001:3001'
+      {%- endif %}
       {%- endif %}
 
   {%- endif %}

--- a/{{cookiecutter.project_slug}}/docker-compose.production.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.production.yml
@@ -15,7 +15,7 @@ services:
     build:
       context: .
       dockerfile: ./compose/production/django/Dockerfile
-      {%- if cookiecutter.frontend_pipeline == 'Webpack' and cookiecutter.use_whitenoise == 'n' %}
+      {%- if cookiecutter.frontend_pipeline in ['Webpack', 'Vite'] and cookiecutter.use_whitenoise == 'n' %}
       args:
         # These variable can be defined in an .env file in the root of the repo
         {%- if cookiecutter.cloud_provider == 'AWS' %}

--- a/{{cookiecutter.project_slug}}/package-lock.json
+++ b/{{cookiecutter.project_slug}}/package-lock.json
@@ -34,6 +34,8 @@
         "postcss-preset-env": "^11.3.0",
         "sass": "^1.93.1",
         "sass-loader": "^17.0.0",
+        "vite": "^8.2.1",
+        "vite-plugin-full-reload": "^1.2.0",
         "webpack": "^5.82.0",
         "webpack-bundle-tracker": "^3.0.1",
         "webpack-cli": "^7.0.2",
@@ -3580,6 +3582,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
@@ -4109,6 +4121,286 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -7349,7 +7641,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11194,6 +11485,279 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -14786,6 +15350,40 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.147.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -16274,6 +16872,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -16982,6 +17628,108 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-full-reload": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+      "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/watchpack": {

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -28,6 +28,8 @@
     "postcss-preset-env": "^11.3.0",
     "sass": "^1.93.1",
     "sass-loader": "^17.0.0",
+    "vite": "^8.2.1",
+    "vite-plugin-full-reload": "^1.2.0",
     "webpack": "^5.82.0",
     "webpack-bundle-tracker": "^3.0.1",
     "webpack-cli": "^7.0.2",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -122,7 +122,7 @@ python_files = [
   "tests.py",
   "test_*.py",
 ]
-{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Vite'] %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Webpack', 'Vite'] %}
 norecursedirs = [ "node_modules" ]
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -122,7 +122,7 @@ python_files = [
   "tests.py",
   "test_*.py",
 ]
-{%- if cookiecutter.frontend_pipeline == 'Gulp' %}
+{%- if cookiecutter.frontend_pipeline in ['Gulp', 'Vite'] %}
 norecursedirs = [ "node_modules" ]
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/requirements/base.txt
@@ -45,4 +45,6 @@ django-cors-headers==4.9.0  # https://github.com/adamchainz/django-cors-headers
 {%- endif %}
 {%- if cookiecutter.frontend_pipeline == 'Webpack' %}
 django-webpack-loader==3.2.4  # https://github.com/django-webpack/django-webpack-loader
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}
+django-vite==3.1.0  # https://github.com/MrBin99/django-vite
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/vite.config.mjs
+++ b/{{cookiecutter.project_slug}}/vite.config.mjs
@@ -1,0 +1,71 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import fullReload from 'vite-plugin-full-reload';
+import autoprefixer from 'autoprefixer';
+import pixrem from 'pixrem';
+import postcssPresetEnv from 'postcss-preset-env';
+
+// This variable should mirror the one from config/settings/production.py
+{%- if cookiecutter.use_whitenoise == 'n' %}
+{%- if cookiecutter.cloud_provider == 'AWS' %}
+const s3BucketName = process.env.DJANGO_AWS_STORAGE_BUCKET_NAME;
+const awsS3Domain = process.env.DJANGO_AWS_S3_CUSTOM_DOMAIN
+  ? process.env.DJANGO_AWS_S3_CUSTOM_DOMAIN
+  : `${s3BucketName}.s3.amazonaws.com`;
+const staticUrl = `https://${awsS3Domain}/static/`;
+{%- elif cookiecutter.cloud_provider == 'GCP' %}
+const staticUrl = `https://storage.googleapis.com/${process.env.DJANGO_GCP_STORAGE_BUCKET_NAME}/static/`;
+{%- elif cookiecutter.cloud_provider == 'Azure' %}
+const staticUrl = `https://${process.env.DJANGO_AZURE_ACCOUNT_NAME}.blob.core.windows.net/static/`;
+{%- endif %}
+{%- else %}
+const staticUrl = '/static/';
+{%- endif %}
+
+const appDir = '{{cookiecutter.project_slug}}';
+
+// This should mirror DJANGO_VITE["default"]["static_url_prefix"] in config/settings/base.py
+const staticUrlPrefix = 'vite_bundles';
+
+// django-vite serves dev assets from STATIC_URL + static_url_prefix, so the dev
+// server has to be mounted there too. In production, `base` only rewrites the
+// references between built files (CSS url(), dynamic imports, ...) because
+// django-vite renders the script and link tags itself.
+const devBase = `/static/${staticUrlPrefix}/`;
+const buildBase = `${staticUrl}${staticUrlPrefix}/`;
+
+export default defineConfig(({ command }) => ({
+  base: command === 'serve' ? devBase : buildBase,
+  plugins: [fullReload([`${appDir}/templates/**/*.html`])],
+  build: {
+    manifest: 'manifest.json',
+    outDir: resolve(import.meta.dirname, appDir, 'static', staticUrlPrefix),
+    emptyOutDir: true,
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        project: resolve(import.meta.dirname, appDir, 'static/js/project.js'),
+        vendors: resolve(import.meta.dirname, appDir, 'static/js/vendors.js'),
+      },
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [postcssPresetEnv(), autoprefixer(), pixrem()],
+    },
+  },
+  server: {
+    port: 5173,
+    {%- if cookiecutter.use_docker == 'y' %}
+    // Listen on all interfaces so the dev server is reachable from the host
+    host: true,
+    // The browser reaches the dev server through the port published by Compose
+    origin: 'http://localhost:5173',
+    {%- endif %}
+    {%- if cookiecutter.windows == 'y' %}
+    watch: {
+      usePolling: true,
+    },
+    {%- endif %}
+  },
+}));

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/js/project.js
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/js/project.js
@@ -1,4 +1,4 @@
-{%- if cookiecutter.frontend_pipeline == 'Webpack' -%}
+{%- if cookiecutter.frontend_pipeline in ['Webpack', 'Vite'] -%}
 import '../sass/project.scss';
 
 {% endif -%}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/sass/project.scss
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/static/sass/project.scss
@@ -1,5 +1,9 @@
 @import 'custom_bootstrap_vars';
+{%- if cookiecutter.frontend_pipeline == 'Vite' %}
+@import 'bootstrap/scss/bootstrap';
+{%- else %}
 @import '~bootstrap/scss/bootstrap';
+{%- endif %}
 
 // project specific CSS goes here
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -6,6 +6,10 @@
     {% load render_bundle from webpack_loader %}
 
   {% endraw %}
+{%- elif cookiecutter.frontend_pipeline == 'Vite' %}{% raw %}
+  {% load django_vite %}
+
+{% endraw %}
 {%- endif %}{% raw %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
@@ -57,6 +61,10 @@
 {% raw %}
 {% render_bundle 'project' 'css' %}
 {%- endraw %}
+{% elif cookiecutter.frontend_pipeline == "Vite" %}
+{% raw %}
+{# The stylesheets are imported by static/js/project.js, django-vite renders them with the JS below #}
+{%- endraw %}
 {% endif %}
 {% raw %}
 {% endblock css %}
@@ -74,6 +82,13 @@
 {% raw %}
 <!-- Vendor dependencies bundled as one file -->
 {% render_bundle 'vendors' 'js' attrs='defer' %}
+{%- endraw %}
+{% elif cookiecutter.frontend_pipeline == "Vite" %}
+{% raw %}
+<!-- Enables hot module replacement, only rendered when dev_mode is on -->
+{% vite_hmr_client %}
+<!-- Vendor dependencies bundled as one file -->
+{% vite_asset '{% endraw %}{{ cookiecutter.project_slug }}{% raw %}/static/js/vendors.js' %}
 {%- endraw %}
 {% else %}
 {% raw %}
@@ -106,6 +121,10 @@
 {% elif cookiecutter.frontend_pipeline == "Webpack" %}
 {% raw %}
 {% render_bundle 'project' 'js' attrs='defer' %}
+{%- endraw %}
+{% elif cookiecutter.frontend_pipeline == "Vite" %}
+{% raw %}
+{% vite_asset '{% endraw %}{{ cookiecutter.project_slug }}{% raw %}/static/js/project.js' %}
 {%- endraw %}
 {% endif %}
 {% raw %}


### PR DESCRIPTION
## Description

Add a new value for frontend pipeline to use [Vite](https://vite.dev/) with [django-vite](https://github.com/MrBin99/django-vite).

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Vite has gained a lot of popularity as front-end build tool.
