### PR TITLE
Fix GitHub CI when Docker is on and `keep_local_envs_in_vcs` is off

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -71,6 +71,32 @@ jobs:
         uses: actions/checkout@v6
       {%- if cookiecutter.use_docker == 'y' %}
 
+      # When keep_local_envs_in_vcs is off, .envs/.local/* are not in the repo.
+      # Create minimal dummy files so Docker Compose / Django / Postgres work in CI.
+      - name: Ensure local env files exist for Docker Compose
+        run: |
+          mkdir -p .envs/.local
+          if [ ! -f .envs/.local/.django ]; then
+            cat <<'EOF' > .envs/.local/.django
+          USE_DOCKER=yes
+          IPYTHONDIR=/app/.ipython
+          {%- if cookiecutter.use_celery == 'y' %}
+          REDIS_URL=redis://redis:6379/0
+          CELERY_FLOWER_USER=debug
+          CELERY_FLOWER_PASSWORD=debug
+          {%- endif %}
+          EOF
+          fi
+          if [ ! -f .envs/.local/.postgres ]; then
+            cat <<'EOF' > .envs/.local/.postgres
+          POSTGRES_HOST=postgres
+          POSTGRES_PORT=5432
+          POSTGRES_DB=ci
+          POSTGRES_USER=debug
+          POSTGRES_PASSWORD=debug
+          EOF
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/{{cookiecutter.project_slug}}/docker-compose.docs.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.docs.yml
@@ -6,7 +6,8 @@ services:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile
     env_file:
-      - ./.envs/.local/.django
+      - path: ./.envs/.local/.django
+        required: false
     volumes:
       - /app/.venv
       - ./docs:/docs:z

--- a/{{cookiecutter.project_slug}}/docker-compose.local.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.local.yml
@@ -25,8 +25,10 @@ services:
       - /app/.venv
       - .:/app:z
     env_file:
-      - ./.envs/.local/.django
-      - ./.envs/.local/.postgres
+      - path: ./.envs/.local/.django
+        required: false
+      - path: ./.envs/.local/.postgres
+        required: false
     ports:
       - '8000:8000'
     command: /start
@@ -45,7 +47,8 @@ services:
       {%- endif %}
       - {{ cookiecutter.project_slug }}_local_postgres_data_backups:/backups
     env_file:
-      - ./.envs/.local/.postgres
+      - path: ./.envs/.local/.postgres
+        required: false
 
   {%- if cookiecutter.mail_catcher == 'Mailpit' %}
 


### PR DESCRIPTION
## Description

When a project is generated with `use_docker=y` and `keep_local_envs_in_vcs=n`, the `.envs/.local/` files are gitignored and are not present in CI. `docker compose` then fails because those paths are listed under `env_file`.

This PR:

1. Marks `env_file` entries as `required: false` in `docker-compose.local.yml` and `docker-compose.docs.yml` (Docker Compose v2.24+), so missing files do not abort Compose while local dev still loads them when present.
2. Adds a CI step in the generated GitHub Actions workflow that creates minimal dummy `.envs/.local/.django` and `.postgres` files when they are absent, so Postgres/Django still receive the variables needed for migrations and tests.

Fixes #5319

Checklist:

- [x] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [x] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Generated projects that opt out of keeping local env files in VCS currently break out of the box on GitHub Actions when Docker is enabled. Maintainers noted in #5319 that CI still needs those values available; `required: false` alone is not enough.

This builds on the approach in #6222 by also providing dummy env files in CI.

Closes #6222 